### PR TITLE
Section outline: tables under offices, table name field, enabled indi…

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -1,5 +1,7 @@
 """Migration: ensure ref tables exist and offices/parties use FK columns."""
 
+import sqlite3
+
 from .connection import get_connection
 
 
@@ -60,6 +62,10 @@ def migrate_to_fk(conn=None):
         _migrate_alt_links(conn)
         # Page -> office_details -> office_table_config hierarchy: add columns and backfill from offices
         _migrate_to_page_office_table_hierarchy(conn)
+        # Multiple tables per office: allow_reuse_tables on source_pages, unique (office_details_id, table_no)
+        _migrate_allow_reuse_tables_and_table_no_unique(conn)
+        # office_table_config: add name (table name for outline)
+        _migrate_office_table_config_name(conn)
     finally:
         if own_conn:
             conn.close()
@@ -573,3 +579,29 @@ def _migrate_to_page_office_table_hierarchy(conn):
             (od_id, tc_id, oid),
         )
     conn.commit()
+
+
+def _migrate_allow_reuse_tables_and_table_no_unique(conn):
+    """Add allow_reuse_tables to source_pages; add UNIQUE(office_details_id, table_no) on office_table_config."""
+    try:
+        sp_cols = _columns(conn, "source_pages")
+    except sqlite3.OperationalError:
+        return
+    if "allow_reuse_tables" not in sp_cols:
+        conn.execute("ALTER TABLE source_pages ADD COLUMN allow_reuse_tables INTEGER NOT NULL DEFAULT 0")
+        conn.commit()
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_table_config_office_table_no ON office_table_config(office_details_id, table_no)"
+    )
+    conn.commit()
+
+
+def _migrate_office_table_config_name(conn):
+    """Add name column to office_table_config for table display name in outline."""
+    try:
+        tc_cols = _columns(conn, "office_table_config")
+    except sqlite3.OperationalError:
+        return
+    if "name" not in tc_cols:
+        conn.execute("ALTER TABLE office_table_config ADD COLUMN name TEXT")
+        conn.commit()

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -71,6 +71,37 @@ def _flatten_hierarchy_row(
     }
 
 
+def _tc_row_to_config(rd: dict[str, Any]) -> dict[str, Any]:
+    """Build a table config dict from a row dict (tc_id, table_no, table_rows, ...). Used for get_office / list grouping."""
+    return {
+        "id": rd.get("tc_id"),
+        "table_no": rd.get("table_no"),
+        "table_rows": rd.get("table_rows"),
+        "link_column": rd.get("link_column"),
+        "party_column": rd.get("party_column"),
+        "term_start_column": rd.get("term_start_column"),
+        "term_end_column": rd.get("term_end_column"),
+        "district_column": rd.get("district_column"),
+        "dynamic_parse": rd.get("dynamic_parse"),
+        "read_right_to_left": rd.get("read_right_to_left"),
+        "find_date_in_infobox": rd.get("find_date_in_infobox"),
+        "parse_rowspan": rd.get("parse_rowspan"),
+        "rep_link": rd.get("rep_link"),
+        "party_link": rd.get("party_link"),
+        "enabled": rd.get("tc_enabled"),
+        "use_full_page_for_table": rd.get("use_full_page_for_table"),
+        "years_only": rd.get("years_only"),
+        "term_dates_merged": rd.get("term_dates_merged"),
+        "party_ignore": rd.get("party_ignore"),
+        "district_ignore": rd.get("district_ignore"),
+        "district_at_large": rd.get("district_at_large"),
+        "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"),
+        "notes": rd.get("tc_notes"),
+        "name": rd.get("tc_name") or "",
+        "created_at": rd.get("created_at"),
+    }
+
+
 def _ref_names(conn: sqlite3.Connection, country_id: int | None, state_id: int | None, level_id: int | None, branch_id: int | None) -> tuple[str, str, str, str]:
     """Return (country_name, state_name, level_name, branch_name)."""
     c = s = lv = b = ""
@@ -150,6 +181,25 @@ def validate_office_table_config(
             "link, party, term start, term end, and district columns must all be different "
             "(when term dates merged, term start and end may be the same)"
         )
+
+
+def _table_nos_on_page(
+    conn: sqlite3.Connection, source_page_id: int, *, exclude_office_details_id: int | None = None
+) -> set[int]:
+    """Return set of table_no values from all office_table_config rows on this page (optionally excluding one office)."""
+    if exclude_office_details_id is not None:
+        cur = conn.execute(
+            """SELECT tc.table_no FROM office_table_config tc
+               JOIN office_details od ON od.id = tc.office_details_id WHERE od.source_page_id = ? AND od.id != ?""",
+            (source_page_id, exclude_office_details_id),
+        )
+    else:
+        cur = conn.execute(
+            """SELECT tc.table_no FROM office_table_config tc
+               JOIN office_details od ON od.id = tc.office_details_id WHERE od.source_page_id = ?""",
+            (source_page_id,),
+        )
+    return {int(row[0]) for row in cur.fetchall() if row[0] is not None}
 
 
 def get_runnable_unit_ids_for_office(office_id: int, conn: sqlite3.Connection | None = None) -> list[int]:
@@ -242,27 +292,41 @@ def list_offices(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large,
-                          tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
-                   ORDER BY p.id, od.id"""
+                   ORDER BY p.id, od.id, tc.table_no, tc.id"""
             )
             rows = cur.fetchall()
-            out = []
+            by_od: dict[int, list[dict]] = {}
             for r in rows:
                 rd = _row_to_dict(r)
                 od_id = rd["office_details_id"]
+                if od_id not in by_od:
+                    by_od[od_id] = []
+                by_od[od_id].append(rd)
+            out = []
+            for od_id, group in by_od.items():
+                rd0 = group[0]
                 alt_links = [
                     row["link_path"]
                     for row in conn.execute("SELECT link_path FROM alt_links WHERE office_details_id = ? ORDER BY id", (od_id,)).fetchall()
                 ]
-                c, s, lv, b = _ref_names(conn, rd.get("country_id"), rd.get("state_id"), rd.get("level_id"), rd.get("branch_id"))
-                p = {"url": rd.get("url"), "country_id": rd.get("country_id"), "state_id": rd.get("state_id"), "level_id": rd.get("level_id"), "branch_id": rd.get("branch_id"), "notes": rd.get("page_notes"), "enabled": rd.get("page_enabled")}
-                od = {"id": od_id, "name": rd.get("name"), "department": rd.get("department"), "notes": rd.get("notes"), "alt_link_include_main": rd.get("alt_link_include_main"), "enabled": rd.get("od_enabled")}
-                tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
-                flat = _flatten_hierarchy_row(p, od, tc, c, s, lv, b, alt_links)
+                c, s, lv, b = _ref_names(conn, rd0.get("country_id"), rd0.get("state_id"), rd0.get("level_id"), rd0.get("branch_id"))
+                p = {"url": rd0.get("url"), "country_id": rd0.get("country_id"), "state_id": rd0.get("state_id"), "level_id": rd0.get("level_id"), "branch_id": rd0.get("branch_id"), "notes": rd0.get("page_notes"), "enabled": rd0.get("page_enabled")}
+                od = {"id": od_id, "name": rd0.get("name"), "department": rd0.get("department"), "notes": rd0.get("notes"), "alt_link_include_main": rd0.get("alt_link_include_main"), "enabled": rd0.get("od_enabled")}
+                table_configs = []
+                for rd in group:
+                    if rd.get("tc_id") is not None:
+                        table_configs.append(_tc_row_to_config(rd))
+                table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
+                first_tc = table_configs[0] if table_configs else {}
+                tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+                flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
                 flat["id"] = od_id
