### PR TITLE
Office config JSON export: full export on /offices, pretty-print

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -33,7 +33,8 @@ def get_connection(path: Path | None = None) -> sqlite3.Connection:
     """Return a connection to the database, creating it and schema if needed."""
     ensure_data_dir()
     db_path = path or DB_PATH
-    conn = sqlite3.connect(str(db_path))
+    # Timeout (seconds) so we don't hang forever if the DB is locked by another process
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -490,6 +490,85 @@ def update_page(source_page_id: int, data: dict[str, Any], conn: sqlite3.Connect
             conn.close()
 
 
+def get_page_export(source_page_id: int, conn: sqlite3.Connection | None = None) -> dict[str, Any] | None:
+    """Return full hierarchy for export: page (all source_pages cols), offices (each with office_details, alt_links, tables).
+    Uses SELECT * so any new columns are included. Returns None if not hierarchy or page not found."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not _use_hierarchy(conn):
+            return None
+        row = conn.execute("SELECT * FROM source_pages WHERE id = ?", (source_page_id,)).fetchone()
+        if not row:
+            return None
+        page_dict = _row_to_dict(row)
+        offices_list: list[dict[str, Any]] = []
+        for od_row in conn.execute(
+            "SELECT * FROM office_details WHERE source_page_id = ? ORDER BY id", (source_page_id,)
+        ).fetchall():
+            od_dict = _row_to_dict(od_row)
+            od_id = od_dict.get("id")
+            alt_links_rows: list[dict[str, Any]] = []
+            try:
+                for al_row in conn.execute(
+                    "SELECT * FROM alt_links WHERE office_details_id = ? ORDER BY id", (od_id,)
+                ).fetchall():
+                    alt_links_rows.append(_row_to_dict(al_row))
+            except sqlite3.OperationalError:
+                pass
+            tables_rows: list[dict[str, Any]] = []
+            for tc_row in conn.execute(
+                "SELECT * FROM office_table_config WHERE office_details_id = ? ORDER BY table_no, id", (od_id,)
+            ).fetchall():
+                tables_rows.append(_row_to_dict(tc_row))
+            offices_list.append({"office": od_dict, "alt_links": alt_links_rows, "tables": tables_rows})
+        return {"page": page_dict, "offices": offices_list}
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def get_full_export(conn: sqlite3.Connection | None = None) -> dict[str, Any]:
+    """Return full hierarchy for all pages: pages (each with page row, offices with alt_links and tables).
+    Uses SELECT * so any new columns are included. Returns {\"pages\": []} when not hierarchy."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not _use_hierarchy(conn):
+            return {"pages": []}
+        pages_list: list[dict[str, Any]] = []
+        for page_row in conn.execute("SELECT * FROM source_pages ORDER BY id").fetchall():
+            page_dict = _row_to_dict(page_row)
+            source_page_id = page_dict.get("id")
+            offices_list: list[dict[str, Any]] = []
+            for od_row in conn.execute(
+                "SELECT * FROM office_details WHERE source_page_id = ? ORDER BY id", (source_page_id,)
+            ).fetchall():
+                od_dict = _row_to_dict(od_row)
+                od_id = od_dict.get("id")
+                alt_links_rows: list[dict[str, Any]] = []
+                try:
+                    for al_row in conn.execute(
+                        "SELECT * FROM alt_links WHERE office_details_id = ? ORDER BY id", (od_id,)
+                    ).fetchall():
+                        alt_links_rows.append(_row_to_dict(al_row))
+                except sqlite3.OperationalError:
+                    pass
+                tables_rows: list[dict[str, Any]] = []
+                for tc_row in conn.execute(
+                    "SELECT * FROM office_table_config WHERE office_details_id = ? ORDER BY table_no, id", (od_id,)
+                ).fetchall():
+                    tables_rows.append(_row_to_dict(tc_row))
+                offices_list.append({"office": od_dict, "alt_links": alt_links_rows, "tables": tables_rows})
+            pages_list.append({"page": page_dict, "offices": offices_list})
+        return {"pages": pages_list}
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def list_offices_for_page(source_page_id: int, conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
     """Return all offices (flat) for a given source_page_id. Empty if not using hierarchy or page not found."""
     own_conn = conn is None

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ Run: uvicorn src.main:app --reload
 From project root: office_holder/
 """
 
+import json
 import re
 import tempfile
 from datetime import datetime
@@ -19,7 +20,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from fastapi import FastAPI, File, Request, Form, HTTPException, Query, UploadFile
-from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -109,7 +110,12 @@ def _office_draft_from_body(body: dict, *, include_ref_names: bool = False) -> d
 
 @app.on_event("startup")
 def startup():
-    init_db()
+    try:
+        init_db()
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        raise RuntimeError(f"Database startup failed: {e}") from e
 
 
 # ---------- Office config CRUD ----------
@@ -298,6 +304,30 @@ async def page_update(request: Request, source_page_id: int):
         return RedirectResponse(f"{base}?error=" + quote(str(e)), status_code=302)
     first_office_id = db_offices.list_offices_for_page(source_page_id)[0]["id"]
     return RedirectResponse(f"/offices/{first_office_id}?saved=1#section-page", status_code=302)
+
+
+@app.get("/api/export-config")
+async def api_export_config():
+    """Return full hierarchy for all pages (each page with offices, alt_links, tables) as JSON download."""
+    data = db_offices.get_full_export()
+    return Response(
+        content=json.dumps(data, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": 'attachment; filename="office-config-export.json"'},
+    )
+
+
+@app.get("/api/pages/{source_page_id}/export-config")
+async def api_page_export_config(source_page_id: int):
+    """Return full page hierarchy (page, offices with alt_links and tables) for one page as JSON download."""
+    data = db_offices.get_page_export(source_page_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Page not found or hierarchy not in use")
+    return Response(
+        content=json.dumps(data, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="page-{source_page_id}-config.json"'},
+    )
 
 
 @app.get("/offices/{office_id}", response_class=HTMLResponse)

--- a/src/templates/offices.html
+++ b/src/templates/offices.html
@@ -8,6 +8,7 @@
 <div class="actions">
   <a href="/offices/new" class="btn">Add office</a>
   <a href="/offices/import" class="btn btn-secondary">Bulk import CSV</a>
+  <a href="/api/export-config" download="office-config-export.json" class="btn btn-secondary">Export all config (JSON)</a>
   <button type="button" class="btn btn-secondary" id="toggleAllOn">Toggle all on</button>
   <button type="button" class="btn btn-secondary" id="toggleAllOff">Toggle all off</button>
   <button type="button" class="btn btn-secondary" id="testAll">Test all configs</button>


### PR DESCRIPTION
- Add get_page_export() and get_full_export() in offices.py (SELECT * for all four tables)
- GET /api/export-config returns all pages/offices/tables as JSON download
- GET /api/pages/{id}/export-config for single-page export
- Export all config (JSON) button on /offices list; pretty-printed JSON (indent=2)
- connection.py: SQLite timeout 10s and main.py startup error handling (from earlier fix)