### PR TITLE
Milestone report: nav tab and three tables (last 90 days)

### DIFF
--- a/src/db/reports.py
+++ b/src/db/reports.py
@@ -1,0 +1,108 @@
+"""Report queries: recent deaths, recent term ends, recent term starts (last 90 days)."""
+
+import sqlite3
+from typing import Any
+
+from .connection import get_connection
+from .office_terms import _has_hierarchy_terms
+from .utils import _row_to_dict
+
+
+def get_recent_deaths(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    """Individuals with death_date in the last 90 days. Returns list of dicts (full_name, birth_date, death_date)."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cur = conn.execute(
+            """SELECT full_name, birth_date, death_date
+               FROM individuals
+               WHERE death_date BETWEEN date('now', '-90 days') AND date('now')
+               ORDER BY death_date DESC"""
+        )
+        return [_row_to_dict(r) for r in cur.fetchall()]
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def _term_report_query(
+    conn: sqlite3.Connection,
+    date_column: str,
+    order_column: str,
+) -> list[dict[str, Any]]:
+    """Shared logic: term report filtered by date_column (term_start or term_end), ordered by order_column."""
+    if _has_hierarchy_terms(conn):
+        cur = conn.execute(
+            f"""
+            SELECT
+              i.full_name AS "Name",
+              c.name AS "Country Name",
+              s.name AS "State Name",
+              l.name AS "Level",
+              b.name AS "Branch",
+              od.name AS "Office Name",
+              ot.district AS "Congressional District",
+              ot.term_start AS "Term Start",
+              ot.term_end AS "Term End"
+            FROM office_terms ot
+            LEFT JOIN individuals i ON i.id = ot.individual_id
+            LEFT JOIN office_details od ON od.id = ot.office_details_id
+            LEFT JOIN source_pages sp ON sp.id = od.source_page_id
+            LEFT JOIN countries c ON c.id = sp.country_id
+            LEFT JOIN states s ON s.id = sp.state_id
+            LEFT JOIN levels l ON l.id = sp.level_id
+            LEFT JOIN branches b ON b.id = sp.branch_id
+            WHERE ot.{date_column} BETWEEN date('now', '-90 days') AND date('now')
+            ORDER BY ot.{order_column} DESC
+            """
+        )
+    else:
+        cur = conn.execute(
+            f"""
+            SELECT
+              i.full_name AS "Name",
+              c.name AS "Country Name",
+              s.name AS "State Name",
+              l.name AS "Level",
+              b.name AS "Branch",
+              o.name AS "Office Name",
+              ot.district AS "Congressional District",
+              ot.term_start AS "Term Start",
+              ot.term_end AS "Term End"
+            FROM office_terms ot
+            LEFT JOIN individuals i ON i.id = ot.individual_id
+            LEFT JOIN offices o ON o.id = ot.office_id
+            LEFT JOIN countries c ON c.id = o.country_id
+            LEFT JOIN states s ON s.id = o.state_id
+            LEFT JOIN levels l ON l.id = o.level_id
+            LEFT JOIN branches b ON b.id = o.branch_id
+            WHERE ot.{date_column} BETWEEN date('now', '-90 days') AND date('now')
+            ORDER BY ot.{order_column} DESC
+            """
+        )
+    return [_row_to_dict(r) for r in cur.fetchall()]
+
+
+def get_recent_term_ends(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    """Office terms with term_end in the last 90 days. Returns list of dicts with Name, Country Name, etc."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        return _term_report_query(conn, "term_end", "term_end")
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def get_recent_term_starts(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    """Office terms with term_start in the last 90 days. Returns list of dicts with Name, Country Name, etc."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        return _term_report_query(conn, "term_start", "term_start")
+    finally:
+        if own_conn:
+            conn.close()

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,7 @@ from src.db import parties as db_parties
 from src.db import refs as db_refs
 from src.db import individuals as db_individuals
 from src.db import office_terms as db_office_terms
+from src.db import reports as db_reports
 from src.db.bulk_import import bulk_import_offices_from_csv, bulk_import_parties_from_csv
 from src.scraper.runner import run_with_db, preview_with_config, parse_full_table_for_export
 from src.scraper.config_test import test_office_config, get_raw_table_preview, get_all_tables_preview, get_table_html, get_table_header_from_html
@@ -1023,6 +1024,22 @@ async def data_office_terms(request: Request, limit: int = Query(100, le=500), o
     terms = db_office_terms.list_office_terms(limit=limit, offset=offset, office_id=office_id)
     offices = db_offices.list_offices()
     return templates.TemplateResponse("office_terms.html", {"request": request, "terms": terms, "offices": offices})
+
+
+@app.get("/report/milestones", response_class=HTMLResponse)
+async def report_milestones(request: Request):
+    recent_deaths = db_reports.get_recent_deaths()
+    recent_term_ends = db_reports.get_recent_term_ends()
+    recent_term_starts = db_reports.get_recent_term_starts()
+    return templates.TemplateResponse(
+        "milestone_report.html",
+        {
+            "request": request,
+            "recent_deaths": recent_deaths,
+            "recent_term_ends": recent_term_ends,
+            "recent_term_starts": recent_term_starts,
+        },
+    )
 
 
 # ---------- Preview (single office) ----------

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -38,6 +38,7 @@
       <li><a href="/run">Run</a></li>
       <li><a href="/data/individuals">Individuals</a></li>
       <li><a href="/data/office-terms">Office terms</a></li>
+      <li><a href="/report/milestones">Milestone report</a></li>
     </ul>
   </nav>
   <main class="container">

--- a/src/templates/milestone_report.html
+++ b/src/templates/milestone_report.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block title %}Milestone report – Office Holder{% endblock %}
+{% block content %}
+<h1>Milestone report</h1>
+<p><small>Last 90 days.</small></p>
+
+<h2>Recent deaths</h2>
+{% if recent_deaths %}
+<table>
+  <thead>
+    <tr><th>Full name</th><th>Birth date</th><th>Death date</th></tr>
+  </thead>
+  <tbody>
+    {% for row in recent_deaths %}
+    <tr>
+      <td>{{ row.full_name or '—' }}</td>
+      <td>{{ row.birth_date or '—' }}</td>
+      <td>{{ row.death_date or '—' }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No deaths in the last 90 days.</p>
+{% endif %}
+
+<h2>Recent term ends</h2>
+{% if recent_term_ends %}
+<table>
+  <thead>
+    <tr>
+      <th>Name</th><th>Country Name</th><th>State Name</th><th>Level</th><th>Branch</th>
+      <th>Office Name</th><th>Congressional District</th><th>Term Start</th><th>Term End</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in recent_term_ends %}
+    <tr>
+      <td>{{ row['Name'] or '—' }}</td>
+      <td>{{ row['Country Name'] or '—' }}</td>
+      <td>{{ row['State Name'] or '—' }}</td>
+      <td>{{ row['Level'] or '—' }}</td>
+      <td>{{ row['Branch'] or '—' }}</td>
+      <td>{{ row['Office Name'] or '—' }}</td>
+      <td>{{ row['Congressional District'] or '—' }}</td>
+      <td>{{ row['Term Start'] or '—' }}</td>
+      <td>{{ row['Term End'] or '—' }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No term ends in the last 90 days.</p>
+{% endif %}
+
+<h2>Started term recently</h2>
+{% if recent_term_starts %}
+<table>
+  <thead>
+    <tr>
+      <th>Name</th><th>Country Name</th><th>State Name</th><th>Level</th><th>Branch</th>
+      <th>Office Name</th><th>Congressional District</th><th>Term Start</th><th>Term End</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in recent_term_starts %}
+    <tr>
+      <td>{{ row['Name'] or '—' }}</td>
+      <td>{{ row['Country Name'] or '—' }}</td>
+      <td>{{ row['State Name'] or '—' }}</td>
+      <td>{{ row['Level'] or '—' }}</td>
+      <td>{{ row['Branch'] or '—' }}</td>
+      <td>{{ row['Office Name'] or '—' }}</td>
+      <td>{{ row['Congressional District'] or '—' }}</td>
+      <td>{{ row['Term Start'] or '—' }}</td>
+      <td>{{ row['Term End'] or '—' }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No term starts in the last 90 days.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
- Add Milestone report nav link to /report/milestones
- New reports.py: get_recent_deaths, get_recent_term_ends, get_recent_term_starts (hierarchy + legacy)
- GET /report/milestones page with three tables: Recent deaths, Recent term ends, Started term recently
- milestone_report.html template with empty states