+                flat["source_page_id"] = rd0.get("page_id")
+                flat["table_configs"] = table_configs
                 out.append(flat)
             return out
         cur = conn.execute(
@@ -303,28 +367,37 @@ def get_office(office_id: int, conn: sqlite3.Connection | None = None) -> dict[s
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large,
-                          tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
                    WHERE od.id = ?""",
                 (office_id,),
             )
-            row = cur.fetchone()
-            if not row:
+            rows = cur.fetchall()
+            if not rows:
                 return None
-            rd = _row_to_dict(row)
-            od_id = rd["office_details_id"]
+            rd0 = _row_to_dict(rows[0])
+            od_id = rd0["office_details_id"]
             alt_links = [
                 r["link_path"]
                 for r in conn.execute("SELECT link_path FROM alt_links WHERE office_details_id = ? ORDER BY id", (od_id,)).fetchall()
             ]
-            c, s, lv, b = _ref_names(conn, rd.get("country_id"), rd.get("state_id"), rd.get("level_id"), rd.get("branch_id"))
-            p = {"url": rd.get("url"), "country_id": rd.get("country_id"), "state_id": rd.get("state_id"), "level_id": rd.get("level_id"), "branch_id": rd.get("branch_id"), "notes": rd.get("page_notes"), "enabled": rd.get("page_enabled")}
-            od = {"id": od_id, "name": rd.get("name"), "department": rd.get("department"), "notes": rd.get("notes"), "alt_link_include_main": rd.get("alt_link_include_main"), "enabled": rd.get("od_enabled")}
-            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
-            flat = _flatten_hierarchy_row(p, od, tc, c, s, lv, b, alt_links)
+            c, s, lv, b = _ref_names(conn, rd0.get("country_id"), rd0.get("state_id"), rd0.get("level_id"), rd0.get("branch_id"))
+            p = {"url": rd0.get("url"), "country_id": rd0.get("country_id"), "state_id": rd0.get("state_id"), "level_id": rd0.get("level_id"), "branch_id": rd0.get("branch_id"), "notes": rd0.get("page_notes"), "enabled": rd0.get("page_enabled")}
+            od = {"id": od_id, "name": rd0.get("name"), "department": rd0.get("department"), "notes": rd0.get("notes"), "alt_link_include_main": rd0.get("alt_link_include_main"), "enabled": rd0.get("od_enabled")}
+            table_configs = []
+            for r in rows:
+                rd = _row_to_dict(r)
+                if rd.get("tc_id") is not None:
+                    table_configs.append(_tc_row_to_config(rd))
+            table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
+            first_tc = table_configs[0] if table_configs else {}
+            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+            flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
             flat["id"] = od_id
+            flat["source_page_id"] = rd0.get("page_id")
+            flat["table_configs"] = table_configs
             return flat
         cur = conn.execute(
             """SELECT o.*, c.name AS country_name, s.name AS state_name, l.name AS level_name, b.name AS branch_name
@@ -343,8 +416,32 @@ def get_office(office_id: int, conn: sqlite3.Connection | None = None) -> dict[s
             conn.close()
 
 
-def create_office(data: dict[str, Any], conn: sqlite3.Connection | None = None) -> int:
-    """Insert office and return new id (office_details_id in hierarchy). Creates source_page + office_details + office_table_config."""
+def get_page(source_page_id: int, conn: sqlite3.Connection | None = None) -> dict[str, Any] | None:
+    """Return source_pages row as dict (id, url, country_id, state_id, level_id, branch_id, notes, enabled, allow_reuse_tables) or None."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, url, country_id, state_id, level_id, branch_id, notes, enabled FROM source_pages WHERE id = ?",
+            (source_page_id,),
+        ).fetchone()
+        if not row:
+            return None
+        d = _row_to_dict(row)
+        try:
+            r2 = conn.execute("SELECT allow_reuse_tables FROM source_pages WHERE id = ?", (source_page_id,)).fetchone()
+            d["allow_reuse_tables"] = r2[0] if r2 is not None else 0
+        except (sqlite3.OperationalError, IndexError):
+            d["allow_reuse_tables"] = 0
+        return d
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def update_page(source_page_id: int, data: dict[str, Any], conn: sqlite3.Connection | None = None) -> bool:
+    """Update only source_pages row. Data: url, country_id, state_id, level_id, branch_id, notes, enabled, allow_reuse_tables."""
     own_conn = conn is None
     if own_conn:
         conn = get_connection()
@@ -352,20 +449,267 @@ def create_office(data: dict[str, Any], conn: sqlite3.Connection | None = None) 
         country_id = int(data.get("country_id") or 0)
         if not country_id:
             raise ValueError("country_id required")
-        term_dates_merged = _bool(data, "term_dates_merged")
-        party_ignore = _bool(data, "party_ignore")
-        district_ignore = _bool(data, "district_ignore")
-        district_at_large = _bool(data, "district_at_large")
-        row_data = dict(data)
-        if term_dates_merged:
-            row_data["term_end_column"] = row_data.get("term_start_column", 4)
-        validate_office_table_config(
-            row_data,
-            term_dates_merged=term_dates_merged,
-            party_ignore=party_ignore,
-            district_ignore=district_ignore,
-            district_at_large=district_at_large,
+        url = (data.get("url") or "").strip()
+        if not url:
+            raise ValueError("url required")
+        enabled = 1 if data.get("enabled") in (True, 1, "TRUE", "true", "1") else 0
+        allow_reuse_tables = 1 if data.get("allow_reuse_tables") in (True, 1, "TRUE", "true", "1") else 0
+        try:
+            conn.execute(
+                """UPDATE source_pages SET country_id=?, state_id=?, level_id=?, branch_id=?, url=?, notes=?, enabled=?, allow_reuse_tables=?, updated_at=datetime('now') WHERE id=?""",
+                (
+                    country_id,
+                    int(data.get("state_id") or 0) or None,
+                    int(data.get("level_id") or 0) or None,
+                    int(data.get("branch_id") or 0) or None,
+                    url,
+                    data.get("notes") or "",
+                    enabled,
+                    allow_reuse_tables,
+                    source_page_id,
+                ),
+            )
+        except sqlite3.OperationalError:
+            conn.execute(
+                """UPDATE source_pages SET country_id=?, state_id=?, level_id=?, branch_id=?, url=?, notes=?, enabled=?, updated_at=datetime('now') WHERE id=?""",
+                (
+                    country_id,
+                    int(data.get("state_id") or 0) or None,
+                    int(data.get("level_id") or 0) or None,
+                    int(data.get("branch_id") or 0) or None,
+                    url,
+                    data.get("notes") or "",
+                    enabled,
+                    source_page_id,
+                ),
+            )
+        conn.commit()
+        return True
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def list_offices_for_page(source_page_id: int, conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    """Return all offices (flat) for a given source_page_id. Empty if not using hierarchy or page not found."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not _use_hierarchy(conn):
+            return []
+        cur = conn.execute(
+            """SELECT p.id AS page_id, p.country_id, p.state_id, p.level_id, p.branch_id, p.url, p.notes AS page_notes, p.enabled AS page_enabled,
+                          od.id AS office_details_id, od.name, od.department, od.notes, od.alt_link_include_main, od.enabled AS od_enabled,
+                          tc.id AS tc_id, tc.table_no, tc.table_rows, tc.link_column, tc.party_column,
+                          tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
+                          tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
+                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large,
+                          tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                   FROM office_details od
+                   JOIN source_pages p ON p.id = od.source_page_id
+                   LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
+                   WHERE p.id = ?
+                   ORDER BY od.id, tc.table_no, tc.id""",
+            (source_page_id,),
         )
+        rows = cur.fetchall()
+        # Group by office_details_id (one office per group, multiple rows per office when multiple table configs)
+        by_od: dict[int, list[dict]] = {}
+        for r in rows:
+            rd = _row_to_dict(r)
+            od_id = rd["office_details_id"]
+            if od_id not in by_od:
+                by_od[od_id] = []
+            by_od[od_id].append(rd)
+        out = []
+        for od_id, group in by_od.items():
+            rd0 = group[0]
+            alt_links = [
+                row["link_path"]
+                for row in conn.execute("SELECT link_path FROM alt_links WHERE office_details_id = ? ORDER BY id", (od_id,)).fetchall()
+            ]
+            c, s, lv, b = _ref_names(conn, rd0.get("country_id"), rd0.get("state_id"), rd0.get("level_id"), rd0.get("branch_id"))
+            p = {"url": rd0.get("url"), "country_id": rd0.get("country_id"), "state_id": rd0.get("state_id"), "level_id": rd0.get("level_id"), "branch_id": rd0.get("branch_id"), "notes": rd0.get("page_notes"), "enabled": rd0.get("page_enabled")}
+            od = {"id": od_id, "name": rd0.get("name"), "department": rd0.get("department"), "notes": rd0.get("notes"), "alt_link_include_main": rd0.get("alt_link_include_main"), "enabled": rd0.get("od_enabled")}
+            table_configs = []
+            for rd in group:
+                if rd.get("tc_id") is not None:
+                    table_configs.append(_tc_row_to_config(rd))
+            table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
+            first_tc = table_configs[0] if table_configs else {}
+            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+            flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
+            flat["id"] = od_id
+            flat["source_page_id"] = rd0.get("page_id")
+            flat["table_configs"] = table_configs
+            out.append(flat)
+        return out
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def _insert_one_table_config(
+    conn: sqlite3.Connection, od_id: int, tc: dict[str, Any], enabled: int
+) -> None:
+    """Insert one office_table_config row from tc dict."""
+    t_merged = _bool(tc, "term_dates_merged")
+    conn.execute(
+        """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
+              term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
+              parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
+              term_dates_merged, party_ignore, district_ignore, district_at_large, consolidate_rowspan_terms, notes, name, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+        (
+            od_id,
+            int(tc.get("table_no", 1)),
+            int(tc.get("table_rows", 4)),
+            int(tc.get("link_column", 1)),
+            int(tc.get("party_column", 0)),
+            int(tc.get("term_start_column", 4)),
+            int(tc.get("term_end_column", 5)),
+            int(tc.get("district_column", 0)),
+            1 if tc.get("dynamic_parse") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("read_right_to_left") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("find_date_in_infobox") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("parse_rowspan") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("rep_link") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("party_link") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("enabled") in (True, 1, "TRUE", "true", "1") else enabled,
+            1 if tc.get("use_full_page_for_table") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("years_only") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if t_merged else 0,
+            1 if tc.get("party_ignore") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("district_ignore") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("district_at_large") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
+            tc.get("notes") or "",
+            tc.get("name") or "",
+        ),
+    )
+
+
+def create_office_for_page(source_page_id: int, data: dict[str, Any], conn: sqlite3.Connection | None = None) -> int:
+    """Add a new office (and its table config(s)) to an existing page. Returns new office_details id.
+    If data has table_configs, creates multiple configs; else one from data."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, country_id, state_id, level_id, branch_id, url, notes, enabled FROM source_pages WHERE id = ?",
+            (source_page_id,),
+        ).fetchone()
+        if not row:
+            raise ValueError("Page not found")
+        row_data = dict(data)
+        table_configs = data.get("table_configs")
+        if table_configs is None or len(table_configs) == 0:
+            term_dates_merged = _bool(data, "term_dates_merged")
+            party_ignore = _bool(data, "party_ignore")
+            district_ignore = _bool(data, "district_ignore")
+            district_at_large = _bool(data, "district_at_large")
+            if term_dates_merged:
+                row_data["term_end_column"] = row_data.get("term_start_column", 4)
+            validate_office_table_config(
+                row_data,
+                term_dates_merged=term_dates_merged,
+                party_ignore=party_ignore,
+                district_ignore=district_ignore,
+                district_at_large=district_at_large,
+            )
+            table_configs = [row_data]
+        else:
+            for tc in table_configs:
+                t_merged = _bool(tc, "term_dates_merged")
+                tcd = dict(tc)
+                if t_merged:
+                    tcd["term_end_column"] = tc.get("term_start_column", 4)
+                validate_office_table_config(
+                    tcd,
+                    term_dates_merged=t_merged,
+                    party_ignore=_bool(tc, "party_ignore"),
+                    district_ignore=_bool(tc, "district_ignore"),
+                    district_at_large=_bool(tc, "district_at_large"),
+                )
+            table_nos = [int(tc.get("table_no") or 1) for tc in table_configs]
+            if len(table_nos) != len(set(table_nos)):
+                raise ValueError("Duplicate table_no within office")
+            page_data = get_page(source_page_id, conn)
+            if page_data and page_data.get("allow_reuse_tables"):
+                other_nos = _table_nos_on_page(conn, source_page_id)
+                if set(table_nos) & other_nos:
+                    raise ValueError(
+                        "Table numbers must be unique per page when 'Allow reuse of tables' is checked"
+                    )
+        enabled = 1 if row_data.get("enabled") in (True, 1, "TRUE", "true", "1") else 0
+        conn.execute(
+            """INSERT INTO office_details (source_page_id, name, variant_name, department, notes, alt_link_include_main, enabled, created_at, updated_at)
+               VALUES (?, ?, '', ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+            (
+                source_page_id,
+                (row_data.get("name") or "New office").strip(),
+                row_data.get("department") or "",
+                row_data.get("notes") or "",
+                1 if row_data.get("alt_link_include_main") in (True, 1, "TRUE", "true", "1") else 0,
+                enabled,
+            ),
+        )
+        od_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        for tc in table_configs:
+            _insert_one_table_config(conn, od_id, tc, enabled)
+        conn.commit()
+        set_alt_links_for_office(od_id, row_data.get("alt_links") or [], conn=conn)
+        return od_id
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def create_office(data: dict[str, Any], conn: sqlite3.Connection | None = None) -> int:
+    """Insert office and return new id (office_details_id in hierarchy). Creates source_page + office_details + office_table_config(s).
+    If data has table_configs, creates multiple configs; else one from data."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        country_id = int(data.get("country_id") or 0)
+        if not country_id:
+            raise ValueError("country_id required")
+        row_data = dict(data)
+        table_configs = data.get("table_configs")
+        if table_configs is None or len(table_configs) == 0:
+            term_dates_merged = _bool(data, "term_dates_merged")
+            party_ignore = _bool(data, "party_ignore")
+            district_ignore = _bool(data, "district_ignore")
+            district_at_large = _bool(data, "district_at_large")
+            if term_dates_merged:
+                row_data["term_end_column"] = row_data.get("term_start_column", 4)
+            validate_office_table_config(
+                row_data,
+                term_dates_merged=term_dates_merged,
+                party_ignore=party_ignore,
+                district_ignore=district_ignore,
+                district_at_large=district_at_large,
+            )
+            table_configs = [row_data]
+        else:
+            for tc in table_configs:
+                t_merged = _bool(tc, "term_dates_merged")
+                tcd = dict(tc)
+                if t_merged:
+                    tcd["term_end_column"] = tc.get("term_start_column", 4)
+                validate_office_table_config(
+                    tcd,
+                    term_dates_merged=t_merged,
+                    party_ignore=_bool(tc, "party_ignore"),
+                    district_ignore=_bool(tc, "district_ignore"),
+                    district_at_large=_bool(tc, "district_at_large"),
+                )
+            table_nos = [int(tc.get("table_no") or 1) for tc in table_configs]
+            if len(table_nos) != len(set(table_nos)):
+                raise ValueError("Duplicate table_no within office")
         enabled = 1 if row_data.get("enabled") in (True, 1, "TRUE", "true", "1") else 0
         conn.execute(
             """INSERT INTO source_pages (country_id, state_id, level_id, branch_id, url, notes, enabled, created_at, updated_at)
@@ -394,38 +738,8 @@ def create_office(data: dict[str, Any], conn: sqlite3.Connection | None = None) 
             ),
         )
         od_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        conn.execute(
-            """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
-                  term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
-                  parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
-                  term_dates_merged, party_ignore, district_ignore, district_at_large, consolidate_rowspan_terms, notes, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
-            (
-                od_id,
-                int(row_data.get("table_no", 1)),
-                int(row_data.get("table_rows", 4)),
-                int(row_data.get("link_column", 1)),
-                int(row_data.get("party_column", 0)),
-                int(row_data.get("term_start_column", 4)),
-                int(row_data.get("term_end_column", 5)),
-                int(row_data.get("district_column", 0)),
-                1 if row_data.get("dynamic_parse") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if row_data.get("read_right_to_left") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if row_data.get("find_date_in_infobox") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if row_data.get("parse_rowspan") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if row_data.get("rep_link") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if row_data.get("party_link") in (True, 1, "TRUE", "true", "1") else 0,
-                enabled,
-                1 if row_data.get("use_full_page_for_table") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if row_data.get("years_only") in (True, 1, "TRUE", "true", "1") else 0,
-                1 if term_dates_merged else 0,
-                1 if party_ignore else 0,
-                1 if district_ignore else 0,
-                1 if district_at_large else 0,
-                1 if row_data.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
-                row_data.get("notes") or "",
-            ),
-        )
+        for tc in table_configs:
+            _insert_one_table_config(conn, od_id, tc, enabled)
         conn.commit()
         set_alt_links_for_office(od_id, row_data.get("alt_links") or [], conn=conn)
         return od_id
@@ -434,48 +748,44 @@ def create_office(data: dict[str, Any], conn: sqlite3.Connection | None = None) 
             conn.close()
 
 
-def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection | None = None) -> bool:
-    """Update office by id (office_details_id in hierarchy). Updates source_page, office_details, office_table_config."""
+def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection | None = None, *, office_only: bool = False) -> bool:
+    """Update office by id (office_details_id in hierarchy). Updates source_page (unless office_only), office_details, office_table_config."""
     own_conn = conn is None
     if own_conn:
         conn = get_connection()
     try:
-        country_id = int(data.get("country_id") or 0)
-        if not country_id:
-            raise ValueError("country_id required")
+        row_data = dict(data)
+        row_data.pop("office_only", None)
         term_dates_merged = _bool(data, "term_dates_merged")
         party_ignore = _bool(data, "party_ignore")
         district_ignore = _bool(data, "district_ignore")
         district_at_large = _bool(data, "district_at_large")
-        row_data = dict(data)
         if term_dates_merged:
             row_data["term_end_column"] = row_data.get("term_start_column", 4)
-        validate_office_table_config(
-            row_data,
-            term_dates_merged=term_dates_merged,
-            party_ignore=party_ignore,
-            district_ignore=district_ignore,
-            district_at_large=district_at_large,
-        )
         enabled_val = 1 if data.get("enabled") in (True, 1, "TRUE", "true", "1") else 0
+        if not office_only:
+            country_id = int(data.get("country_id") or 0)
+            if not country_id:
+                raise ValueError("country_id required")
         if _use_hierarchy(conn):
             row = conn.execute("SELECT source_page_id FROM office_details WHERE id = ?", (office_id,)).fetchone()
             if not row:
                 return False
             page_id = row["source_page_id"]
-            conn.execute(
-                """UPDATE source_pages SET country_id=?, state_id=?, level_id=?, branch_id=?, url=?, notes=?, enabled=?, updated_at=datetime('now') WHERE id=?""",
-                (
-                    country_id,
-                    int(row_data.get("state_id") or 0) or None,
-                    int(row_data.get("level_id") or 0) or None,
-                    int(row_data.get("branch_id") or 0) or None,
-                    (row_data.get("url") or "").strip(),
-                    row_data.get("notes") or "",
-                    enabled_val,
-                    page_id,
-                ),
-            )
+            if not office_only:
+                conn.execute(
+                    """UPDATE source_pages SET country_id=?, state_id=?, level_id=?, branch_id=?, url=?, notes=?, enabled=?, updated_at=datetime('now') WHERE id=?""",
+                    (
+                        int(row_data.get("country_id") or 0),
+                        int(row_data.get("state_id") or 0) or None,
+                        int(row_data.get("level_id") or 0) or None,
+                        int(row_data.get("branch_id") or 0) or None,
+                        (row_data.get("url") or "").strip(),
+                        row_data.get("notes") or "",
+                        enabled_val,
+                        page_id,
+                    ),
+                )
             conn.execute(
                 """UPDATE office_details SET name=?, department=?, notes=?, alt_link_include_main=?, enabled=?, updated_at=datetime('now') WHERE id=?""",
                 (
@@ -487,38 +797,155 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                     office_id,
                 ),
             )
-            conn.execute(
-                """UPDATE office_table_config SET table_no=?, table_rows=?, link_column=?, party_column=?,
-                      term_start_column=?, term_end_column=?, district_column=?, dynamic_parse=?, read_right_to_left=?,
-                      find_date_in_infobox=?, parse_rowspan=?, rep_link=?, party_link=?, enabled=?, use_full_page_for_table=?,
-                      years_only=?, term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?,
-                      consolidate_rowspan_terms=?, notes=?, updated_at=datetime('now') WHERE office_details_id=?""",
-                (
-                    int(row_data.get("table_no", 1)),
-                    int(row_data.get("table_rows", 4)),
-                    int(row_data.get("link_column", 1)),
-                    int(row_data.get("party_column", 0)),
-                    int(row_data.get("term_start_column", 4)),
-                    int(row_data.get("term_end_column", 5)),
-                    int(row_data.get("district_column", 0)),
-                    1 if row_data.get("dynamic_parse") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if row_data.get("read_right_to_left") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if row_data.get("find_date_in_infobox") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if row_data.get("parse_rowspan") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if row_data.get("rep_link") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if row_data.get("party_link") in (True, 1, "TRUE", "true", "1") else 0,
-                    enabled_val,
-                    1 if row_data.get("use_full_page_for_table") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if row_data.get("years_only") in (True, 1, "TRUE", "true", "1") else 0,
-                    1 if term_dates_merged else 0,
-                    1 if party_ignore else 0,
-                    1 if district_ignore else 0,
-                    1 if district_at_large else 0,
-                    1 if row_data.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
-                    row_data.get("notes") or "",
-                    office_id,
-                ),
-            )
+            table_configs = data.get("table_configs")
+            if table_configs is None:
+                # Backward compat: build single table config from flat fields
+                one = {
+                    "table_no": row_data.get("table_no", 1),
+                    "table_rows": row_data.get("table_rows", 4),
+                    "link_column": row_data.get("link_column", 1),
+                    "party_column": row_data.get("party_column", 0),
+                    "term_start_column": row_data.get("term_start_column", 4),
+                    "term_end_column": row_data.get("term_end_column", 5),
+                    "district_column": row_data.get("district_column", 0),
+                    "dynamic_parse": row_data.get("dynamic_parse"),
+                    "read_right_to_left": row_data.get("read_right_to_left"),
+                    "find_date_in_infobox": row_data.get("find_date_in_infobox"),
+                    "parse_rowspan": row_data.get("parse_rowspan"),
+                    "rep_link": row_data.get("rep_link"),
+                    "party_link": row_data.get("party_link"),
+                    "enabled": data.get("enabled"),
+                    "use_full_page_for_table": row_data.get("use_full_page_for_table"),
+                    "years_only": row_data.get("years_only"),
+                    "term_dates_merged": row_data.get("term_dates_merged"),
+                    "party_ignore": row_data.get("party_ignore"),
+                    "district_ignore": row_data.get("district_ignore"),
+                    "district_at_large": row_data.get("district_at_large"),
+                    "consolidate_rowspan_terms": row_data.get("consolidate_rowspan_terms"),
+                    "notes": row_data.get("notes"),
+                }
+                existing_tc = conn.execute(
+                    "SELECT id FROM office_table_config WHERE office_details_id = ?", (office_id,)
+                ).fetchall()
+                if len(existing_tc) == 1:
+                    one["id"] = existing_tc[0][0]
+                table_configs = [one]
+            if table_configs is not None:
+                if not table_configs:
+                    raise ValueError("Office must have at least one table config")
+                for tc in table_configs:
+                    t_merged = _bool(tc, "term_dates_merged")
+                    p_ignore = _bool(tc, "party_ignore")
+                    d_ignore = _bool(tc, "district_ignore")
+                    d_large = _bool(tc, "district_at_large")
+                    tcd = dict(tc)
+                    if t_merged:
+                        tcd["term_end_column"] = tc.get("term_start_column", 4)
+                    validate_office_table_config(
+                        tcd,
+                        term_dates_merged=t_merged,
+                        party_ignore=p_ignore,
+                        district_ignore=d_ignore,
+                        district_at_large=d_large,
+                    )
+                table_nos = [int(tc.get("table_no") or 1) for tc in table_configs]
+                if len(table_nos) != len(set(table_nos)):
+                    raise ValueError("Duplicate table_no within office")
+                page_data = get_page(page_id, conn)
+                if page_data and page_data.get("allow_reuse_tables"):
+                    other_nos = _table_nos_on_page(conn, page_id, exclude_office_details_id=office_id)
+                    if set(table_nos) & other_nos:
+                        raise ValueError(
+                            "Table numbers must be unique per page when 'Allow reuse of tables' is checked"
+                        )
+                existing_ids = {
+                    r[0]
+                    for r in conn.execute(
+                        "SELECT id FROM office_table_config WHERE office_details_id = ?", (office_id,)
+                    ).fetchall()
+                }
+                kept_ids = []
+                for tc in table_configs:
+                    tc_id = tc.get("id")
+                    if tc_id is not None and int(tc_id) in existing_ids:
+                        tc_id = int(tc_id)
+                        t_merged = _bool(tc, "term_dates_merged")
+                        conn.execute(
+                            """UPDATE office_table_config SET table_no=?, table_rows=?, link_column=?, party_column=?,
+                                  term_start_column=?, term_end_column=?, district_column=?, dynamic_parse=?, read_right_to_left=?,
+                                  find_date_in_infobox=?, parse_rowspan=?, rep_link=?, party_link=?, enabled=?, use_full_page_for_table=?,
+                                  years_only=?, term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?,
+                                  consolidate_rowspan_terms=?, notes=?, name=?, updated_at=datetime('now') WHERE id=?""",
+                            (
+                                int(tc.get("table_no", 1)),
+                                int(tc.get("table_rows", 4)),
+                                int(tc.get("link_column", 1)),
+                                int(tc.get("party_column", 0)),
+                                int(tc.get("term_start_column", 4)),
+                                int(tc.get("term_end_column", 5)),
+                                int(tc.get("district_column", 0)),
+                                1 if tc.get("dynamic_parse") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("read_right_to_left") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("find_date_in_infobox") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("parse_rowspan") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("rep_link") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("party_link") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("enabled") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("use_full_page_for_table") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("years_only") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if t_merged else 0,
+                                1 if tc.get("party_ignore") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("district_ignore") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("district_at_large") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
+                                tc.get("notes") or "",
+                                tc.get("name") or "",
+                                tc_id,
+                            ),
+                        )
+                        kept_ids.append(tc_id)
+                    else:
+                        t_merged = _bool(tc, "term_dates_merged")
+                        conn.execute(
+                            """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
+                                  term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
+                                  parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
+                                  term_dates_merged, party_ignore, district_ignore, district_at_large, consolidate_rowspan_terms, notes, name, created_at, updated_at)
+                               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                            (
+                                office_id,
+                                int(tc.get("table_no", 1)),
+                                int(tc.get("table_rows", 4)),
+                                int(tc.get("link_column", 1)),
+                                int(tc.get("party_column", 0)),
+                                int(tc.get("term_start_column", 4)),
+                                int(tc.get("term_end_column", 5)),
+                                int(tc.get("district_column", 0)),
+                                1 if tc.get("dynamic_parse") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("read_right_to_left") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("find_date_in_infobox") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("parse_rowspan") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("rep_link") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("party_link") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("enabled") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("use_full_page_for_table") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("years_only") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if t_merged else 0,
+                                1 if tc.get("party_ignore") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("district_ignore") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("district_at_large") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
+                                tc.get("notes") or "",
+                                tc.get("name") or "",
+                            ),
+                        )
+                        kept_ids.append(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+                if kept_ids:
+                    placeholders = ",".join("?" * len(kept_ids))
+                    conn.execute(
+                        f"DELETE FROM office_table_config WHERE office_details_id = ? AND id NOT IN ({placeholders})",
+                        (office_id, *kept_ids),
+                    )
             conn.commit()
             set_alt_links_for_office(office_id, row_data.get("alt_links") or [], conn=conn)
             return True
@@ -611,22 +1038,75 @@ def set_all_offices_enabled(enabled: bool, conn: sqlite3.Connection | None = Non
             conn.close()
 
 
+def delete_table(office_table_config_id: int, conn: sqlite3.Connection | None = None) -> bool:
+    """Delete one office_table_config and its office_terms. Fails if it would leave the office with zero configs."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not _use_hierarchy(conn):
+            return False
+        row = conn.execute(
+            "SELECT office_details_id FROM office_table_config WHERE id = ?", (office_table_config_id,)
+        ).fetchone()
+        if not row:
+            return False
+        od_id = row[0]
+        count = conn.execute(
+            "SELECT COUNT(*) FROM office_table_config WHERE office_details_id = ?", (od_id,)
+        ).fetchone()[0]
+        if count <= 1:
+            raise ValueError("Office must have at least one table config")
+        conn.execute("DELETE FROM office_terms WHERE office_table_config_id = ?", (office_table_config_id,))
+        conn.execute("DELETE FROM office_table_config WHERE id = ?", (office_table_config_id,))
+        conn.commit()
+        return True
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def delete_page(source_page_id: int, conn: sqlite3.Connection | None = None) -> bool:
+    """Delete page and all its offices (each office's table configs, alt_links, office_terms, then office_details, then source_pages row)."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not _use_hierarchy(conn):
+            return False
+        office_ids = [
+            r[0]
+            for r in conn.execute(
+                "SELECT id FROM office_details WHERE source_page_id = ?", (source_page_id,)
+            ).fetchall()
+        ]
+        for od_id in office_ids:
+            conn.execute("DELETE FROM office_table_config WHERE office_details_id = ?", (od_id,))
+            conn.execute("DELETE FROM alt_links WHERE office_details_id = ?", (od_id,))
+            conn.execute("DELETE FROM office_terms WHERE office_details_id = ?", (od_id,))
+            conn.execute("DELETE FROM office_details WHERE id = ?", (od_id,))
+        conn.execute("DELETE FROM source_pages WHERE id = ?", (source_page_id,))
+        conn.commit()
+        return True
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def delete_office(office_id: int, conn: sqlite3.Connection | None = None) -> bool:
-    """Delete office by id (office_details_id in hierarchy: table_configs, alt_links, terms, office_details, source_page)."""
+    """Delete office by id (office_details_id in hierarchy: table_configs, alt_links, terms, office_details). Does not delete source_pages."""
     own_conn = conn is None
     if own_conn:
         conn = get_connection()
     try:
         if _use_hierarchy(conn):
-            row = conn.execute("SELECT source_page_id FROM office_details WHERE id = ?", (office_id,)).fetchone()
+            row = conn.execute("SELECT id FROM office_details WHERE id = ?", (office_id,)).fetchone()
             if not row:
                 return False
-            page_id = row["source_page_id"]
             conn.execute("DELETE FROM office_table_config WHERE office_details_id = ?", (office_id,))
             conn.execute("DELETE FROM alt_links WHERE office_details_id = ?", (office_id,))
             conn.execute("DELETE FROM office_terms WHERE office_details_id = ?", (office_id,))
             conn.execute("DELETE FROM office_details WHERE id = ?", (office_id,))
-            conn.execute("DELETE FROM source_pages WHERE id = ?", (page_id,))
             conn.commit()
             return True
         conn.execute("DELETE FROM alt_links WHERE office_id = ?", (office_id,))

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS source_pages (
     url TEXT NOT NULL,
     notes TEXT,
     enabled INTEGER NOT NULL DEFAULT 1,
+    allow_reuse_tables INTEGER NOT NULL DEFAULT 0,
     last_scraped_at TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
@@ -104,11 +105,13 @@ CREATE TABLE IF NOT EXISTS office_table_config (
     district_at_large INTEGER NOT NULL DEFAULT 0,
     consolidate_rowspan_terms INTEGER NOT NULL DEFAULT 0,
     notes TEXT,
+    name TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_office_table_config_office_details_id ON office_table_config(office_details_id);
 CREATE INDEX IF NOT EXISTS idx_office_table_config_enabled ON office_table_config(enabled);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_office_table_config_office_table_no ON office_table_config(office_details_id, table_no);
 
 -- Offices: office definitions (what we scrape); link by FK to countries, states, levels, branches (legacy; migrated to hierarchy)
 CREATE TABLE IF NOT EXISTS offices (

--- a/src/main.py
+++ b/src/main.py
@@ -214,12 +214,106 @@ async def offices_import(request: Request, csv_path: str = Form("")):
         return templates.TemplateResponse("import.html", {"request": request, "error": str(e)})
 
 
+@app.post("/offices/add-office-to-page")
+async def office_add_to_page(request: Request):
+    """Add a new office (and table) to an existing page. Form: source_page_id. Redirects to new office edit."""
+    form = await request.form()
+    try:
+        source_page_id = int(form.get("source_page_id") or 0)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="source_page_id required")
+    if source_page_id <= 0:
+        raise HTTPException(status_code=400, detail="source_page_id required")
+    offices_on_page = db_offices.list_offices_for_page(source_page_id)
+    if not offices_on_page:
+        raise HTTPException(status_code=404, detail="Page not found or has no offices")
+    first = offices_on_page[0]
+    data = {
+        "country_id": first.get("country_id") or 0,
+        "state_id": first.get("state_id"),
+        "level_id": first.get("level_id"),
+        "branch_id": first.get("branch_id"),
+        "department": (first.get("department") or "").strip(),
+        "name": "New office",
+        "enabled": False,
+        "notes": "",
+        "url": first.get("url") or "",
+        "table_no": int(first.get("table_no") or 1),
+        "table_rows": int(first.get("table_rows") or 4),
+        "link_column": int(first.get("link_column") or 1),
+        "party_column": int(first.get("party_column") or 0),
+        "term_start_column": int(first.get("term_start_column") or 4),
+        "term_end_column": int(first.get("term_end_column") or 5),
+        "district_column": int(first.get("district_column") or 0),
+        "dynamic_parse": bool(first.get("dynamic_parse")),
+        "read_right_to_left": bool(first.get("read_right_to_left")),
+        "find_date_in_infobox": bool(first.get("find_date_in_infobox")),
+        "years_only": bool(first.get("years_only")),
+        "parse_rowspan": bool(first.get("parse_rowspan")),
+        "consolidate_rowspan_terms": bool(first.get("consolidate_rowspan_terms")),
+        "rep_link": bool(first.get("rep_link")),
+        "party_link": bool(first.get("party_link")),
+        "alt_links": list(first.get("alt_links") or []),
+        "alt_link_include_main": bool(first.get("alt_link_include_main")),
+        "use_full_page_for_table": bool(first.get("use_full_page_for_table")),
+        "term_dates_merged": bool(first.get("term_dates_merged")),
+        "party_ignore": bool(first.get("party_ignore")),
+        "district_ignore": bool(first.get("district_ignore")),
+        "district_at_large": bool(first.get("district_at_large")),
+    }
+    try:
+        new_id = db_offices.create_office_for_page(source_page_id, data)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return RedirectResponse(f"/offices/{new_id}?saved=0#section-office-{new_id}", status_code=302)
+
+
+@app.post("/pages/{source_page_id}/delete")
+async def page_delete(source_page_id: int):
+    """Delete page and all its offices. Redirect to /offices. Confirmation must be done in UI (onsubmit confirm)."""
+    db_offices.delete_page(source_page_id)
+    return RedirectResponse("/offices", status_code=302)
+
+
+@app.post("/pages/{source_page_id}")
+async def page_update(request: Request, source_page_id: int):
+    """Update only the page (URL, location). Used when editing one page with multiple offices."""
+    form = await request.form()
+    page_data = {
+        "url": (form.get("url") or "").strip(),
+        "country_id": int(form.get("country_id") or 0),
+        "state_id": int(form.get("state_id") or 0) or None,
+        "level_id": int(form.get("level_id") or 0) or None,
+        "branch_id": int(form.get("branch_id") or 0) or None,
+        "notes": (form.get("notes") or "").strip(),
+        "enabled": form.get("enabled") == "1",
+        "allow_reuse_tables": form.get("allow_reuse_tables") == "1",
+    }
+    try:
+        db_offices.update_page(source_page_id, page_data)
+    except ValueError as e:
+        from urllib.parse import quote
+        offices_on_page = db_offices.list_offices_for_page(source_page_id)
+        base = f"/offices/{offices_on_page[0]['id']}" if offices_on_page else "/offices"
+        return RedirectResponse(f"{base}?error=" + quote(str(e)), status_code=302)
+    first_office_id = db_offices.list_offices_for_page(source_page_id)[0]["id"]
+    return RedirectResponse(f"/offices/{first_office_id}?saved=1#section-page", status_code=302)
+
+
 @app.get("/offices/{office_id}", response_class=HTMLResponse)
 async def office_edit_page(request: Request, office_id: int):
     office = db_offices.get_office(office_id)
     if not office:
         raise HTTPException(status_code=404)
     office["alt_links"] = db_offices.list_alt_links(office_id)
+    offices_on_page = None
+    source_page_id = office.get("source_page_id")
+    page_data = None
+    if source_page_id is not None:
+        offices_on_page = db_offices.list_offices_for_page(source_page_id)
+        page_data = db_offices.get_page(source_page_id)
+        for o in offices_on_page or []:
+            o["terms_count"] = db_office_terms.count_terms_for_office(o["id"])
     saved = request.query_params.get("saved") == "1"
     validation_error = request.query_params.get("error") or None
     nav_ids_raw = request.query_params.get("nav_ids") or ""
@@ -239,18 +333,76 @@ async def office_edit_page(request: Request, office_id: int):
     countries = db_refs.list_countries()
     levels = db_refs.list_levels()
     branches = db_refs.list_branches()
-    states = db_refs.list_states(office.get("country_id") or 0) if office.get("country_id") else []
+    country_id_for_states = (page_data or office).get("country_id") or office.get("country_id") or 0
+    states = db_refs.list_states(country_id_for_states) if country_id_for_states else []
     terms_count = db_office_terms.count_terms_for_office(office_id)
     return templates.TemplateResponse(
         "page_form.html",
-        {"request": request, "office": office, "countries": countries, "levels": levels, "branches": branches, "states": states, "nav_ids": nav_ids_raw, "nav_prev_id": nav_prev_id, "nav_next_id": nav_next_id, "nav_current": nav_current, "nav_total": nav_total, "terms_count": terms_count, "saved": saved, "validation_error": validation_error, "form_template": "page_form"},
+        {"request": request, "office": office, "offices_on_page": offices_on_page, "source_page_id": source_page_id, "page_data": page_data, "countries": countries, "levels": levels, "branches": branches, "states": states, "nav_ids": nav_ids_raw, "nav_prev_id": nav_prev_id, "nav_next_id": nav_next_id, "nav_current": nav_current, "nav_total": nav_total, "terms_count": terms_count, "saved": saved, "validation_error": validation_error, "form_template": "page_form"},
     )
+
+
+def _form_to_table_config(form, i: int) -> dict:
+    """Build one table config dict from form using index i for tc_* getlist."""
+    def _get(key_flat: str, key_tc: str):
+        lst = form.getlist(key_tc)
+        if lst and i < len(lst) and lst[i] is not None and str(lst[i]).strip() != "":
+            return lst[i]
+        return form.get(key_flat) if i == 0 else None
+    def _int(key_flat: str, key_tc: str, default: int) -> int:
+        v = _get(key_flat, key_tc)
+        if v is None or v == "":
+            return default
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return default
+    def _bool(key_flat: str, key_tc: str) -> bool:
+        v = _get(key_flat, key_tc)
+        return v in (True, "1", 1, "true", "TRUE")
+    tc_id = _get("tc_id", "tc_id")
+    if tc_id is not None and str(tc_id).strip() != "":
+        try:
+            tc_id = int(tc_id)
+        except (TypeError, ValueError):
+            tc_id = None
+    else:
+        tc_id = None
+    date_src = _get("date_source", "tc_date_source") or ""
+    dist_mode = _get("district_mode", "tc_district_mode") or "column"
+    return {
+        "id": tc_id,
+        "table_no": _int("table_no", "tc_table_no", 1),
+        "table_rows": _int("table_rows", "tc_table_rows", 4),
+        "link_column": _int("link_column", "tc_link_column", 1),
+        "party_column": _int("party_column", "tc_party_column", 0),
+        "term_start_column": _int("term_start_column", "tc_term_start_column", 4),
+        "term_end_column": _int("term_end_column", "tc_term_end_column", 5),
+        "district_column": _int("district_column", "tc_district_column", 0),
+        "dynamic_parse": _bool("dynamic_parse", "tc_dynamic_parse"),
+        "read_right_to_left": _bool("read_right_to_left", "tc_read_right_to_left"),
+        "find_date_in_infobox": date_src == "find_date_in_infobox",
+        "years_only": date_src == "years_only",
+        "parse_rowspan": _bool("parse_rowspan", "tc_parse_rowspan"),
+        "consolidate_rowspan_terms": _bool("consolidate_rowspan_terms", "tc_consolidate_rowspan_terms"),
+        "rep_link": _bool("rep_link", "tc_rep_link"),
+        "party_link": _bool("party_link", "tc_party_link"),
+        "enabled": _bool("enabled", "tc_enabled") if _get("tc_enabled", "tc_enabled") is not None else True,
+        "use_full_page_for_table": _bool("use_full_page_for_table", "tc_use_full_page_for_table"),
+        "term_dates_merged": _bool("term_dates_merged", "tc_term_dates_merged"),
+        "party_ignore": _bool("party_ignore", "tc_party_ignore"),
+        "district_ignore": dist_mode == "no_district",
+        "district_at_large": dist_mode == "at_large",
+        "notes": _get("notes", "tc_notes") or "",
+        "name": _get("name", "tc_name") or "",
+    }
 
 
 @app.post("/offices/{office_id}")
 async def office_update(request: Request, office_id: int):
     form = await request.form()
     action = form.get("action", "save_and_close")
+    office_only = form.get("office_only") == "1"
     nav_ids = (form.get("nav_ids") or "").strip()
     alt_links = [v.strip() for v in form.getlist("alt_links") if v and isinstance(v, str) and v.strip()]
     alt_link_include_main = form.get("alt_link_include_main") == "1"
@@ -277,15 +429,21 @@ async def office_update(request: Request, office_id: int):
         "district_ignore": (form.get("district_mode") or "column") == "no_district",
         "district_at_large": (form.get("district_mode") or "column") == "at_large",
     }
+    tc_ids = form.getlist("tc_id")
+    tc_table_nos = form.getlist("tc_table_no")
+    if tc_table_nos or tc_ids:
+        n = max(len(tc_ids), len(tc_table_nos), 1)
+        data["table_configs"] = [_form_to_table_config(form, i) for i in range(n)]
     try:
-        db_offices.update_office(office_id, data)
+        db_offices.update_office(office_id, data, office_only=office_only)
     except ValueError as e:
         from urllib.parse import quote
         q = "?error=" + quote(str(e)) + ("&nav_ids=" + nav_ids.strip() if nav_ids and nav_ids.strip() else "")
         return RedirectResponse(f"/offices/{office_id}{q}", status_code=302)
     if action == "save":
         q = "?saved=1" + ("&nav_ids=" + nav_ids.strip() if nav_ids and nav_ids.strip() else "")
-        return RedirectResponse(f"/offices/{office_id}{q}", status_code=302)
+        hash_frag = "#section-office-" + str(office_id) if office_only else ""
+        return RedirectResponse(f"/offices/{office_id}{q}{hash_frag}", status_code=302)
     return RedirectResponse("/offices?saved=1", status_code=302)
 
 
@@ -293,6 +451,17 @@ async def office_update(request: Request, office_id: int):
 async def office_delete(office_id: int):
     db_offices.delete_office(office_id)
     return RedirectResponse("/offices", status_code=302)
+
+
+@app.post("/offices/{office_id}/table/{tc_id}/delete")
+async def table_delete(office_id: int, tc_id: int):
+    """Delete one table config. Redirect back to office edit. Confirmation must be done in UI."""
+    try:
+        db_offices.delete_table(tc_id)
+    except ValueError as e:
+        from urllib.parse import quote
+        return RedirectResponse(f"/offices/{office_id}?error=" + quote(str(e)), status_code=302)
+    return RedirectResponse(f"/offices/{office_id}?saved=1", status_code=302)
 
 
 @app.post("/offices/{office_id}/duplicate")
@@ -337,6 +506,9 @@ async def office_duplicate(office_id: int):
         "district_ignore": bool(office.get("district_ignore")),
         "district_at_large": bool(office.get("district_at_large")),
     }
+    table_configs = office.get("table_configs")
+    if table_configs:
+        data["table_configs"] = [{k: v for k, v in tc.items() if k != "id"} for tc in table_configs]
     try:
         new_id = db_offices.create_office(data)
     except ValueError as e:
@@ -1019,6 +1191,13 @@ async def api_preview_all_tables(request: Request):
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
     url = (body.get("url") or "").strip()
+    # #region agent log
+    try:
+        with open("c:\\Users\\wcmch\\cursor\\office_holder\\.cursor\\debug.log", "a") as _f:
+            _f.write(__import__("json").dumps({"location": "main.py:api_preview_all_tables", "message": "request", "data": {"url_len": len(url), "url_preview": url[:80] if url else "", "has_confirm": body.get("confirm") is True}, "timestamp": __import__("time").time() * 1000}) + "\n")
+    except Exception:
+        pass
+    # #endregion
     if not url:
         raise HTTPException(status_code=400, detail="url required")
     confirmed = body.get("confirm") is True

--- a/src/templates/page_form.html
+++ b/src/templates/page_form.html
@@ -5,7 +5,7 @@
 <p role="status" style="background:var(--bg2, #f0f0f0); border:1px solid var(--border, #ccc); border-radius:4px; padding:0.35rem 0.75rem; margin-bottom:1rem; font-size:0.9rem;">Form: <strong>page_form</strong> (template: page_form.html)</p>
 {% endif %}
 <p class="form-note" style="margin-bottom:1rem;">{{ "Edit" if office else "New" }} office</p>
-{% if office and (nav_prev_id or nav_next_id) %}
+{% if office and (nav_prev_id or nav_next_id) and not (source_page_id is not none and page_data) %}
 <p class="nav-row" style="margin-bottom:1rem;">
   {% if nav_prev_id %}<a href="/offices/{{ nav_prev_id }}{% if nav_ids %}?nav_ids={{ nav_ids }}{% endif %}" class="btn btn-secondary btn-sm">Previous</a>{% endif %}
   {% if nav_prev_id and nav_current and nav_total %} | {% endif %}
@@ -16,8 +16,205 @@
 {% endif %}
 {% if saved %}<div class="alert alert-success">Saved.</div>{% endif %}
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
+
+{% if source_page_id is not none and page_data and offices_on_page %}
+{# Multi-office: one page config, multiple office sections, floating outline to jump #}
+<aside class="page-outline" aria-label="Page sections" style="position:fixed; right:1rem; top:6rem; width:11rem; max-height:calc(100vh - 8rem); overflow:auto; background:var(--bg2, #f5f5f5); border:1px solid var(--border, #ccc); border-radius:6px; padding:0.75rem; font-size:0.9rem; z-index:10;">
+  <strong style="display:block; margin-bottom:0.5rem;">Sections</strong>
+  <ul style="list-style:none; margin:0; padding:0;">
+    <li style="margin-bottom:0.35rem;"><a href="#section-page">{% if page_data.enabled %}<span style="color:green;" aria-label="Enabled">✓</span>{% else %}<span style="color:red;" aria-label="Disabled">✗</span>{% endif %} Page</a></li>
+    {% for o in offices_on_page %}
+    <li style="margin-bottom:0.35rem;"><a href="#section-office-{{ o.id }}">{% if o.enabled %}<span style="color:green;" aria-label="Enabled">✓</span>{% else %}<span style="color:red;" aria-label="Disabled">✗</span>{% endif %} {{ o.name or 'Office' }}</a></li>
+    {% set tclist_outline = o.table_configs if o.table_configs and o.table_configs|length > 0 else [] %}
+    {% for tc in tclist_outline %}
+    <li style="margin-bottom:0.25rem; margin-left:0.75rem; font-size:0.85rem;"><a href="#section-table-{{ tc.id if tc.id else (o.id ~ '-t' ~ loop.index) }}">{% if tc.enabled %}<span style="color:green;" aria-label="Enabled">✓</span>{% else %}<span style="color:red;" aria-label="Disabled">✗</span>{% endif %} {{ tc.name or ('Table ' ~ loop.index) }}</a></li>
+    {% endfor %}
+    {% endfor %}
+    <li style="margin-top:0.5rem; padding-top:0.5rem; border-top:1px solid var(--border, #ccc);">
+      <form method="post" action="/offices/add-office-to-page">
+        <input type="hidden" name="source_page_id" value="{{ source_page_id }}">
+        <button type="submit" class="btn btn-secondary btn-sm" style="width:100%;">Add office</button>
+      </form>
+    </li>
+  </ul>
+</aside>
+<div class="page-edit-main" style="margin-right:13rem;">
+  <div class="save-all-bar" style="margin-bottom:1rem;" data-source-page-id="{{ source_page_id }}">
+    <button type="button" class="btn save-all-btn" id="saveAllBtn">Save</button>
+    <span class="save-all-status" id="saveAllStatus" style="margin-left:0.5rem; font-size:0.9rem; color:var(--muted, #666);"></span>
+  </div>
+  <section id="section-page" style="margin-bottom:2rem;" data-page-url="{{ (page_data.url or '')|e }}">
+    <h1>Page</h1>
+    <p class="form-note">Source page (URL and location). Shared by all offices below.</p>
+    <form method="post" action="/pages/{{ source_page_id }}" id="pageForm">
+      <div class="form-group"><label>URL</label><input type="url" name="url" value="{{ page_data.url or '' }}" required placeholder="https://en.wikipedia.org/wiki/..."></div>
+      <div class="form-row">
+        <div class="form-group">
+          <label>Country</label>
+          <select name="country_id" required>
+            <option value="">— Select country —</option>
+            {% for c in countries %}
+            <option value="{{ c.id }}" {% if page_data.country_id == c.id %}selected{% endif %}>{{ c.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-group">
+          <label>State / Province / Territory</label>
+          <select name="state_id">
+            <option value="">— None —</option>
+            {% for s in states %}
+            <option value="{{ s.id }}" {% if page_data.state_id == s.id %}selected{% endif %}>{{ s.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-group">
+          <label>Level</label>
+          <select name="level_id">
+            <option value="">— None —</option>
+            {% for l in levels %}
+            <option value="{{ l.id }}" {% if page_data.level_id == l.id %}selected{% endif %}>{{ l.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Branch</label>
+          <select name="branch_id">
+            <option value="">— None —</option>
+            {% for b in branches %}
+            <option value="{{ b.id }}" {% if page_data.branch_id == b.id %}selected{% endif %}>{{ b.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-group"><label>Notes</label><input type="text" name="notes" value="{{ page_data.notes or '' }}"></div>
+      <div class="form-group checkbox-group"><label><input type="checkbox" name="enabled" value="1" {% if page_data.enabled %}checked{% endif %}> Page enabled</label></div>
+      <div class="form-group checkbox-group"><label><input type="checkbox" name="allow_reuse_tables" value="1" {% if page_data.allow_reuse_tables %}checked{% endif %}> Allow reuse of tables</label></div>
+      <p class="form-note">When checked, table numbers must be unique per page. When unchecked, different offices can use the same table number.</p>
+      <div class="actions">
+        <button type="submit" class="btn btn-secondary save-page-btn">Save page only</button>
+        <a href="/offices" class="btn btn-secondary">Cancel</a>
+        <form method="post" action="/pages/{{ source_page_id }}/delete" style="display:inline;" onsubmit="return confirm('Delete this page and all its offices and tables? This cannot be undone.');">
+          <button type="submit" class="btn btn-danger">Delete page</button>
+        </form>
+        <button type="button" class="btn btn-secondary" id="showAllTablesBtnMulti" data-action="show-all-tables" data-url-source="page">Show all tables</button>
+        <span id="showAllTablesDebugMulti" style="display:none; margin-left:0.5rem; font-size:0.8rem; color:var(--muted);"></span>
+      </div>
+    </form>
+  </section>
+  {% for o in offices_on_page %}
+  <section id="section-office-{{ o.id }}" style="margin-bottom:2rem; padding-top:1rem; border-top:1px solid var(--border, #ccc);">
+    <h2>{{ o.name or 'Office' }}</h2>
+    {% if o.terms_count is not none %}<p><small>Office terms: {{ o.terms_count }}</small></p>{% endif %}
+    <form method="post" action="/offices/{{ o.id }}" class="office-form" data-office-id="{{ o.id }}">
+      <input type="hidden" name="office_only" value="1">
+      <input type="hidden" name="action" value="save">
+      <div class="form-row">
+        <div class="form-group"><label>Department</label><input type="text" name="department" value="{{ o.department or '' }}"></div>
+        <div class="form-group"><label>Office name</label><input type="text" name="name" value="{{ o.name or '' }}" required></div>
+      </div>
+      <div class="form-group checkbox-group"><label><input type="checkbox" name="enabled" value="1" {% if o.enabled %}checked{% endif %}> Include in runs</label></div>
+      <div class="form-group"><label>Notes</label><input type="text" name="notes" value="{{ o.notes or '' }}"></div>
+      <div class="form-group">
+        <label>Alt links</label>
+        <div class="alt-links-container">
+          {% for link in (o.alt_links if o.alt_links else ['']) %}
+          <div class="alt-link-row" style="margin-bottom:0.25rem;"><input type="text" name="alt_links" value="{{ link }}" placeholder="/wiki/..."> <button type="button" class="btn btn-secondary btn-sm alt-link-remove" aria-label="Remove">Remove</button></div>
+          {% endfor %}
+        </div>
+        <button type="button" class="btn btn-secondary btn-sm alt-link-add" aria-label="Add alt link">Add another alt link</button>
+      </div>
+      <div class="form-group checkbox-group"><label><input type="checkbox" name="alt_link_include_main" value="1" {% if o.alt_link_include_main %}checked{% endif %}> Include main office link in search</label></div>
+      <h3>Table parsing</h3>
+      {% set tclist = o.table_configs if o.table_configs and o.table_configs|length > 0 else [{'id': none, 'name': '', 'table_no': o.table_no or 1, 'table_rows': o.table_rows or 4, 'link_column': o.link_column or 1, 'party_column': o.party_column or 0, 'term_start_column': o.term_start_column or 4, 'term_end_column': o.term_end_column or 5, 'district_column': o.district_column or 0, 'dynamic_parse': o.dynamic_parse, 'read_right_to_left': o.read_right_to_left, 'find_date_in_infobox': o.find_date_in_infobox, 'years_only': o.years_only, 'parse_rowspan': o.parse_rowspan, 'consolidate_rowspan_terms': o.consolidate_rowspan_terms, 'rep_link': o.rep_link, 'party_link': o.party_link, 'enabled': o.enabled, 'use_full_page_for_table': o.use_full_page_for_table, 'term_dates_merged': o.term_dates_merged, 'party_ignore': o.party_ignore, 'district_ignore': o.district_ignore, 'district_at_large': o.district_at_large, 'notes': o.notes or ''}] %}
+      <div class="table-config-blocks" data-office-id="{{ o.id }}">
+      {% for tc in tclist %}
+      <div class="table-config-block" id="section-table-{{ tc.id if tc.id else (o.id ~ '-t' ~ loop.index) }}" data-tc-id="{{ tc.id or '' }}" style="margin-bottom:1.5rem; padding:1rem; border:1px solid var(--border, #ccc); border-radius:6px;">
+        <input type="hidden" name="tc_id" value="{{ tc.id or '' }}">
+        <h4 style="margin-top:0;">Table {{ loop.index }}</h4>
+        <div class="form-row">
+          <div class="form-group"><label>Table name</label><input type="text" name="tc_name" value="{{ tc.name or '' }}" placeholder="e.g. Current members"></div>
+          <div class="form-group"><label>Table no</label><input type="number" name="tc_table_no" value="{{ tc.table_no or 1 }}" min="1"></div>
+          <div class="form-group"><label>Table rows (min)</label><input type="number" name="tc_table_rows" value="{{ tc.table_rows or 4 }}" min="1"></div>
+        </div>
+        <div class="form-row">
+          <div class="form-group"><label>Link column</label><input type="number" name="tc_link_column" value="{{ tc.link_column or 1 }}" min="0"></div>
+          <div class="form-group"><label>Party column</label><input type="number" name="tc_party_column" value="{{ tc.party_column or 0 }}" min="0"></div>
+          <div class="form-group"><label>Term start column</label><input type="number" name="tc_term_start_column" value="{{ tc.term_start_column or 4 }}" min="0"></div>
+          <div class="form-group"><label>Term end column</label><input type="number" name="tc_term_end_column" value="{{ tc.term_end_column or 5 }}" min="0"></div>
+          <div class="form-group"><label>District column</label><input type="number" name="tc_district_column" value="{{ tc.district_column or 0 }}" min="0"></div>
+        </div>
+        <div class="form-row">
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_term_dates_merged" value="1" {% if tc.term_dates_merged %}checked{% endif %}> Term dates merged</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_party_ignore" value="1" {% if tc.party_ignore %}checked{% endif %}> Ignore party</label></div>
+          <div class="form-group">
+            <label>District</label>
+            <select name="tc_district_mode">
+              <option value="column" {% if not tc.district_ignore and not tc.district_at_large %}selected{% endif %}>Use district column</option>
+              <option value="at_large" {% if tc.district_at_large %}selected{% endif %}>At-Large</option>
+              <option value="no_district" {% if tc.district_ignore %}selected{% endif %}>No District</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_dynamic_parse" value="1" {% if tc.dynamic_parse %}checked{% endif %}> Dynamic parse</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_read_right_to_left" value="1" {% if tc.read_right_to_left %}checked{% endif %}> Read right to left</label></div>
+          <div class="form-group">
+            <label>Date source</label>
+            <select name="tc_date_source">
+              <option value="not_applicable" {% if not tc.find_date_in_infobox and not tc.years_only %}selected{% endif %}>Not applicable</option>
+              <option value="find_date_in_infobox" {% if tc.find_date_in_infobox %}selected{% endif %}>Find date in infobox</option>
+              <option value="years_only" {% if tc.years_only %}selected{% endif %}>Table has years only</option>
+            </select>
+          </div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_parse_rowspan" value="1" {% if tc.parse_rowspan %}checked{% endif %}> Parse rowspan</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_consolidate_rowspan_terms" value="1" {% if tc.consolidate_rowspan_terms %}checked{% endif %}> Consolidate rowspan terms</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_rep_link" value="1" {% if tc.rep_link %}checked{% endif %}> Rep link</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_party_link" value="1" {% if tc.party_link %}checked{% endif %}> Party link</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_use_full_page_for_table" value="1" {% if tc.use_full_page_for_table %}checked{% endif %}> Use full page for table</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_enabled" value="1" {% if tc.enabled %}checked{% endif %}> Table enabled</label></div>
+        </div>
+        <div class="form-group"><label>Notes</label><input type="text" name="tc_notes" value="{{ tc.notes or '' }}"></div>
+        <div class="actions" style="margin-top:0.5rem;">
+          <button type="button" class="btn btn-secondary btn-sm remove-table-btn">Remove table</button>
+          {% if tc.id %}
+          <button type="button" class="btn btn-danger btn-sm delete-table-btn" data-office-id="{{ o.id }}" data-tc-id="{{ tc.id }}">Delete table</button>
+          {% endif %}
+          <button type="button" class="btn btn-secondary btn-sm" data-action="test-config">Test config</button>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="preview-all">Preview all</button>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="preview-top-x">Preview top X</button>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="show-selected-table">Show selected table</button>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="show-table-html">Show table HTML</button>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="refresh-table-cache">Refresh table from Wikipedia</button>
+          <select class="form-select form-select-sm export-debug-mode" style="width:auto; display:inline-block;" data-action="export-debug-mode">
+            <option value="preview">Offices only (preview)</option>
+            <option value="full" selected>Office + bio (full parse)</option>
+          </select>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="export-debug">Export debug file</button>
+          <a href="/data/office-terms?office_id={{ o.id }}" class="btn btn-secondary btn-sm" target="_blank" rel="noopener">View current terms</a>
+          <button type="button" class="btn btn-secondary btn-sm" data-action="populate-terms" data-office-id="{{ o.id }}">Populate terms</button>
+        </div>
+      </div>
+      {% endfor %}
+      </div>
+      <button type="button" class="btn btn-secondary add-table-btn" data-office-id="{{ o.id }}" style="margin-bottom:1rem;">Add table</button>
+      <div class="actions">
+        <button type="submit" class="btn btn-secondary save-office-btn">Save this office only</button>
+        <a href="/offices" class="btn btn-secondary">Cancel</a>
+      </div>
+    </form>
+    <div class="actions" style="margin-top:0.25rem;">
+      <form action="/offices/{{ o.id }}/duplicate" method="post" style="display:inline;"><button type="submit" class="btn btn-secondary">Duplicate</button></form>
+      <form action="/offices/{{ o.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete this office and all its tables? This cannot be undone.');"><button type="submit" class="btn btn-danger">Delete</button></form>
+    </div>
+  </section>
+  {% endfor %}
+</div>
+{% else %}
+{# Single office or new: one combined form (page + office + table) #}
 {% if office and terms_count is not none %}<p><small>Office terms: {{ terms_count }}</small></p>{% endif %}
-<form method="post" action="{% if office %}/offices/{{ office.id }}{% else %}/offices/new{% endif %}" id="officeForm">
+<form method="post" action="{% if office %}/offices/{{ office.id }}{% else %}/offices/new{% endif %}" id="officeForm" class="office-form">
   {% if office and nav_ids %}<input type="hidden" name="nav_ids" value="{{ nav_ids }}">{% endif %}
 
   <h1>Page</h1>
@@ -185,28 +382,35 @@
     {% endif %}
   </div>
 </form>
-{% if office %}
+{% endif %}
+{% if office and not (source_page_id is not none and page_data and offices_on_page) %}
 <div class="actions" style="margin-top:0.25rem;">
   <form action="/offices/{{ office.id }}/duplicate" method="post" style="display:inline;">
     <button type="submit" class="btn btn-secondary">Duplicate</button>
   </form>
-  <form action="/offices/{{ office.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete this office?');">
+  <form action="/offices/{{ office.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete this office and all its tables? This cannot be undone.');">
     <button type="submit" class="btn btn-danger">Delete</button>
   </form>
 </div>
 {% endif %}
-{% if office %}
-<div id="testConfigResult" class="alert" style="display:none; margin-top:0.5rem;"></div>
-<button type="button" class="btn btn-secondary btn-sm" id="populateTermsStopBtn" style="display:none; margin-top:0.25rem;">Stop</button>
-<div id="previewPanel" class="preview-panel" style="display:none; margin-top:1rem;">
-  <h2>Preview</h2>
-  <p><small>Dry run — not saved. Use &quot;Preview all&quot; or &quot;Preview top X&quot;.</small></p>
-  <div id="previewContent"></div>
-  <button type="button" class="btn btn-secondary btn-sm" id="previewStopBtn" style="display:none; margin-top:0.25rem;">Stop</button>
-  <div class="actions" style="margin-top:0.5rem;">
-    <button type="button" class="btn btn-secondary btn-sm" id="previewClose">Close preview</button>
-  </div>
+{% if office and source_page_id is not none and not (page_data and offices_on_page) %}
+<div class="offices-on-page" style="margin-top:1rem;">
+  <form method="post" action="/offices/add-office-to-page" style="display:inline;">
+    <input type="hidden" name="source_page_id" value="{{ source_page_id }}">
+    <button type="submit" class="btn btn-secondary">Add office</button>
+  </form>
+  {% if offices_on_page and offices_on_page|length > 1 %}
+  <p style="margin-top:0.75rem; margin-bottom:0.25rem;">Offices on this page:</p>
+  <ul style="margin:0; padding-left:1.25rem;">
+  {% for o in offices_on_page %}
+  {% if o.id != office.id %}
+  <li><a href="/offices/{{ o.id }}">{{ o.name or 'Office' }}</a></li>
+  {% endif %}
+  {% endfor %}
+  </ul>
+  {% endif %}
 </div>
+{% endif %}
 <div id="allTablesPanel" class="preview-panel" style="display:none; margin-top:1rem;">
   <h2>All tables on page</h2>
   <p><small>Top 10 rows per table (from current URL).</small></p>
@@ -219,6 +423,18 @@
   <div class="actions" style="margin-top:0.5rem;">
     <button type="button" class="btn btn-secondary btn-sm" id="allTablesClear">Clear</button>
     <button type="button" class="btn btn-secondary btn-sm" id="allTablesClose">Close</button>
+  </div>
+</div>
+{% if office %}
+<div id="testConfigResult" class="alert" style="display:none; margin-top:0.5rem;"></div>
+<button type="button" class="btn btn-secondary btn-sm" id="populateTermsStopBtn" style="display:none; margin-top:0.25rem;">Stop</button>
+<div id="previewPanel" class="preview-panel" style="display:none; margin-top:1rem;">
+  <h2>Preview</h2>
+  <p><small>Dry run — not saved. Use &quot;Preview all&quot; or &quot;Preview top X&quot;.</small></p>
+  <div id="previewContent"></div>
+  <button type="button" class="btn btn-secondary btn-sm" id="previewStopBtn" style="display:none; margin-top:0.25rem;">Stop</button>
+  <div class="actions" style="margin-top:0.5rem;">
+    <button type="button" class="btn btn-secondary btn-sm" id="previewClose">Close preview</button>
   </div>
 </div>
 <div id="rawTablePanel" class="preview-panel" style="display:none; margin-top:1rem;">
@@ -249,6 +465,7 @@
   var selectedStateId = {% if office and office.state_id %}{{ office.state_id }}{% else %}null{% endif %};
 
   function loadStates(countryId) {
+    if (!stateSelect) return;
     stateSelect.innerHTML = '<option value="">— None —</option>';
     if (!countryId) return;
     fetch('/api/states?country_id=' + encodeURIComponent(countryId))
@@ -264,16 +481,136 @@
       });
   }
 
-  countrySelect.addEventListener('change', function() {
+  if (countrySelect) countrySelect.addEventListener('change', function() {
     selectedStateId = null;
     loadStates(countrySelect.value);
   });
 
-  if (countrySelect.value) loadStates(countrySelect.value);
+  if (countrySelect && countrySelect.value) loadStates(countrySelect.value);
+
+  var allTablesPendingUrl = null;
+  function renderAllTables(data) {
+    var content = document.getElementById('allTablesContent');
+    if (data.error) {
+      if (content) content.innerHTML = '<div class="alert alert-error">' + esc(data.error) + '</div>';
+      return;
+    }
+    var tables = data.tables || [];
+    var html = '';
+    tables.forEach(function(tbl) {
+      var rows = tbl.rows || [];
+      var maxCols = 0;
+      rows.forEach(function(r) { if (r.length > maxCols) maxCols = r.length; });
+      if (maxCols === 0) maxCols = 1;
+      html += '<h3 style="margin-top:1rem;">Table ' + tbl.table_index + '</h3>';
+      html += '<table><thead><tr>';
+      for (var c = 1; c <= maxCols; c++) html += '<th>Column ' + c + '</th>';
+      html += '</tr></thead><tbody>';
+      rows.forEach(function(row) {
+        html += '<tr>';
+        for (var i = 0; i < maxCols; i++) html += '<td>' + esc(row[i] || '') + '</td>';
+        html += '</tr>';
+      });
+      html += '</tbody></table>';
+    });
+    if (content) content.innerHTML = html || '<p>No tables found.</p>';
+  }
+  function runShowAllTables(url) {
+    var panel = document.getElementById('allTablesPanel');
+    var debugEl = document.getElementById('showAllTablesDebugMulti');
+    if (debugEl) { debugEl.style.display = 'inline'; debugEl.textContent = (debugEl.textContent || '') + ' | runShowAllTables(urlLen=' + (url ? url.length : 0) + ', panel=' + (panel ? 'yes' : 'no') + ')'; }
+    if (!url) { alert('Enter a URL first.'); return; }
+    var content = document.getElementById('allTablesContent');
+    var confirmDiv = document.getElementById('allTablesConfirm');
+    if (panel) {
+      panel.style.display = 'block';
+      panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+    if (confirmDiv) confirmDiv.style.display = 'none';
+    if (content) content.innerHTML = '<p>Loading…</p>';
+    fetch('/api/preview-all-tables', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url }) })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.confirm_required && data.num_tables) {
+          allTablesPendingUrl = url;
+          var countEl = document.getElementById('allTablesCount');
+          if (countEl) countEl.textContent = data.num_tables;
+          if (content) content.innerHTML = '';
+          if (confirmDiv) confirmDiv.style.display = 'block';
+          return;
+        }
+        renderAllTables(data);
+      })
+      .catch(function() { if (content) content.innerHTML = '<div class="alert alert-error">Request failed.</div>'; });
+  }
+  document.getElementById('showAllTablesBtn')?.addEventListener('click', function() {
+    var url = document.getElementById('officeForm')?.url?.value?.trim();
+    runShowAllTables(url);
+  });
+  document.body.addEventListener('click', function(e) {
+    var btn = e.target.closest ? e.target.closest('[data-action="show-all-tables"]') : null;
+    if (!btn) return;
+    e.preventDefault();
+    var url = '';
+    if (btn.getAttribute('data-url-source') === 'page') {
+      var sectionPage = document.getElementById('section-page');
+      if (sectionPage) {
+        var inp = sectionPage.querySelector('input[type="url"]') || sectionPage.querySelector('input[name="url"]');
+        if (inp && inp.value) url = inp.value.trim();
+        if (!url && sectionPage.getAttribute('data-page-url')) url = sectionPage.getAttribute('data-page-url').trim();
+      }
+      if (!url) {
+        var pf = document.getElementById('pageForm');
+        if (pf && pf.elements && pf.elements['url'] && pf.elements['url'].value) url = String(pf.elements['url'].value).trim();
+      }
+      var debugEl = document.getElementById('showAllTablesDebugMulti');
+      if (debugEl) { debugEl.style.display = 'inline'; debugEl.textContent = 'urlLen=' + (url ? url.length : 0); }
+    } else {
+      var of = document.getElementById('officeForm');
+      if (of && of.url && of.url.value) url = of.url.value.trim();
+    }
+    runShowAllTables(url);
+  });
+  document.getElementById('allTablesConfirmLoad')?.addEventListener('click', function() {
+    if (!allTablesPendingUrl) return;
+    var content = document.getElementById('allTablesContent');
+    var confirmDiv = document.getElementById('allTablesConfirm');
+    content.innerHTML = '<p>Loading…</p>';
+    if (confirmDiv) confirmDiv.style.display = 'none';
+    fetch('/api/preview-all-tables', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: allTablesPendingUrl, confirm: true }) })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        allTablesPendingUrl = null;
+        renderAllTables(data);
+      })
+      .catch(function() { if (content) content.innerHTML = '<div class="alert alert-error">Request failed.</div>'; });
+  });
+  document.getElementById('allTablesConfirmCancel')?.addEventListener('click', function() {
+    allTablesPendingUrl = null;
+    var confirmEl = document.getElementById('allTablesConfirm');
+    var contentEl = document.getElementById('allTablesContent');
+    if (confirmEl) confirmEl.style.display = 'none';
+    if (contentEl) contentEl.innerHTML = '';
+  });
+  document.getElementById('allTablesClose')?.addEventListener('click', function() {
+    var p = document.getElementById('allTablesPanel');
+    if (p) p.style.display = 'none';
+  });
+  document.getElementById('allTablesClear')?.addEventListener('click', function() {
+    var contentEl = document.getElementById('allTablesContent');
+    var confirmEl = document.getElementById('allTablesConfirm');
+    if (contentEl) contentEl.innerHTML = '';
+    if (confirmEl) confirmEl.style.display = 'none';
+    allTablesPendingUrl = null;
+  });
 
   {% if office %}
   function getFormDraft() {
     var form = document.getElementById('officeForm');
+    var firstBlock = form && form.querySelector('.table-config-block');
+    if (firstBlock && firstBlock.querySelector('[name="tc_table_no"]')) {
+      return getFormDraftFromOfficeForm(form, firstBlock);
+    }
     var data = {
       country_id: form.country_id?.value || '',
       state_id: form.state_id?.value || '',
@@ -311,6 +648,114 @@
     };
     return data;
   }
+  function getFormDraftFromOfficeForm(officeForm, tableBlock) {
+    var pageForm = document.getElementById('pageForm');
+    var pf = pageForm || officeForm;
+    var of = officeForm;
+    var block = tableBlock || of;
+    function el(name, tcName) {
+      var b = block.querySelector && block.querySelector('[name="' + tcName + '"]');
+      if (b) return b;
+      return of[name] || block[name];
+    }
+    function elVal(name, tcName, def) {
+      var n = el(name, tcName);
+      if (!n) return def;
+      var v = n.value;
+      if (v === '' || v == null) return def;
+      return parseInt(v, 10);
+    }
+    function elChecked(name, tcName) {
+      var n = el(name, tcName);
+      return n && n.checked;
+    }
+    function dateSource() {
+      var n = el('date_source', 'tc_date_source');
+      return n ? n.value : 'not_applicable';
+    }
+    function distMode() {
+      var n = el('district_mode', 'tc_district_mode');
+      return n ? n.value : 'column';
+    }
+    return {
+      country_id: (pf.country_id && pf.country_id.value) || '',
+      state_id: (pf.state_id && pf.state_id.value) || '',
+      level_id: (pf.level_id && pf.level_id.value) || '',
+      branch_id: (pf.branch_id && pf.branch_id.value) || '',
+      department: (of.department && of.department.value) || '',
+      name: (of.name && of.name.value) || '',
+      notes: (of.notes && of.notes.value) || '',
+      url: (pf.url && pf.url.value) || '',
+      table_no: elVal('table_no', 'tc_table_no', 1),
+      table_rows: elVal('table_rows', 'tc_table_rows', 4),
+      link_column: elVal('link_column', 'tc_link_column', 1),
+      party_column: elVal('party_column', 'tc_party_column', 0),
+      term_start_column: elVal('term_start_column', 'tc_term_start_column', 4),
+      term_end_column: elChecked('term_dates_merged', 'tc_term_dates_merged') ? elVal('term_start_column', 'tc_term_start_column', 4) : elVal('term_end_column', 'tc_term_end_column', 5),
+      district_column: elVal('district_column', 'tc_district_column', 0),
+      dynamic_parse: elChecked('dynamic_parse', 'tc_dynamic_parse'),
+      read_right_to_left: elChecked('read_right_to_left', 'tc_read_right_to_left'),
+      find_date_in_infobox: dateSource() === 'find_date_in_infobox',
+      years_only: dateSource() === 'years_only',
+      parse_rowspan: elChecked('parse_rowspan', 'tc_parse_rowspan'),
+      consolidate_rowspan_terms: elChecked('consolidate_rowspan_terms', 'tc_consolidate_rowspan_terms'),
+      rep_link: elChecked('rep_link', 'tc_rep_link'),
+      party_link: elChecked('party_link', 'tc_party_link'),
+      alt_links: Array.from(of.querySelectorAll('input[name="alt_links"]')).map(function(inp) { return inp.value.trim(); }).filter(Boolean),
+      alt_link_include_main: !!(of.alt_link_include_main && of.alt_link_include_main.checked),
+      use_full_page_for_table: elChecked('use_full_page_for_table', 'tc_use_full_page_for_table'),
+      term_dates_merged: elChecked('term_dates_merged', 'tc_term_dates_merged'),
+      party_ignore: elChecked('party_ignore', 'tc_party_ignore'),
+      district_ignore: distMode() === 'no_district',
+      district_at_large: distMode() === 'at_large'
+    };
+  }
+  function syncTableBlockValidation(block) {
+    if (!block || !block.querySelector) return;
+    var mergedCb = block.querySelector('input[name="tc_term_dates_merged"]');
+    var termStartInput = block.querySelector('input[name="tc_term_start_column"]');
+    var termEndInput = block.querySelector('input[name="tc_term_end_column"]');
+    var termEndGroup = termEndInput && termEndInput.closest('.form-group');
+    if (mergedCb && termEndInput && termStartInput) {
+      if (mergedCb.checked) {
+        termEndInput.value = termStartInput.value;
+        termEndInput.disabled = true;
+        if (termEndGroup) { termEndGroup.style.opacity = '0.5'; termEndGroup.style.pointerEvents = 'none'; }
+      } else {
+        termEndInput.disabled = false;
+        if (termEndGroup) { termEndGroup.style.opacity = '1'; termEndGroup.style.pointerEvents = ''; }
+      }
+    }
+    var partyIgnoreCb = block.querySelector('input[name="tc_party_ignore"]');
+    var partyInput = block.querySelector('input[name="tc_party_column"]');
+    var partyGroup = partyInput && partyInput.closest('.form-group');
+    if (partyIgnoreCb && partyInput) {
+      if (partyIgnoreCb.checked) {
+        partyInput.value = '0';
+        partyInput.disabled = true;
+        if (partyGroup) { partyGroup.style.opacity = '0.5'; partyGroup.style.pointerEvents = 'none'; }
+      } else {
+        partyInput.disabled = false;
+        if (partyGroup) { partyGroup.style.opacity = '1'; partyGroup.style.pointerEvents = ''; }
+      }
+    }
+    var districtModeSelect = block.querySelector('select[name="tc_district_mode"]');
+    var districtInput = block.querySelector('input[name="tc_district_column"]');
+    var districtGroup = districtInput && districtInput.closest('.form-group');
+    if (districtGroup && districtInput) {
+      var useOverride = districtModeSelect && districtModeSelect.value !== 'column';
+      if (useOverride) {
+        districtInput.value = '0';
+        districtInput.disabled = true;
+        districtGroup.style.opacity = '0.5';
+        districtGroup.style.pointerEvents = 'none';
+      } else {
+        districtInput.disabled = false;
+        districtGroup.style.opacity = '1';
+        districtGroup.style.pointerEvents = '';
+      }
+    }
+  }
   (function() {
     var mergedCb = document.getElementById('termDatesMerged');
     var termEndGroup = document.getElementById('termEndColumnGroup');
@@ -338,6 +783,7 @@
     function syncPartyIgnore() {
       if (!partyIgnoreCb || !partyInput) return;
       if (partyIgnoreCb.checked) {
+        partyInput.value = '0';
         partyInput.disabled = true;
         if (partyGroup) { partyGroup.style.opacity = '0.5'; partyGroup.style.pointerEvents = 'none'; }
       } else {
@@ -356,6 +802,7 @@
       if (!districtGroup || !districtInput) return;
       var useOverride = districtModeSelect && districtModeSelect.value !== 'column';
       if (useOverride) {
+        districtInput.value = '0';
         districtInput.disabled = true;
         districtGroup.style.opacity = '0.5';
         districtGroup.style.pointerEvents = 'none';
@@ -367,6 +814,76 @@
     }
     if (districtModeSelect) districtModeSelect.addEventListener('change', syncDistrictOverride);
     syncDistrictOverride();
+  })();
+  (function() {
+    function runSyncForBlock(block) {
+      if (block && block.classList && block.classList.contains('table-config-block')) syncTableBlockValidation(block);
+    }
+    document.querySelectorAll('.table-config-block').forEach(syncTableBlockValidation);
+    document.body.addEventListener('change', function(e) {
+      var block = e.target.closest('.table-config-block');
+      if (block) runSyncForBlock(block);
+    });
+    document.body.addEventListener('input', function(e) {
+      var block = e.target.closest('.table-config-block');
+      if (block && e.target.name === 'tc_term_start_column') runSyncForBlock(block);
+    });
+  })();
+  (function() {
+    document.body.addEventListener('submit', function(e) {
+      var form = e.target && e.target.tagName === 'FORM' ? e.target : null;
+      if (form) {
+        form.querySelectorAll('input[disabled], select[disabled]').forEach(function(el) { el.disabled = false; });
+      }
+    }, true);
+  })();
+  (function() {
+    var saveAllBtn = document.getElementById('saveAllBtn');
+    var pageForm = document.getElementById('pageForm');
+    var saveAllBar = document.querySelector('.save-all-bar');
+    if (!saveAllBtn || !pageForm || !saveAllBar) return;
+    saveAllBtn.addEventListener('click', function() {
+      var statusEl = document.getElementById('saveAllStatus');
+      var pageId = saveAllBar.getAttribute('data-source-page-id');
+      var officeForms = document.querySelectorAll('.office-form');
+      function setStatus(txt) { if (statusEl) statusEl.textContent = txt; }
+      setStatus('Saving…');
+      saveAllBtn.disabled = true;
+      function formToBody(form) {
+        form.querySelectorAll('input[disabled], select[disabled]').forEach(function(el) { el.disabled = false; });
+        return new FormData(form);
+      }
+      var pageAction = pageForm.getAttribute('action') || pageForm.action;
+      if (typeof pageAction !== 'string') pageAction = '';
+      fetch(pageAction, { method: 'POST', body: formToBody(pageForm) })
+        .then(function(r) {
+          if (!r.ok && r.status !== 302) throw new Error('Page save failed');
+          var idx = 0;
+          function next() {
+            if (idx >= officeForms.length) {
+              setStatus('Saved.');
+              var firstForm = officeForms[0];
+              var firstAction = firstForm ? (firstForm.getAttribute('action') || firstForm.action) : '';
+              var firstOfficeId = typeof firstAction === 'string' ? (firstAction.match(/\/offices\/(\d+)/) || [])[1] : null;
+              if (firstOfficeId) window.location.href = '/offices/' + firstOfficeId + '?saved=1';
+              else window.location.href = '/offices?saved=1';
+              return;
+            }
+            var of = officeForms[idx++];
+            var officeAction = of.getAttribute('action') || of.action;
+            if (typeof officeAction !== 'string') officeAction = '';
+            return fetch(officeAction, { method: 'POST', body: formToBody(of) }).then(function(res) {
+              if (!res.ok && res.status !== 302) throw new Error('Office save failed');
+              return next();
+            });
+          }
+          return next();
+        })
+        .catch(function(err) {
+          setStatus('Error: ' + (err && err.message ? err.message : 'Save failed'));
+          saveAllBtn.disabled = false;
+        });
+    });
   })();
   (function() {
     var list = document.getElementById('altLinksList');
@@ -384,6 +901,79 @@
     });
     list.addEventListener('click', function(e) {
       if (e.target.classList.contains('alt-link-remove') && list.querySelectorAll('.alt-link-row').length > 1) e.target.closest('.alt-link-row').remove();
+    });
+  })();
+  (function() {
+    document.body.addEventListener('click', function(e) {
+      var form = e.target.closest('.office-form');
+      if (!form) return;
+      var container = form.querySelector('.alt-links-container');
+      if (!container) return;
+      if (e.target.classList.contains('alt-link-add')) {
+        e.preventDefault();
+        var row = document.createElement('div');
+        row.className = 'alt-link-row';
+        row.style.marginBottom = '0.25rem';
+        row.innerHTML = '<input type="text" name="alt_links" value="" placeholder="/wiki/..."> <button type="button" class="btn btn-secondary btn-sm alt-link-remove" aria-label="Remove">Remove</button>';
+        container.appendChild(row);
+      } else if (e.target.classList.contains('alt-link-remove')) {
+        if (container.querySelectorAll('.alt-link-row').length > 1) e.target.closest('.alt-link-row').remove();
+      }
+      var addTableBtnEl = (e.target && e.target.nodeType === 1 ? e.target : e.target.parentElement) && (e.target.nodeType === 1 ? e.target : e.target.parentElement).closest('.add-table-btn');
+      if (addTableBtnEl) {
+        e.preventDefault();
+        var form = e.target.closest('.office-form');
+        var container = form && form.querySelector('.table-config-blocks');
+        var firstBlock = container && container.querySelector('.table-config-block');
+        if (!container || !firstBlock) return;
+        var clone = firstBlock.cloneNode(true);
+        clone.removeAttribute('data-tc-id');
+        clone.querySelector('input[name="tc_id"]').value = '';
+        var nameInput = clone.querySelector('input[name="tc_name"]');
+        if (nameInput) nameInput.value = '';
+        clone.querySelector('input[name="tc_table_no"]').value = '1';
+        clone.querySelector('input[name="tc_table_rows"]').value = '4';
+        clone.querySelector('input[name="tc_link_column"]').value = '1';
+        clone.querySelector('input[name="tc_party_column"]').value = '0';
+        clone.querySelector('input[name="tc_term_start_column"]').value = '4';
+        clone.querySelector('input[name="tc_term_end_column"]').value = '5';
+        clone.querySelector('input[name="tc_district_column"]').value = '0';
+        clone.querySelector('input[name="tc_notes"]').value = '';
+        var deleteForm = clone.querySelector('form[action*="/table/"]');
+        if (deleteForm) deleteForm.remove();
+        var h4 = clone.querySelector('h4');
+        if (h4) h4.textContent = 'Table ' + (container.querySelectorAll('.table-config-block').length + 1);
+        clone.querySelectorAll('input[type="checkbox"]').forEach(function(cb) { cb.checked = false; });
+        clone.querySelectorAll('select').forEach(function(sel) {
+          if (sel.name === 'tc_date_source') sel.value = 'not_applicable';
+          else if (sel.name === 'tc_district_mode') sel.value = 'column';
+        });
+        container.appendChild(clone);
+        var newIdx = container.querySelectorAll('.table-config-block').length;
+        clone.id = 'section-office-' + (container.getAttribute('data-office-id') || '') + '-t-' + newIdx;
+        if (clone.querySelector('h4')) clone.querySelector('h4').textContent = 'Table ' + newIdx;
+        if (typeof syncTableBlockValidation === 'function') syncTableBlockValidation(clone);
+      }
+      if (e.target.classList.contains('remove-table-btn')) {
+        e.preventDefault();
+        var block = e.target.closest('.table-config-block');
+        var container = block && block.closest('.table-config-blocks');
+        if (block && container && container.querySelectorAll('.table-config-block').length > 1) block.remove();
+      }
+      if (e.target.classList.contains('delete-table-btn')) {
+        e.preventDefault();
+        var btn = e.target.closest('.delete-table-btn');
+        if (!btn) return;
+        var officeId = btn.getAttribute('data-office-id');
+        var tcId = btn.getAttribute('data-tc-id');
+        if (!officeId || !tcId) return;
+        if (!confirm('Delete this table config and its terms? This cannot be undone.')) return;
+        var f = document.createElement('form');
+        f.method = 'post';
+        f.action = '/offices/' + officeId + '/table/' + tcId + '/delete';
+        document.body.appendChild(f);
+        f.submit();
+      }
     });
   })();
   document.getElementById('testConfigBtn')?.addEventListener('click', function() {
@@ -406,6 +996,158 @@
         el.className = 'alert alert-error';
       });
   });
+  (function() {
+    document.body.addEventListener('click', function(e) {
+      var btn = e.target.closest('[data-action]');
+      if (!btn || !btn.closest('.office-form')) return;
+      var form = btn.closest('.office-form');
+      var block = btn.closest('.table-config-block');
+      var action = btn.getAttribute('data-action');
+      if (!action) return;
+      var draft = getFormDraftFromOfficeForm(form, block || null);
+      var el = document.getElementById('testConfigResult');
+      if (action === 'test-config') {
+        if (el) { el.style.display = 'block'; el.textContent = '…'; el.className = 'alert'; }
+        fetch('/api/offices/test-config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(draft) })
+          .then(function(r) { return r.json(); })
+          .then(function(d) {
+            if (el) { el.textContent = d.ok ? 'OK: ' + d.message : 'Error: ' + d.message; el.className = d.ok ? 'alert alert-success' : 'alert alert-error'; }
+          })
+          .catch(function() { if (el) { el.textContent = 'Request failed'; el.className = 'alert alert-error'; } });
+        return;
+      }
+      if (action === 'preview-all') { runPreview({ showAll: true, draft: draft }); return; }
+      if (action === 'preview-top-x') {
+        var raw = window.prompt('Show how many rows?', '10');
+        if (raw == null) return;
+        var num = parseInt(raw, 10);
+        if (isNaN(num) || num < 1) { alert('Please enter a number greater than 0.'); return; }
+        if (num > 2000) { num = 2000; }
+        runPreview({ maxRows: num, draft: draft });
+        return;
+      }
+      if (action === 'show-selected-table') {
+        if (!draft.url) { alert('Enter a URL first.'); return; }
+        var panel = document.getElementById('rawTablePanel');
+        var content = document.getElementById('rawTableContent');
+        if (panel) panel.style.display = 'block';
+        if (content) content.innerHTML = '<p>Loading…</p>';
+        fetch('/api/raw-table-preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: draft.url, table_no: draft.table_no || 1 }) })
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (data.error && content) { content.innerHTML = '<div class="alert alert-error">' + esc(data.error) + '</div>'; return; }
+            var rows = data.rows || [];
+            var maxCols = 0;
+            rows.forEach(function(r) { if (r.length > maxCols) maxCols = r.length; });
+            if (maxCols === 0) maxCols = 1;
+            var html = '<p><small>Table ' + esc(data.table_no) + ' of ' + esc(data.num_tables) + ' (top 10 rows).</small></p><table><thead><tr>';
+            for (var c = 1; c <= maxCols; c++) html += '<th>Column ' + c + '</th>';
+            html += '</tr></thead><tbody>';
+            rows.forEach(function(row) { html += '<tr>'; for (var i = 0; i < maxCols; i++) html += '<td>' + esc(row[i] || '') + '</td>'; html += '</tr>'; });
+            if (content) content.innerHTML = html + '</tbody></table>' || '<p>No rows.</p>';
+          })
+          .catch(function() { if (content) content.innerHTML = '<div class="alert alert-error">Request failed.</div>'; });
+        return;
+      }
+      if (action === 'show-table-html') {
+        if (!draft.url) { alert('Enter a URL first.'); return; }
+        var panel = document.getElementById('tableHtmlPanel');
+        var content = document.getElementById('tableHtmlContent');
+        if (panel) panel.style.display = 'block';
+        if (content) content.innerHTML = '<p>Loading…</p>';
+        fetch('/api/table-html', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: draft.url, table_no: draft.table_no || 1 }) })
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (content) content.innerHTML = data.error ? '<div class="alert alert-error">' + esc(data.error) + '</div>' : '<pre style="white-space:pre-wrap; word-break:break-all; max-height:30rem; overflow:auto; font-size:0.8rem; background:var(--bg2); padding:0.75rem; border-radius:4px;"><code>' + esc(data.html || '') + '</code></pre>';
+          })
+          .catch(function() { if (content) content.innerHTML = '<div class="alert alert-error">Request failed.</div>'; });
+        return;
+      }
+      if (action === 'refresh-table-cache') {
+        if (!draft.url) { alert('Enter a URL first.'); return; }
+        btn.disabled = true;
+        fetch('/api/refresh-table-cache', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: draft.url, table_no: draft.table_no || 1, use_full_page: !!draft.use_full_page_for_table }) })
+          .then(function(r) { if (!r.ok) return r.json().then(function(d) { throw new Error(d.detail || r.statusText); }); return r.json(); })
+          .then(function() { alert('Table cache updated.'); })
+          .catch(function(err) { alert('Refresh failed: ' + (err.message || 'Request failed')); })
+          .finally(function() { btn.disabled = false; });
+        return;
+      }
+      if (action === 'export-debug') {
+        var resultEl = document.getElementById('exportDebugResult');
+        var officeName = (draft.name || '').trim() || 'office';
+        var modeSelect = form.querySelector('.export-debug-mode');
+        var exportMode = (modeSelect && modeSelect.value) || 'full';
+        if (resultEl) { resultEl.style.display = 'block'; resultEl.className = 'alert'; resultEl.textContent = 'Exporting…'; }
+        if (exportMode === 'full' && draft.find_date_in_infobox) {
+          fetch('/api/office-debug-export', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ office_name: officeName, config: draft, export_mode: 'full' }) })
+            .then(function(r) { if (r.status === 202) return r.json().then(function(d) { return { async: true, job_id: d.job_id }; }); return r.json().then(function(d) { return { async: false, data: d }; }); })
+            .then(function(res) {
+              if (res.async && res.job_id) {
+                var jobId = res.job_id;
+                var poll = function() {
+                  fetch('/api/office-debug-export-status/' + jobId).then(function(r) { return r.json(); }).then(function(s) {
+                    if (resultEl) resultEl.textContent = s.message || 'Exporting…';
+                    if (s.status === 'complete') { if (resultEl) { resultEl.className = 'alert alert-success'; resultEl.textContent = 'Debug file exported successfully.'; } if (window.playJobCompleteSound) window.playJobCompleteSound(); return; }
+                    if (s.status === 'error') { if (resultEl) { resultEl.className = 'alert alert-error'; resultEl.textContent = 'Export failed: ' + (s.error || ''); } return; }
+                    setTimeout(poll, 600);
+                  });
+                };
+                poll();
+              } else { if (resultEl) { resultEl.className = 'alert alert-success'; resultEl.textContent = 'Debug file exported successfully.'; } }
+            })
+            .catch(function(err) { if (resultEl) { resultEl.className = 'alert alert-error'; resultEl.textContent = err && err.message ? err.message : 'Export failed.'; } });
+        } else {
+          fetch('/api/preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(draft) })
+            .then(function(r) { return r.json(); })
+            .then(function(previewResult) {
+              return fetch('/api/table-html', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: draft.url, table_no: draft.table_no || 1, use_full_page: !!draft.use_full_page_for_table }) }).then(function(r) { return r.json(); }).then(function(tableHtmlResult) { return { previewResult: previewResult, tableHtmlResult: tableHtmlResult }; });
+            })
+            .then(function(_) {
+              return fetch('/api/office-debug-export', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ office_name: officeName, config: draft, preview_result: _.previewResult, table_html_result: _.tableHtmlResult, export_mode: exportMode }) }).then(function(r) { return r.json(); });
+            })
+            .then(function(data) { if (resultEl) { resultEl.className = 'alert alert-success'; resultEl.textContent = 'Debug file exported successfully.'; } })
+            .catch(function(err) { if (resultEl) { resultEl.className = 'alert alert-error'; resultEl.textContent = err && err.message ? err.message : 'Export failed.'; } });
+        }
+        return;
+      }
+      if (action === 'populate-terms') {
+        var officeId = btn.getAttribute('data-office-id');
+        if (!officeId) return;
+        var resultEl = document.getElementById('testConfigResult');
+        var stopBtn = document.getElementById('populateTermsStopBtn');
+        if (resultEl) { resultEl.style.display = 'block'; resultEl.textContent = 'Starting…'; resultEl.className = 'alert'; }
+        btn.disabled = true;
+        if (stopBtn) stopBtn.style.display = 'none';
+        fetch('/api/offices/' + officeId + '/populate-terms', { method: 'POST' })
+          .then(function(r) { return r.json().then(function(d) { return { status: r.status, data: d }; }); })
+          .then(function(res) {
+            if (res.status === 202 && res.data.job_id) {
+              var jobId = res.data.job_id;
+              if (stopBtn) { stopBtn.style.display = 'inline-block'; stopBtn.disabled = false; stopBtn.onclick = function() { stopBtn.disabled = true; fetch('/api/offices/' + officeId + '/populate-terms/cancel/' + jobId, { method: 'POST' }).catch(function() {}); }; }
+              var poll = function() {
+                fetch('/api/offices/' + officeId + '/populate-terms/status/' + jobId).then(function(r) { return r.json(); }).then(function(s) {
+                  if (resultEl) resultEl.textContent = (s.message || 'Processing…') + (s.total > 0 ? ' (' + s.current + ' of ' + s.total + ')' : '');
+                  if (s.status === 'complete' || s.status === 'cancelled') {
+                    var r = s.result;
+                    if (resultEl) { resultEl.textContent = r && r.ok ? r.message : ((r && r.message) || s.error || 'Failed'); resultEl.className = (r && r.ok) ? 'alert alert-success' : 'alert alert-error'; }
+                    btn.disabled = false;
+                    if (stopBtn) stopBtn.style.display = 'none';
+                    if (window.playJobCompleteSound) window.playJobCompleteSound();
+                  }
+                  if (s.status === 'error') { if (resultEl) { resultEl.textContent = 'Error: ' + (s.error || 'Failed'); resultEl.className = 'alert alert-error'; } btn.disabled = false; if (stopBtn) stopBtn.style.display = 'none'; if (window.playJobCompleteSound) window.playJobCompleteSound(); }
+                  if (s.status !== 'complete' && s.status !== 'cancelled' && s.status !== 'error') setTimeout(poll, 800);
+                }).catch(function() { if (resultEl) resultEl.textContent = 'Request failed.'; resultEl.className = 'alert alert-error'; btn.disabled = false; if (stopBtn) stopBtn.style.display = 'none'; });
+              };
+              poll();
+            } else if (res.data.ok) { if (resultEl) { resultEl.textContent = res.data.message; resultEl.className = 'alert alert-success'; } btn.disabled = false; if (window.playJobCompleteSound) window.playJobCompleteSound(); }
+            else { if (resultEl) { resultEl.textContent = 'Error: ' + (res.data.message || 'Failed'); resultEl.className = 'alert alert-error'; } btn.disabled = false; if (window.playJobCompleteSound) window.playJobCompleteSound(); }
+          })
+          .catch(function() { if (resultEl) { resultEl.textContent = 'Request failed.'; resultEl.className = 'alert alert-error'; } btn.disabled = false; });
+        return;
+      }
+    });
+  })();
   function renderPreviewResult(result, content) {
     var rows = result.preview_rows || [];
     var raw = result.raw_table_preview;
@@ -454,7 +1196,7 @@
     panel.style.display = 'block';
     content.innerHTML = '<p>Loading preview…</p>';
     if (previewStopBtn) previewStopBtn.style.display = 'none';
-    var draft = getFormDraft();
+    var draft = (opts && opts.draft) ? opts.draft : getFormDraft();
     if (opts.showAll) {
       draft.show_all = true;
     } else if (opts.maxRows != null) {
@@ -543,99 +1285,6 @@
   });
   document.getElementById('previewClose')?.addEventListener('click', function() {
     document.getElementById('previewPanel').style.display = 'none';
-  });
-
-  var allTablesPendingUrl = null;
-  function renderAllTables(data) {
-    var content = document.getElementById('allTablesContent');
-    if (data.error) {
-      content.innerHTML = '<div class="alert alert-error">' + esc(data.error) + '</div>';
-      return;
-    }
-    var tables = data.tables || [];
-    var html = '';
-    tables.forEach(function(tbl) {
-      var rows = tbl.rows || [];
-      var maxCols = 0;
-      rows.forEach(function(r) { if (r.length > maxCols) maxCols = r.length; });
-      if (maxCols === 0) maxCols = 1;
-      html += '<h3 style="margin-top:1rem;">Table ' + tbl.table_index + '</h3>';
-      html += '<table><thead><tr>';
-      for (var c = 1; c <= maxCols; c++) html += '<th>Column ' + c + '</th>';
-      html += '</tr></thead><tbody>';
-      rows.forEach(function(row) {
-        html += '<tr>';
-        for (var i = 0; i < maxCols; i++) html += '<td>' + esc(row[i] || '') + '</td>';
-        html += '</tr>';
-      });
-      html += '</tbody></table>';
-    });
-    content.innerHTML = html || '<p>No tables found.</p>';
-  }
-  document.getElementById('showAllTablesBtn')?.addEventListener('click', function() {
-    var url = document.getElementById('officeForm')?.url?.value?.trim();
-    if (!url) {
-      alert('Enter a URL first.');
-      return;
-    }
-    var panel = document.getElementById('allTablesPanel');
-    var content = document.getElementById('allTablesContent');
-    var confirmDiv = document.getElementById('allTablesConfirm');
-    panel.style.display = 'block';
-    confirmDiv.style.display = 'none';
-    content.innerHTML = '<p>Loading…</p>';
-    fetch('/api/preview-all-tables', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url: url })
-    })
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        if (data.confirm_required && data.num_tables) {
-          allTablesPendingUrl = url;
-          document.getElementById('allTablesCount').textContent = data.num_tables;
-          content.innerHTML = '';
-          confirmDiv.style.display = 'block';
-          return;
-        }
-        renderAllTables(data);
-      })
-      .catch(function() {
-        content.innerHTML = '<div class="alert alert-error">Request failed.</div>';
-      });
-  });
-  document.getElementById('allTablesConfirmLoad')?.addEventListener('click', function() {
-    if (!allTablesPendingUrl) return;
-    var content = document.getElementById('allTablesContent');
-    var confirmDiv = document.getElementById('allTablesConfirm');
-    content.innerHTML = '<p>Loading…</p>';
-    confirmDiv.style.display = 'none';
-    fetch('/api/preview-all-tables', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url: allTablesPendingUrl, confirm: true })
-    })
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        allTablesPendingUrl = null;
-        renderAllTables(data);
-      })
-      .catch(function() {
-        content.innerHTML = '<div class="alert alert-error">Request failed.</div>';
-      });
-  });
-  document.getElementById('allTablesConfirmCancel')?.addEventListener('click', function() {
-    allTablesPendingUrl = null;
-    document.getElementById('allTablesConfirm').style.display = 'none';
-    document.getElementById('allTablesContent').innerHTML = '';
-  });
-  document.getElementById('allTablesClose')?.addEventListener('click', function() {
-    document.getElementById('allTablesPanel').style.display = 'none';
-  });
-  document.getElementById('allTablesClear')?.addEventListener('click', function() {
-    document.getElementById('allTablesContent').innerHTML = '';
-    document.getElementById('allTablesConfirm').style.display = 'none';
-    allTablesPendingUrl = null;
   });
 
   document.getElementById('showSelectedTableBtn')?.addEventListener('click', function() {


### PR DESCRIPTION
…cators

- Add name column to office_table_config (schema + migration) for display in outline
- Outline shows Page -> Office -> Table hierarchy; each table shows table name (fallback: Table N)
- Show enabled state in outline: green check when enabled, red X when disabled (page, office, table)
- Add Table name input to each table config block; persist via form and backend
- Add section ids for table blocks for outline deep-links; set id on cloned blocks when adding table