### PR TITLE
Generic infobox slug matching, table parsing and config fixes

### DIFF
--- a/src/db/individuals.py
+++ b/src/db/individuals.py
@@ -20,7 +20,7 @@ def list_individuals(
         cur = conn.execute(
             """SELECT id, wiki_url, page_path, full_name, birth_date, death_date,
                       birth_date_imprecise, death_date_imprecise,
-                      birth_place, death_place, created_at, updated_at
+                      birth_place, death_place, is_dead_link, created_at, updated_at
                FROM individuals ORDER BY full_name LIMIT ? OFFSET ?""",
             (limit, offset),
         )
@@ -71,12 +71,13 @@ def upsert_individual(data: dict[str, Any], conn: sqlite3.Connection | None = No
         dd_imprecise = 1 if data.get("death_date_imprecise") else 0
         cur = conn.execute("SELECT id FROM individuals WHERE wiki_url = ?", (wiki_url,))
         row = cur.fetchone()
+        is_dead_link = 1 if data.get("is_dead_link") else 0
         if row:
             conn.execute(
                 """UPDATE individuals SET
                     page_path=?, full_name=?, birth_date=?, death_date=?,
                     birth_date_imprecise=?, death_date_imprecise=?,
-                    birth_place=?, death_place=?, updated_at=datetime('now')
+                    birth_place=?, death_place=?, is_dead_link=?, updated_at=datetime('now')
                 WHERE id=?""",
                 (
                     data.get("page_path"),
@@ -87,14 +88,15 @@ def upsert_individual(data: dict[str, Any], conn: sqlite3.Connection | None = No
                     dd_imprecise,
                     data.get("birth_place"),
                     data.get("death_place"),
+                    is_dead_link,
                     row["id"],
                 ),
             )
             conn.commit()
             return row["id"]
         cur = conn.execute(
-            """INSERT INTO individuals (wiki_url, page_path, full_name, birth_date, death_date, birth_date_imprecise, death_date_imprecise, birth_place, death_place)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO individuals (wiki_url, page_path, full_name, birth_date, death_date, birth_date_imprecise, death_date_imprecise, birth_place, death_place, is_dead_link)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 wiki_url,
                 data.get("page_path"),
@@ -105,6 +107,7 @@ def upsert_individual(data: dict[str, Any], conn: sqlite3.Connection | None = No
                 dd_imprecise,
                 data.get("birth_place"),
                 data.get("death_place"),
+                is_dead_link,
             ),
         )
         conn.commit()
@@ -150,6 +153,19 @@ def get_living_individual_wiki_urls(conn: sqlite3.Connection | None = None) -> s
         cur = conn.execute(
             "SELECT wiki_url FROM individuals WHERE death_date IS NULL OR death_date = '' OR death_date LIKE 'Invalid%'"
         )
+        return {row["wiki_url"] for row in cur.fetchall()}
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def get_dead_link_wiki_urls(conn: sqlite3.Connection | None = None) -> set[str]:
+    """Return set of wiki_urls for individuals marked as dead link (no bio page)."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cur = conn.execute("SELECT wiki_url FROM individuals WHERE is_dead_link = 1")
         return {row["wiki_url"] for row in cur.fetchall()}
     finally:
         if own_conn:

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -54,6 +54,8 @@ def migrate_to_fk(conn=None):
         _migrate_office_terms_year_columns(conn)
         # Add term_dates_merged, party_ignore, district_ignore, district_at_large to offices
         _migrate_offices_parsing_options(conn)
+        # Add is_dead_link to individuals if missing
+        _migrate_individuals_dead_link(conn)
     finally:
         if own_conn:
             conn.close()
@@ -301,3 +303,11 @@ def _migrate_imprecise_date_columns(conn):
         if te is not None and not valid_date.match(str(te).strip()):
             conn.execute("UPDATE office_terms SET term_end = NULL, term_end_imprecise = 1 WHERE id = ?", (oid,))
     conn.commit()
+
+
+def _migrate_individuals_dead_link(conn):
+    """Add is_dead_link to individuals if missing."""
+    ind_cols = _columns(conn, "individuals")
+    if "is_dead_link" not in ind_cols:
+        conn.execute("ALTER TABLE individuals ADD COLUMN is_dead_link INTEGER NOT NULL DEFAULT 0")
+        conn.commit()

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -46,7 +46,8 @@ def validate_office_table_config(
     except (TypeError, ValueError):
         raise ValueError("link, party, term start, term end, and district columns must be integers") from None
 
-    if link_column < 1:
+    dynamic_parse = data.get("dynamic_parse") in (True, 1, "1", "true", "TRUE")
+    if link_column < 1 and not dynamic_parse:
         raise ValueError("link column must be at least 1")
     if term_start_column < 1 or term_end_column < 1:
         raise ValueError("term start and term end columns must be at least 1")

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS individuals (
     death_date_imprecise INTEGER NOT NULL DEFAULT 0,
     birth_place TEXT,
     death_place TEXT,
+    is_dead_link INTEGER NOT NULL DEFAULT 0,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
 );

--- a/src/main.py
+++ b/src/main.py
@@ -1178,6 +1178,9 @@ async def api_office_debug_export(request: Request):
     config = body.get("config") or {}
     preview_result = body.get("preview_result") or {}
     table_html_result = body.get("table_html_result") or {}
+    export_mode = (body.get("export_mode") or "full").strip().lower()
+    if export_mode not in ("preview", "full"):
+        export_mode = "full"
     try:
         db_offices.validate_office_table_config(
             config,
@@ -1189,7 +1192,93 @@ async def api_office_debug_export(request: Request):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     use_infobox = _config_bool_export(config.get("find_date_in_infobox"))
-    if use_infobox:
+
+    # Preview mode: no full parse, no infobox; require preview_result and table_html_result from client
+    if export_mode == "preview":
+        table_html = (table_html_result.get("html") or "") if not table_html_result.get("error") else ""
+        header_cells = get_table_header_from_html(table_html) if table_html else []
+        timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        safe_name = _sanitize_debug_filename(office_name)
+        filename = f"{safe_name}_{timestamp}.txt"
+        debug_dir = ROOT / "debug"
+        debug_dir.mkdir(parents=True, exist_ok=True)
+        filepath = debug_dir / filename
+        link_1 = int(config.get("link_column") or 0)
+        term_start_1 = int(config.get("term_start_column") or 4)
+        term_end_1 = int(config.get("term_end_column") or 5)
+        def _col_1_to_0(v):
+            val = int(v) if v is not None and v != "" else 0
+            return (val - 1) if val > 0 else -1
+        link_0 = _col_1_to_0(link_1)
+        term_start_0 = _col_1_to_0(term_start_1)
+        term_end_0 = _col_1_to_0(term_end_1)
+        lines = [
+            "=== INSTRUCTIONS (when you share this file with Cursor) ===",
+            "Help me understand the configuration issue. The problem could be:",
+            "  1) I simply did not configure correctly — in that case, give me the correct configs.",
+            "  2) We came across a new scenario our parser cannot handle — in that case, propose a plan.",
+            "When investigating: test the HTML extract (RAW HTML section below) against our parser code",
+            "to see if the issue is resolved or still outstanding (e.g. run scripts/test_debug_export.py).",
+            "",
+            "=== Investigation context ===",
+            "Column indices: Form/DB store 1-based column numbers. The parser uses 0-based indices.",
+            "Conversion happens in src/db/offices.py in office_row_to_table_config (e.g. form term_start_column 5 -> parser column index 4).",
+            "How to verify: From project root run: python scripts/test_debug_export.py debug/" + filename,
+            "Code reference:",
+            "  - Config to 0-based: src/db/offices.py office_row_to_table_config, _col_1based_to_0based",
+            "  - Table parsing: src/scraper/table_parser.py process_table, parse_table_row, extract_term_dates",
+            "  - Date parsing: src/scraper/table_parser.py DataCleanup.format_date, DataCleanup.parse_date_info",
+            "  - Preview pipeline: src/scraper/runner.py preview_with_config",
+            "",
+            "Office: " + office_name,
+            "Exported: " + timestamp,
+            "Export mode: Preview (offices only — no full parse, no infobox fetches)",
+            "",
+            "=== CONFIG (form values used for preview) ===",
+        ]
+        for k, v in sorted(config.items()):
+            lines.append(f"{k}: {v}")
+        mapping_parts = [
+            "Parser columns (0-based): link=%s, term_start=%s, term_end=%s (from form 1-based: link %s, term_start %s, term_end %s)."
+            % (link_0, term_start_0, term_end_0, link_1, term_start_1, term_end_1)
+        ]
+        if header_cells:
+            h_start = header_cells[term_start_0][1] if 0 <= term_start_0 < len(header_cells) else "?"
+            h_end = header_cells[term_end_0][1] if 0 <= term_end_0 < len(header_cells) else "?"
+            mapping_parts.append('Header at term_start: %r, at term_end: %r.' % (h_start, h_end))
+        lines.append(" ".join(mapping_parts))
+        lines.append("")
+        lines.append("=== TABLE STRUCTURE (header row, 0-based column index) ===")
+        if header_cells:
+            for i, text in header_cells:
+                lines.append("Column %s: %s" % (i, text))
+        else:
+            lines.append("Could not parse table header.")
+        lines.append("")
+        lines.append("=== EXTRACTED TABLE (Preview - offices only) ===")
+        preview_rows = preview_result.get("preview_rows") or []
+        if preview_rows:
+            headers = ["Wiki Link", "Party", "District", "Term Start", "Term End", "Term Start Year", "Term End Year", "Infobox items"]
+            lines.append("\t".join(headers))
+            for row in preview_rows:
+                cells = [str(row.get(h) or "").replace("\t", " ").replace("\n", " ") for h in headers]
+                lines.append("\t".join(cells))
+        else:
+            lines.append("No preview rows.")
+        lines.append("")
+        lines.append("=== RAW HTML (selected table) ===")
+        if table_html_result.get("error"):
+            lines.append(f"Error: {table_html_result.get('error')}")
+        else:
+            lines.append(table_html_result.get("html") or "(empty)")
+        try:
+            filepath.write_text("\n".join(lines), encoding="utf-8")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Could not write file: {e}")
+        return JSONResponse({"path": f"debug/{filename}", "filename": filename})
+
+    # Full export: async when find_date_in_infobox, else sync with full parse
+    if export_mode == "full" and use_infobox:
         job_id = str(uuid.uuid4())
         with _export_job_lock:
             _export_job_store[job_id] = {

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -26,6 +26,7 @@ from src.db.date_utils import normalize_date
 from src.scraper.logger import HTTP_USER_AGENT, Logger
 from src.scraper.config_test import get_raw_table_preview
 from src.scraper.table_cache import get_table_html_cached
+from src.scraper.wiki_fetch import normalize_wiki_url
 
 from src.scraper import parse_core
 
@@ -56,7 +57,7 @@ def parse_full_table_for_export(
     years_only = bool(office_row.get("years_only"))
     rows_out = []
     for row in table_data:
-        normalized = _normalize_row_for_import(row, years_only=years_only)
+        normalized = _normalize_row_for_import(row, years_only=years_only, include_no_link=True)
         if normalized is None:
             continue
         _, term_start_val, term_end_val, _ts_imp, _te_imp, term_start_year, term_end_year = normalized
@@ -103,15 +104,19 @@ def _parse_office_html(
     )
 
 
-def _normalize_row_for_import(row: dict[str, Any], years_only: bool = False) -> tuple[dict, str | None, str | None, bool, bool, int | None, int | None] | None:
+def _normalize_row_for_import(
+    row: dict[str, Any], years_only: bool = False, include_no_link: bool = False
+) -> tuple[dict, str | None, str | None, bool, bool, int | None, int | None] | None:
     """
     Same filter/normalize logic as the DB write path. Returns None if row should be skipped,
     else (row, term_start_val, term_end_val, term_start_imprecise, term_end_imprecise, term_start_year, term_end_year).
     When years_only is True (from row["_years_only"] or caller), accept rows with Term Start Year / Term End Year and leave dates null.
+    When include_no_link is True (e.g. debug export), include rows with Wiki Link "No link" using their term dates/years.
     """
     wiki_url = row.get("Wiki Link") or ""
     if not wiki_url or wiki_url == "No link":
-        return None
+        if not include_no_link:
+            return None
     use_years_only = years_only or bool(row.get("_years_only"))
     if use_years_only:
         term_start_year = row.get("Term Start Year")
@@ -127,6 +132,9 @@ def _normalize_row_for_import(row: dict[str, Any], years_only: bool = False) -> 
         term_end_year = row.get("Term End Year")
         if term_start_year is not None or term_end_year is not None:
             return (row, None, None, False, False, term_start_year, term_end_year)
+        # include_no_link: include name-only rows even with no parseable dates so they appear in preview and DB
+        if include_no_link and row.get("_name_from_table"):
+            return (row, None, None, False, False, None, None)
         return None
     return (row, term_start_val, term_end_val, term_start_imp, term_end_imp, None, None)
 
@@ -324,18 +332,24 @@ def run_with_db(
             if dry_run or test_run:
                 preview_rows = []
                 for row in all_office_data:
-                    normalized = _normalize_row_for_import(row)
+                    normalized = _normalize_row_for_import(row, years_only=bool(row.get("_years_only")))
+                    if normalized is None and (row.get("Wiki Link") or "") in ("", "No link") and row.get("_name_from_table"):
+                        normalized = _normalize_row_for_import(row, years_only=bool(row.get("_years_only")), include_no_link=True)
                     if normalized is None:
                         continue
                     _, term_start_val, term_end_val, _ts_imp, _te_imp, term_start_year, term_end_year = normalized
+                    wiki_link = row.get("Wiki Link") or ""
+                    dead_link = bool(row.get("_dead_link") or (wiki_link in ("", "No link") and row.get("_name_from_table")))
                     preview_rows.append({
-                        "Wiki Link": row.get("Wiki Link") or "",
+                        "Wiki Link": wiki_link,
                         "Party": row.get("Party") or "",
                         "District": row.get("District") or "",
                         "Term Start": term_start_val if term_start_val else "",
                         "Term End": term_end_val if term_end_val else "",
                         "Term Start Year": term_start_year,
                         "Term End Year": term_end_year,
+                        "Dead link": dead_link,
+                        "Name (no link)": row.get("_name_from_table") if dead_link and wiki_link in ("", "No link") else None,
                     })
                 preview_rows = preview_rows[:50]
             logger.close()
@@ -368,13 +382,6 @@ def run_with_db(
 
         table_no = int(office_row.get("table_no") or 1)
         use_full_page = bool(office_row.get("use_full_page_for_table"))
-        # #region agent log
-        import json
-        from pathlib import Path
-        _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
-        with open(_log_path, "a", encoding="utf-8") as _f:
-            _f.write(json.dumps({"location": "runner.py:run_with_db", "message": "before get_table_html_cached", "data": {"office_id": office_id, "url": (url or "")[:80], "table_no": table_no, "refresh_table_cache": refresh_table_cache, "use_full_page": use_full_page, "hypothesisId": "H3"}, "timestamp": __import__("time").time() * 1000}) + "\n")
-        # #endregion
         cache_result = get_table_html_cached(url.strip(), table_no, refresh=refresh_table_cache, use_full_page=use_full_page)
         if "error" in cache_result:
             logger.log(f"Failed to get table for {url}: {cache_result['error']}", True)
@@ -413,19 +420,29 @@ def run_with_db(
                 if office_id is None:
                     continue
                 normalized = _normalize_row_for_import(row)
+                # Include "No link" rows that have a name (e.g. Charles W. Wright) as dead-link individuals
+                if normalized is None and (row.get("Wiki Link") or "") in ("", "No link") and row.get("_name_from_table"):
+                    normalized = _normalize_row_for_import(row, include_no_link=True)
                 if normalized is None:
                     continue
                 _, term_start_val, term_end_val, term_start_imp, term_end_imp, term_start_year, term_end_year = normalized
                 wiki_url = row.get("Wiki Link") or ""
+                no_link_placeholder = wiki_url in ("", "No link") and row.get("_name_from_table")
+                if no_link_placeholder:
+                    wiki_url = "No link:" + str(office_id) + ":" + (row.get("_name_from_table") or "Unknown")
                 # Resolve or create individual
                 ind = db_individuals.get_individual_by_wiki_url(wiki_url, conn=conn)
                 individual_id = ind["id"] if ind else None
                 if not ind:
-                    # Create placeholder individual so we can link office_term
-                    individual_id = db_individuals.upsert_individual(
-                        {"wiki_url": wiki_url, "page_path": wiki_url.split("/")[-1] if wiki_url else None},
-                        conn=conn,
-                    )
+                    # Create placeholder or dead-link individual so we can link office_term
+                    payload = {
+                        "wiki_url": wiki_url,
+                        "page_path": wiki_url.split("/")[-1] if "/" in wiki_url else None,
+                    }
+                    if row.get("_dead_link") or no_link_placeholder:
+                        payload["full_name"] = row.get("_name_from_table")
+                        payload["is_dead_link"] = 1
+                    individual_id = db_individuals.upsert_individual(payload, conn=conn)
                 party_text = row.get("Party")
                 party_id = db_parties.resolve_party_id(office_id, party_text, conn=conn)
                 db_office_terms.insert_office_term(
@@ -493,18 +510,26 @@ def run_with_db(
                 logger.log(f"Skipping {bio_skipped_count} individuals (already in DB); fetching bio for {len(to_fetch)} new.", True)
                 report("bio", 0, len(to_fetch), f"Skipped {bio_skipped_count} (in DB). Fetching {len(to_fetch)} new…", {"bio_skipped": bio_skipped_count})
             total_bios = len(to_fetch)
+            # Build bio cache from table parse so we skip re-fetch when find_date_in_infobox was used (key by normalized URL)
+            bio_cache: dict[str, dict] = {}
+            for row in all_office_data:
+                wiki_url_row = row.get("Wiki Link")
+                if wiki_url_row and wiki_url_row != "No link" and row.get("_bio_details"):
+                    key = normalize_wiki_url(wiki_url_row) or wiki_url_row
+                    if key not in bio_cache:
+                        bio_cache[key] = row["_bio_details"]
             bio_fetched_this_run: set[str] = set()
             for bio_idx, wiki_url in enumerate(to_fetch):
                 report("bio", bio_idx + 1, total_bios, "Fetching biographies (new individuals)…", {"current": bio_idx + 1, "total": total_bios, "bio_skipped": bio_skipped_count})
                 if wiki_url in bio_fetched_this_run:
                     continue
-                if bio_idx > 0:
-                    time.sleep(1.5)
                 try:
-                    bio_info = biography.biography_extract(wiki_url)
-                    bio_fetched_this_run.add(wiki_url)
-                    if bio_info:
+                    bio_cache_key = normalize_wiki_url(wiki_url) or wiki_url
+                    if bio_cache_key in bio_cache:
+                        bio_info = dict(bio_cache[bio_cache_key])
                         bio_info["wiki_url"] = wiki_url
+                        if bio_info.get("page_path") is None:
+                            bio_info["page_path"] = (wiki_url or "").rstrip("/").split("/")[-1] or ""
                         bd, bd_imp = normalize_date(bio_info.get("birth_date"))
                         dd, dd_imp = normalize_date(bio_info.get("death_date"))
                         bio_info["birth_date"] = bd
@@ -512,12 +537,28 @@ def run_with_db(
                         bio_info["birth_date_imprecise"] = bd_imp
                         bio_info["death_date_imprecise"] = dd_imp
                         db_individuals.upsert_individual(bio_info)
+                        bio_fetched_this_run.add(wiki_url)
                         bio_success_count += 1
                     else:
-                        bio_error_count += 1
-                        err_msg = "No bio data extracted (e.g. 403 or empty page)"
-                        logger.log(f"Bio failed for {wiki_url}: {err_msg}", True)
-                        bio_errors.append({"url": wiki_url, "error": err_msg})
+                        if bio_idx > 0:
+                            time.sleep(1.5)
+                        bio_info = biography.biography_extract(wiki_url)
+                        bio_fetched_this_run.add(wiki_url)
+                        if bio_info:
+                            bio_info["wiki_url"] = wiki_url
+                            bd, bd_imp = normalize_date(bio_info.get("birth_date"))
+                            dd, dd_imp = normalize_date(bio_info.get("death_date"))
+                            bio_info["birth_date"] = bd
+                            bio_info["death_date"] = dd
+                            bio_info["birth_date_imprecise"] = bd_imp
+                            bio_info["death_date_imprecise"] = dd_imp
+                            db_individuals.upsert_individual(bio_info)
+                            bio_success_count += 1
+                        else:
+                            bio_error_count += 1
+                            err_msg = "No bio data extracted (e.g. 403 or empty page)"
+                            logger.log(f"Bio failed for {wiki_url}: {err_msg}", True)
+                            bio_errors.append({"url": wiki_url, "error": err_msg})
                 except Exception as e:
                     bio_fetched_this_run.add(wiki_url)
                     bio_error_count += 1
@@ -567,23 +608,29 @@ def run_with_db(
     logger.close()
     report("complete", 1, 1, "Done", {"terms_parsed": total_terms, "unique_wiki_urls": len(unique_wiki_urls)})
 
-    # Preview rows: same filter/normalize as import so UI shows exactly what would be in the table
+    # Preview rows: same filter/normalize as import so UI shows exactly what would be in the table (include dead-link / name-only rows)
     preview_rows = None
     if dry_run or test_run:
         preview_rows = []
         for row in all_office_data:
-            normalized = _normalize_row_for_import(row)
+            normalized = _normalize_row_for_import(row, years_only=bool(row.get("_years_only")))
+            if normalized is None and (row.get("Wiki Link") or "") in ("", "No link") and row.get("_name_from_table"):
+                normalized = _normalize_row_for_import(row, years_only=bool(row.get("_years_only")), include_no_link=True)
             if normalized is None:
                 continue
             _, term_start_val, term_end_val, _ts_imp, _te_imp, term_start_year, term_end_year = normalized
+            wiki_link = row.get("Wiki Link") or ""
+            dead_link = bool(row.get("_dead_link") or (wiki_link in ("", "No link") and row.get("_name_from_table")))
             preview_rows.append({
-                "Wiki Link": row.get("Wiki Link") or "",
+                "Wiki Link": wiki_link,
                 "Party": row.get("Party") or "",
                 "District": row.get("District") or "",
                 "Term Start": term_start_val if term_start_val else "",
                 "Term End": term_end_val if term_end_val else "",
                 "Term Start Year": term_start_year,
                 "Term End Year": term_end_year,
+                "Dead link": dead_link,
+                "Name (no link)": row.get("_name_from_table") if dead_link and wiki_link in ("", "No link") else None,
             })
         preview_rows = preview_rows[:50]
 
@@ -633,13 +680,6 @@ def preview_with_config(
 
     table_no = int(office_row.get("table_no") or 1)
     use_full_page = bool(office_row.get("use_full_page_for_table"))
-    # #region agent log
-    import json
-    from pathlib import Path
-    _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
-    with open(_log_path, "a", encoding="utf-8") as _f:
-        _f.write(json.dumps({"location": "runner.py:preview_with_config", "message": "before get_table_html_cached", "data": {"url": url[:80], "table_no": table_no, "use_full_page": use_full_page, "hypothesisId": "H3"}, "timestamp": __import__("time").time() * 1000}) + "\n")
-    # #endregion
     cache_result = get_table_html_cached(url, table_no, refresh=False, use_full_page=use_full_page)
     if "error" in cache_result:
         return {"preview_rows": [], "raw_table_preview": None, "error": cache_result["error"]}
@@ -657,22 +697,38 @@ def preview_with_config(
         raw = get_raw_table_preview(url, int(office_row.get("table_no") or 1), raw_max)
         return {"preview_rows": [], "raw_table_preview": raw, "error": str(e)}
 
-    # Same filter/normalize as import: only rows that would be inserted, with normalized Term Start/End and optional years
+    # Same filter/normalize as import: only rows that would be inserted (include dead-link / name-only rows)
     years_only = bool(office_row.get("years_only"))
     preview_rows = []
     for row in table_data:
         normalized = _normalize_row_for_import(row, years_only=years_only)
+        if normalized is None and (row.get("Wiki Link") or "") in ("", "No link") and row.get("_name_from_table"):
+            normalized = _normalize_row_for_import(row, years_only=years_only, include_no_link=True)
         if normalized is None:
             continue
         _, term_start_val, term_end_val, _ts_imp, _te_imp, term_start_year, term_end_year = normalized
+        wiki_link = row.get("Wiki Link") or ""
+        dead_link = bool(row.get("_dead_link") or (wiki_link in ("", "No link") and row.get("_name_from_table")))
+        # #region agent log
+        if dead_link and wiki_link in ("", "No link"):
+            try:
+                import json
+                from pathlib import Path
+                _dp = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                open(_dp, "a", encoding="utf-8").write(json.dumps({"location": "runner:preview_with_config", "message": "adding no-link row to preview", "data": {"name_from_table": (row.get("_name_from_table") or "")[:80], "term_start_year": term_start_year, "term_end_year": term_end_year}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
+            except Exception:
+                pass
+        # #endregion
         preview_rows.append({
-            "Wiki Link": row.get("Wiki Link") or "",
+            "Wiki Link": wiki_link,
             "Party": row.get("Party") or "",
             "District": row.get("District") or "",
             "Term Start": term_start_val if term_start_val else "",
             "Term End": term_end_val if term_end_val else "",
             "Term Start Year": term_start_year,
             "Term End Year": term_end_year,
+            "Dead link": dead_link,
+            "Name (no link)": row.get("_name_from_table") if dead_link and wiki_link in ("", "No link") else None,
         })
     if max_rows is not None:
         preview_rows = preview_rows[:max_rows]

--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -182,7 +182,7 @@ class DataCleanup:
           return (None, None)
       text = self.remove_footnote(text)
       text = text.strip()
-      year_match = re.search(r'\b(19|20)\d{2}\b', text)
+      year_match = re.search(r'\b(17|18|19|20)\d{2}\b', text)
       if not year_match:
           return (None, None)
       delimiters = ['–', '-', ' —<br/>', ' to ', ' – ', ', to ']
@@ -192,11 +192,11 @@ class DataCleanup:
               parts = text.split(d, 1)
               start_str = (parts[0].strip() if parts else "").strip()
               end_str = (parts[1].strip() if len(parts) > 1 else "").strip()
-              start_m = re.search(r'\b(19|20)\d{2}\b', start_str)
+              start_m = re.search(r'\b(17|18|19|20)\d{2}\b', start_str)
               start_year = int(start_m.group(0)) if start_m else None
               if not end_str or end_str.lower().strip() in present_cases:
                   return (start_year, None)
-              end_m = re.search(r'\b(19|20)\d{2}\b', end_str)
+              end_m = re.search(r'\b(17|18|19|20)\d{2}\b', end_str)
               end_year = int(end_m.group(0)) if end_m else None
               return (start_year, end_year)
       sy = int(year_match.group(0))
@@ -206,15 +206,57 @@ class DataCleanup:
       # Dynamic identification of the link column and subsequent data columns.
       # If max_column_index is set (0-based), only consider cells up to that index so we never
       # pick a link from a non-data column (e.g. President column) when it appears after term dates.
+      # #region agent log
+      try:
+          _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+          open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_link_and_data_columns", "message": "entry", "data": {"len_row": len(row), "max_column_index": max_column_index}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
+      except Exception:
+          pass
+      # #endregion
       for i, cell in enumerate(row):
           if max_column_index is not None and i > max_column_index:
               break
-          cell_str = str(cell)  # Convert BeautifulSoup object or similar to string, if necessary
-          has_wiki_link = 'href="/wiki/' in cell_str
-          has_file_link = 'href="/wiki/File:' in cell_str
+          try:
+              cell_str = str(cell)  # Convert BeautifulSoup object or similar to string, if necessary
+          except Exception as e:
+              # #region agent log
+              try:
+                  _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                  open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_link_and_data_columns", "message": "str_cell_error", "data": {"i": i, "error": str(e), "type": type(e).__name__}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H3"}) + "\n")
+              except Exception:
+                  pass
+              # #endregion
+              raise
+          # Wiki article link: absolute path, relative (./), or full URL
+          has_absolute = 'href="/wiki/' in cell_str
+          has_relative = 'href="./' in cell_str and 'href="./File:' not in cell_str and 'href="./Special:' not in cell_str
+          has_full_url = 'en.wikipedia.org/wiki/' in cell_str and '/wiki/File:' not in cell_str and '/wiki/Special:' not in cell_str
+          has_wiki_link = has_absolute or has_relative or has_full_url
+          # Exclude file/special links in any form
+          has_file_link = (
+              'href="/wiki/File:' in cell_str
+              or 'href="./File:' in cell_str
+              or '/wiki/File:' in cell_str
+              or 'href="./Special:' in cell_str
+              or '/wiki/Special:' in cell_str
+          )
           if has_wiki_link and not has_file_link:
+              # #region agent log
+              try:
+                  _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                  open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_link_and_data_columns", "message": "return_column", "data": {"column": i, "has_absolute": has_absolute, "has_relative": has_relative, "has_full_url": has_full_url, "cell_snippet": cell_str[:200]}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H1"}) + "\n")
+              except Exception:
+                  pass
+              # #endregion
               self.Logger.debug_log( f"Wiki link (not a file link) found at column {i}: {cell}" , True )
               return i  # Return the index of the column containing the link
+      # #region agent log
+      try:
+          _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+          open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_link_and_data_columns", "message": "return_none", "data": {"reason": "no_cell_matched"}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H4"}) + "\n")
+      except Exception:
+          pass
+      # #endregion
       self.Logger.debug_log( f"Wiki did not find a link in {row}" , True )
       return None  # If no matching link column is found, or data structure is different
 
@@ -312,6 +354,8 @@ class Offices:
         pass
     # #endregion
 
+    # Per-table cache so we only call find_term_dates once per wiki_link (same person in multiple rows)
+    self._infobox_cache = {}
     # tracks the previous entry --> this helps the rowspan function track
     previous_row_wiki_link = None
     previous_row_district = None
@@ -366,15 +410,6 @@ class Offices:
                 pass
             # #endregion
 
-    # #region agent log
-    try:
-        _f = open(_log_path, "a", encoding="utf-8")
-        _f.write(json.dumps({"location": "table_parser:process_table", "message": "accumulated total", "data": {"accumulated": len(accumulated_results), "with_wiki_link": sum(1 for r in accumulated_results if (r.get("Wiki Link") or "").strip() and r.get("Wiki Link") != "No link")}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H3"}) + "\n")
-        _f.close()
-    except Exception:
-        pass
-    # #endregion
-
     return accumulated_results
 
 
@@ -389,7 +424,7 @@ class Offices:
 
       self.Logger.debug_log( f"previous values: \n wiki_link: {previous_row_wiki_link} \n district: {previous_row_district} \n party: {previous_row_party}" , True )
 
-      cells = row.find_all('td')
+      cells = row.find_all(['td', 'th'])
       self.Logger.debug_log( f" cells {cells} \n\n" , True )
 
       # total columns primarily works with right_to_left function
@@ -490,6 +525,8 @@ class Offices:
         wiki_link = previous_row_wiki_link
         self.Logger.debug_log( f"Adding previous link {previous_row_wiki_link} as link {wiki_link}" , True )
         found_rowspan = True
+      if wiki_link is None or (wiki_link or "").strip() == "":
+        wiki_link = "No link"
 
       '''
       The following three logic chains deal with the rowspan function. Rowspan works for office holders with multiple terms.
@@ -575,6 +612,22 @@ class Offices:
 
 
 
+      link_column = table_config_to_parse.get("link_column", 0)
+      name_from_table = None
+      if 0 <= link_column < len(cells):
+          first_a = cells[link_column].find("a")
+          name_from_table = first_a.get_text(strip=True) if first_a else None
+          if name_from_table is None:
+              name_from_table = cells[link_column].get_text(strip=True) or None
+              # #region agent log
+              if name_from_table and (wiki_link or "").strip() in ("", "No link"):
+                  try:
+                      import json
+                      _dp = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                      open(_dp, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:parse_table_row", "message": "name_from_table from cell text (no link)", "data": {"wiki_link": (wiki_link or "")[:60], "name_from_table": (name_from_table or "")[:80]}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H1"}) + "\n")
+                  except Exception:
+                      pass
+                  # #endregion
       infobox_debug = getattr(self, "_last_infobox_items", None)
       if infobox_debug is not None:
           self._last_infobox_items = None  # Consume so next row does not inherit
@@ -596,8 +649,17 @@ class Offices:
               'Party': party,
               'District': district
           }
+          row_dict["_name_from_table"] = name_from_table
+          last_dead_link = getattr(self.Biography, "_last_dead_link", False)
+          row_dict["_dead_link"] = bool(last_dead_link and wiki_link and wiki_link != "No link")
+          if last_dead_link:
+              self.Biography._last_dead_link = False  # Consume so next row does not inherit
           if infobox_debug is not None:
               row_dict['Infobox items'] = "\n".join(infobox_debug) if isinstance(infobox_debug, list) else str(infobox_debug)
+              last_bio = getattr(self.Biography, "_last_bio_details", None)
+              if last_bio is not None:
+                  row_dict["_bio_details"] = last_bio
+                  self.Biography._last_bio_details = None  # Attach only to first result row for this person
           results_list.append(row_dict)
       for results in results_list:
           self.Logger.log( f"results {results}" , True )
@@ -727,6 +789,14 @@ class Offices:
       term_start_column = parse_row_no
       term_end_column = parse_row_no
 
+    # #region agent log
+    try:
+        _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+        open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:extract_term_dates", "message": "entry", "data": {"term_start_column": term_start_column, "term_end_column": term_end_column, "len_cells": len(cells), "would_oob": term_start_column >= len(cells) or term_end_column >= len(cells)}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
+    except Exception:
+        pass
+    # #endregion
+
     # Extract and format the term start and end dates
 
     try:
@@ -743,8 +813,22 @@ class Offices:
       # Find date in infobox: fetch full dates from person's bio; collect all matching terms from infobox
       if table_config_to_parse["find_date_in_infobox"] == True:
         self.Logger.debug_log( f" parse_table_row found TRUE in find_date_in_infobox \n\n about to process {cells[term_start_column]}" , True )
-        terms_list, infobox_items = self.Biography.find_term_dates( wiki_link , url , table_config_to_parse , office_details , district )
-        self._last_infobox_items = infobox_items  # For debug export
+        cache = getattr(self, "_infobox_cache", None)
+        if cache is not None and wiki_link in cache:
+          cached = cache[wiki_link]
+          terms_list = cached["terms"]
+          infobox_items = cached["infobox_items"]
+          self._last_infobox_items = infobox_items
+          self.Biography._last_bio_details = cached.get("bio_details")
+        else:
+          terms_list, infobox_items = self.Biography.find_term_dates( wiki_link , url , table_config_to_parse , office_details , district )
+          self._last_infobox_items = infobox_items  # For debug export
+          if cache is not None:
+            cache[wiki_link] = {
+              "terms": terms_list,
+              "infobox_items": infobox_items,
+              "bio_details": getattr(self.Biography, "_last_bio_details", None),
+            }
         self.Logger.debug_log( f" find_term_dates returned {len(terms_list)} term(s) from infobox" , True )
         # When infobox had no dates (placeholder), use table years only for this record (same as "table has years only")
         if len(terms_list) == 1 and terms_list[0][0] == "YYYY-00-00" and terms_list[0][1] == "YYYY-00-00":
@@ -771,6 +855,13 @@ class Offices:
       return (term_start, term_end, None, None)
 
     except ( ValueError , TypeError , AttributeError , IndexError ) as e:
+      # #region agent log
+      try:
+          _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+          open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:extract_term_dates", "message": "caught_exception", "data": {"error": str(e), "type": type(e).__name__, "term_start_column": term_start_column, "term_end_column": term_end_column, "len_cells": len(cells)}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
+      except Exception:
+          pass
+      # #endregion
       self.Logger.log( f" error {e} when parsing {wiki_link}" , True )
       return ("Invalid date", "Invalid date", None, None)
 
@@ -996,6 +1087,14 @@ class Offices:
     table_config_to_parse["term_end_column"] = term_end_column
     table_config_to_parse["district_column"] = district_column
 
+    # #region agent log
+    try:
+        _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+        open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:process_dynamic_parse", "message": "columns_updated", "data": {"link_column": link_column, "term_start_column": term_start_column, "term_end_column": term_end_column, "len_cells": len(cells)}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
+    except Exception:
+        pass
+    # #endregion
+
     self.Logger.debug_log( f"table config at the end of dynamic parse: \n {table_config_to_parse} \n\n" , True )
 
     return True, table_config_to_parse
@@ -1176,6 +1275,8 @@ class Biography:
 
 
       infobox_items = []  # For debug export: what we found in the infobox
+      self._last_bio_details = None
+      self._last_dead_link = False
       fetch_url = wiki_url_to_rest_html_url(wiki_link) or wiki_link
       try:
           response = requests.get(fetch_url, headers=WIKIPEDIA_REQUEST_HEADERS, timeout=30)
@@ -1199,6 +1300,41 @@ class Biography:
                           return "/wiki" + h
                       return "/wiki/" + h
                   office_slug = (office_partial_url or "").rstrip("/").split("/")[-1]
+                  # Person infoboxes may link to either "X_of_State" or "State_X" form. Derive generically.
+                  office_slug_alt = None
+                  office_slug_alt2 = None
+                  _slug_to_check = office_slug
+                  if office_slug.startswith("List_of_"):
+                      _slug_to_check = office_slug[len("List_of_"):]
+                      office_slug_alt = _slug_to_check  # match list-style rest if infobox links to it
+                  if "_of_" in _slug_to_check:
+                      parts = _slug_to_check.rsplit("_of_", 1)
+                      prefix, state_part = parts[0], parts[1]
+                      office_slug_alt2 = state_part + "_" + prefix
+                      # List pages often use plural prefix (e.g. secretaries_of_state); infobox may use singular.
+                      if office_slug.startswith("List_of_") and prefix:
+                          _segments = prefix.split("_")
+                          _title_parts = [
+                              "of" if p.lower() == "of" else (p.title() if p.islower() else p)
+                              for p in _segments
+                          ]
+                          if _title_parts:
+                              _first = _title_parts[0].lower()
+                              if _first.endswith("ies") and len(_first) > 3:
+                                  _title_parts[0] = (_first[:-3] + "y").title()
+                              elif _first.endswith("s") and not _first.endswith("ss") and len(_first) > 1:
+                                  _title_parts[0] = (_first[:-1]).title()
+                              _title = "_".join(_title_parts)
+                              if _title != prefix:
+                                  office_slug_alt = (office_slug_alt or prefix + "_of_" + state_part)
+                                  office_slug_alt2 = state_part + "_" + _title
+                  # #region agent log
+                  try:
+                      _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                      open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_term_dates", "message": "office_slugs", "data": {"office_partial_url": office_partial_url, "office_slug": office_slug, "office_slug_alt": office_slug_alt, "office_slug_alt2": office_slug_alt2}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "infobox_match"}) + "\n")
+                  except Exception:
+                      pass
+                  # #endregion
                   all_terms = []  # Collect all matching term (start, end) from every matching row in the infobox
                   for tr in infobox.find_all('tr'):
                       self.Logger.debug_log( f"found tr \n {tr}" , True )
@@ -1206,7 +1342,12 @@ class Biography:
                       row_text = tr.get_text(" ", strip=True)
                       raw_href = a.get("href", "") if a else ""
                       norm_path = _normalize_infobox_href(raw_href)
-                      link_matches = a and (office_partial_url in norm_path or (office_slug and office_slug in norm_path))
+                      link_matches = a and (
+                          office_partial_url in norm_path
+                          or (office_slug and office_slug in norm_path)
+                          or (office_slug_alt and office_slug_alt in norm_path)
+                          or (office_slug_alt2 and office_slug_alt2 in norm_path)
+                      )
                       if link_matches:
                           # Examine the next two sibling rows for date information
                           self.Logger.debug_log( f"found match. starting to iterate on {office_partial_url}" , True )
@@ -1214,7 +1355,7 @@ class Biography:
                           row_desc = "Office row: %r" % (row_text[:80] + ("..." if len(row_text) > 80 else ""))
                           term_added_this_tr = False
                           for _ in range(2):  # Check the next row and the one after that
-                              tr_cur = tr_cur.find_next_sibling('tr')
+                              tr_cur = tr_cur.find_next_sibling('tr') if tr_cur else None
                               if tr_cur:
                                   self.Logger.debug_log(f"find next tr {tr_cur}", True)
                                   date_text = tr_cur.get_text(" ", strip=True)
@@ -1266,18 +1407,46 @@ class Biography:
                                   # If dates are invalid, continue to the next sibling row
                           if not term_added_this_tr:
                               infobox_items.append("%s -> checked 2 sibling rows; no valid dates" % row_desc)
+                  # Single fetch: also collect birth/death from same infobox so runner can skip second fetch
+                  details = self.parse_infobox(infobox)
+                  details["wiki_url"] = normalize_wiki_url(wiki_link) or wiki_link
+                  details["page_path"] = (urlparse(wiki_link).path.split("/")[-1] or "").strip()
+                  if not details.get("full_name"):
+                      details["full_name"] = details.get("name") or ""
+                  self._last_bio_details = details
                   if all_terms:
                       return (all_terms, infobox_items if infobox_items else ["Infobox: matched rows returned terms above."])
 
               if not infobox:
+                  self._last_bio_details = None
                   infobox_items.append("No infobox in page.")
               elif not infobox_items:
                   infobox_items.append("Infobox found; no rows matching office link/name.")
           else:
+              self._last_bio_details = None
               infobox_items.append("Failed to fetch page: HTTP %s" % response.status_code)
+              if (wiki_link or "").strip() and (wiki_link or "").strip() != "No link":
+                  self._last_dead_link = True
+                  # #region agent log
+                  try:
+                      _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                      open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_term_dates", "message": "dead_link_reason", "data": {"wiki_link": (wiki_link or "")[:120], "reason": "http_error", "status": response.status_code}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H3"}) + "\n")
+                  except Exception:
+                      pass
+                  # #endregion
       except requests.exceptions.RequestException as e:
+          self._last_bio_details = None
           self.Logger.log(f"Request failed: {e}", False)
           infobox_items.append("Request failed: %s" % str(e))
+          if (wiki_link or "").strip() and (wiki_link or "").strip() != "No link":
+              self._last_dead_link = True
+              # #region agent log
+              try:
+                  _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
+                  open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_term_dates", "message": "dead_link_reason", "data": {"wiki_link": (wiki_link or "")[:120], "reason": "request_exception", "error": str(e)[:100]}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H5"}) + "\n")
+              except Exception:
+                  pass
+              # #endregion
           # #region agent log
           try:
               _f = open(_log_path, "a", encoding="utf-8")
@@ -1287,10 +1456,13 @@ class Biography:
               pass
           # #endregion
 
+      # Placeholder return: no infobox or no matching terms. Do NOT set dead link here — dead link means
+      # the page does not exist (404, request failed). Missing/mismatched infobox means the page exists.
       # #region agent log
       try:
           _f = open(_log_path, "a", encoding="utf-8")
-          _f.write(json.dumps({"location": "table_parser:find_term_dates", "message": "placeholder return", "data": {"term_start": "YYYY-00-00", "term_end": "YYYY-00-00"}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H3"}) + "\n")
+          infobox_reason = (infobox_items[-1][:150] if infobox_items else "no_items") if isinstance(infobox_items, list) else str(infobox_items)[:150]
+          _f.write(json.dumps({"location": "table_parser:find_term_dates", "message": "placeholder return", "data": {"term_start": "YYYY-00-00", "term_end": "YYYY-00-00", "wiki_link": (wiki_link or "")[:120], "dead_link_set": False, "infobox_reason": infobox_reason}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H3"}) + "\n")
           _f.close()
       except Exception:
           pass

--- a/src/templates/office_form.html
+++ b/src/templates/office_form.html
@@ -147,6 +147,10 @@
     <button type="button" class="btn btn-secondary" id="showSelectedTableBtn">Show selected table</button>
     <button type="button" class="btn btn-secondary" id="showTableHtmlBtn">Show table HTML</button>
     <button type="button" class="btn btn-secondary" id="refreshTableCacheBtn">Refresh table from Wikipedia</button>
+    <select id="exportDebugMode" class="form-select form-select-sm" style="width:auto; display:inline-block;">
+      <option value="preview">Offices only (preview)</option>
+      <option value="full" selected>Office + bio (full parse)</option>
+    </select>
     <button type="button" class="btn btn-secondary" id="exportDebugBtn">Export debug file</button>
     <button type="button" class="btn btn-secondary" id="populateTermsBtn" data-office-id="{{ office.id }}">Populate terms</button>
     <form action="/offices/{{ office.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete this office?');">
@@ -357,13 +361,15 @@
     }
     if (rows.length) {
       var caption = '<p><small>Showing all ' + rows.length + ' rows.</small></p>';
-      var html = caption + '<table><thead><tr><th>Wiki Link</th><th>Party</th><th>District</th><th>Term Start</th><th>Term End</th><th>Start year</th><th>End year</th></tr></thead><tbody>';
+      var html = caption + '<table><thead><tr><th>Wiki Link</th><th>Dead link</th><th>Party</th><th>District</th><th>Term Start</th><th>Term End</th><th>Start year</th><th>End year</th></tr></thead><tbody>';
       rows.forEach(function(r) {
         var link = r['Wiki Link'];
-        var linkCell = (link && link !== 'No link') ? '<a href="' + esc(link) + '" target="_blank" rel="noopener">' + esc(link.length > 50 ? link.slice(0, 50) + '…' : link) + '</a>' : esc(link || '—');
+        var nameNoLink = r['Name (no link)'];
+        var linkCell = (link && link !== 'No link') ? '<a href="' + esc(link) + '" target="_blank" rel="noopener">' + esc(link.length > 50 ? link.slice(0, 50) + '…' : link) + '</a>' : (nameNoLink ? esc(nameNoLink) + ' <small>(no link)</small>' : esc(link || '—'));
+        var deadCell = r['Dead link'] ? 'Yes' : '—';
         var sy = r['Term Start Year'] != null && r['Term Start Year'] !== '' ? r['Term Start Year'] : '—';
         var ey = r['Term End Year'] != null && r['Term End Year'] !== '' ? r['Term End Year'] : '—';
-        html += '<tr><td>' + linkCell + '</td><td>' + esc(r.Party || '—') + '</td><td>' + esc(r.District || '—') + '</td><td>' + esc(r['Term Start'] || '—') + '</td><td>' + esc(r['Term End'] || '—') + '</td><td>' + esc(sy) + '</td><td>' + esc(ey) + '</td></tr>';
+        html += '<tr><td>' + linkCell + '</td><td>' + deadCell + '</td><td>' + esc(r.Party || '—') + '</td><td>' + esc(r.District || '—') + '</td><td>' + esc(r['Term Start'] || '—') + '</td><td>' + esc(r['Term End'] || '—') + '</td><td>' + esc(sy) + '</td><td>' + esc(ey) + '</td></tr>';
       });
       html += '</tbody></table>';
       content.innerHTML = html;
@@ -684,15 +690,17 @@
     }
     var config = getFormDraft();
     var officeName = (config.name || '').trim() || 'office';
+    var exportMode = (document.getElementById('exportDebugMode')?.value || 'full');
     resultEl.style.display = 'block';
     resultEl.className = 'alert';
     var useInfobox = !!config.find_date_in_infobox;
-    if (useInfobox) {
+    // Office + bio (full): when find_date_in_infobox, use async worker
+    if (exportMode === 'full' && useInfobox) {
       resultEl.textContent = 'Exporting…';
       fetch('/api/office-debug-export', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ office_name: officeName, config: config })
+        body: JSON.stringify({ office_name: officeName, config: config, export_mode: 'full' })
       })
         .then(function(r) {
           if (r.status === 202) return r.json().then(function(d) { return { async: true, job_id: d.job_id }; });
@@ -740,6 +748,7 @@
         });
       return;
     }
+    // Offices only (preview) or Office + bio without infobox: get preview + table HTML, then POST
     resultEl.textContent = 'Exporting…';
     fetch('/api/preview', {
       method: 'POST',
@@ -768,7 +777,8 @@
             office_name: officeName,
             config: config,
             preview_result: _.previewResult,
-            table_html_result: _.tableHtmlResult
+            table_html_result: _.tableHtmlResult,
+            export_mode: exportMode
           })
         }).then(function(r) { return r.json(); });
       })

--- a/src/templates/offices.html
+++ b/src/templates/offices.html
@@ -581,7 +581,7 @@
 
     function renderResults(results) {
       var html = '';
-      var headers = ['Wiki Link', 'Party', 'District', 'Term Start', 'Term End', 'Start year', 'End year'];
+      var headers = ['Wiki Link', 'Dead link', 'Party', 'District', 'Term Start', 'Term End', 'Start year', 'End year'];
       results.forEach(function(item) {
         html += '<div class="preview-all-office" style="margin-bottom:1.5rem;">';
         html += '<h3 style="margin:0 0 0.5rem 0; font-size:1rem;"><a href="/offices/' + esc(item.office_id) + '">' + esc(item.name || 'Office ' + item.office_id) + '</a>';
@@ -595,10 +595,12 @@
           html += '</tr></thead><tbody>';
           item.preview_rows.forEach(function(r) {
             var link = r['Wiki Link'];
-            var linkCell = (link && link !== 'No link') ? '<a href="' + esc(link) + '" target="_blank" rel="noopener">' + esc(String(link).length > 50 ? String(link).slice(0, 50) + '…' : link) + '</a>' : esc(link || '—');
+            var nameNoLink = r['Name (no link)'];
+            var linkCell = (link && link !== 'No link') ? '<a href="' + esc(link) + '" target="_blank" rel="noopener">' + esc(String(link).length > 50 ? String(link).slice(0, 50) + '…' : link) + '</a>' : (nameNoLink ? esc(nameNoLink) + ' <small>(no link)</small>' : esc(link || '—'));
+            var deadCell = r['Dead link'] ? 'Yes' : '—';
             var sy = r['Term Start Year'] != null && r['Term Start Year'] !== '' ? r['Term Start Year'] : '—';
             var ey = r['Term End Year'] != null && r['Term End Year'] !== '' ? r['Term End Year'] : '—';
-            html += '<tr><td>' + linkCell + '</td><td>' + esc(r.Party || '—') + '</td><td>' + esc(r.District || '—') + '</td><td>' + esc(r['Term Start'] || '—') + '</td><td>' + esc(r['Term End'] || '—') + '</td><td>' + esc(sy) + '</td><td>' + esc(ey) + '</td></tr>';
+            html += '<tr><td>' + linkCell + '</td><td>' + deadCell + '</td><td>' + esc(r.Party || '—') + '</td><td>' + esc(r.District || '—') + '</td><td>' + esc(r['Term Start'] || '—') + '</td><td>' + esc(r['Term End'] || '—') + '</td><td>' + esc(sy) + '</td><td>' + esc(ey) + '</td></tr>';
           });
           html += '</tbody></table>';
         } else if (item.raw_table_preview && item.raw_table_preview.rows && item.raw_table_preview.rows.length) {

--- a/src/templates/preview.html
+++ b/src/templates/preview.html
@@ -11,6 +11,7 @@
   <thead>
     <tr>
       <th>Wiki Link</th>
+      <th>Dead link</th>
       <th>Party</th>
       <th>District</th>
       <th>Term Start</th>
@@ -22,7 +23,8 @@
   <tbody>
     {% for r in rows %}
     <tr>
-      <td>{% if r.get('Wiki Link') and r.get('Wiki Link') != 'No link' %}<a href="{{ r['Wiki Link'] }}" target="_blank" rel="noopener">{% if r['Wiki Link']|length > 50 %}{{ r['Wiki Link'][:50] }}…{% else %}{{ r['Wiki Link'] }}{% endif %}</a>{% else %}{{ r.get('Wiki Link', '—') }}{% endif %}</td>
+      <td>{% if r.get('Wiki Link') and r.get('Wiki Link') != 'No link' %}<a href="{{ r['Wiki Link'] }}" target="_blank" rel="noopener">{% if r['Wiki Link']|length > 50 %}{{ r['Wiki Link'][:50] }}…{% else %}{{ r['Wiki Link'] }}{% endif %}</a>{% elif r.get('Name (no link)') %}{{ r.get('Name (no link)') }} <small>(no link)</small>{% else %}{{ r.get('Wiki Link', '—') }}{% endif %}</td>
+      <td>{% if r.get('Dead link') %}Yes{% else %}—{% endif %}</td>
       <td>{{ r.get('Party') or '—' }}</td>
       <td>{{ r.get('District') or '—' }}</td>
       <td>{{ r.get('Term Start') or '—' }}</td>


### PR DESCRIPTION
- Table parser: generic X_of_Y -> State_X slug derivation for infobox matching (no office-specific branches); plural singularization for list-derived slugs
- Table parser: link detection for relative/full wiki URLs; year range supports 17xx/18xx; parse th in name column; safe find_next_sibling; dead link only on HTTP/request error
- DB: validate_office_table_config allows link_column<1 when dynamic_parse; one-time migration for term_dates_merged, district_ignore, party_ignore
- Templates and main/runner/schema/individuals updates