### PR TITLE
feat: move table to another office on same page

### DIFF
--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -1145,6 +1145,63 @@ def delete_table(office_table_config_id: int, conn: sqlite3.Connection | None = 
             conn.close()
 
 
+def move_table(
+    tc_id: int,
+    to_office_details_id: int,
+    delete_source_office_if_empty: bool = False,
+    conn: sqlite3.Connection | None = None,
+) -> int:
+    """Move a table config to another office on the same page. Returns to_office_details_id on success.
+    If source office has only one table and delete_source_office_if_empty is False, raises ValueError
+    with message 'OFFICE_WOULD_BE_EMPTY:Office Name' so the route can return 409."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not _use_hierarchy(conn):
+            raise ValueError("Hierarchy required")
+        row = conn.execute(
+            "SELECT office_details_id FROM office_table_config WHERE id = ?", (tc_id,)
+        ).fetchone()
+        if not row:
+            raise ValueError("Table config not found")
+        source_od_id = row[0]
+        if source_od_id == to_office_details_id:
+            raise ValueError("Table is already in that office")
+        src_page = conn.execute(
+            "SELECT source_page_id FROM office_details WHERE id = ?", (source_od_id,)
+        ).fetchone()
+        tgt_page = conn.execute(
+            "SELECT source_page_id FROM office_details WHERE id = ?", (to_office_details_id,)
+        ).fetchone()
+        if not src_page or not tgt_page or src_page[0] != tgt_page[0]:
+            raise ValueError("Source and target office must be on the same page")
+        count = conn.execute(
+            "SELECT COUNT(*) FROM office_table_config WHERE office_details_id = ?", (source_od_id,)
+        ).fetchone()[0]
+        if count == 1 and not delete_source_office_if_empty:
+            name_row = conn.execute(
+                "SELECT name FROM office_details WHERE id = ?", (source_od_id,)
+            ).fetchone()
+            source_name = (name_row[0] or "Office").strip() if name_row else "Office"
+            raise ValueError(f"OFFICE_WOULD_BE_EMPTY:{source_name}")
+        next_no = conn.execute(
+            "SELECT COALESCE(MAX(table_no), 0) + 1 FROM office_table_config WHERE office_details_id = ?",
+            (to_office_details_id,),
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE office_table_config SET office_details_id = ?, table_no = ?, updated_at = datetime('now') WHERE id = ?",
+            (to_office_details_id, next_no, tc_id),
+        )
+        conn.commit()
+        if count == 1 and delete_source_office_if_empty:
+            delete_office(source_od_id, conn=conn)
+        return to_office_details_id
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def delete_page(source_page_id: int, conn: sqlite3.Connection | None = None) -> bool:
     """Delete page and all its offices (each office's table configs, alt_links, office_terms, then office_details, then source_pages row)."""
     own_conn = conn is None

--- a/src/main.py
+++ b/src/main.py
@@ -495,6 +495,30 @@ async def table_delete(office_id: int, tc_id: int):
     return RedirectResponse(f"/offices/{office_id}?saved=1", status_code=302)
 
 
+@app.post("/offices/{office_id}/table/{tc_id}/move")
+async def table_move(
+    office_id: int,
+    tc_id: int,
+    to_office_id: int = Form(...),
+    delete_source_office_if_empty: str = Form(""),
+):
+    """Move a table config to another office on the same page. Returns 409 with requires_confirm if source would be empty; client may resubmit with delete_source_office_if_empty=1."""
+    delete_flag = str(delete_source_office_if_empty).strip().lower() in ("1", "true", "yes")
+    try:
+        db_offices.move_table(tc_id, to_office_id, delete_source_office_if_empty=delete_flag)
+    except ValueError as e:
+        msg = str(e)
+        if msg.startswith("OFFICE_WOULD_BE_EMPTY:"):
+            source_name = msg.split(":", 1)[-1].strip() or "Office"
+            return JSONResponse(
+                {"requires_confirm": True, "source_office_name": source_name},
+                status_code=409,
+            )
+        return JSONResponse({"error": msg}, status_code=400)
+    redirect_url = f"/offices/{to_office_id}?saved=1"
+    return JSONResponse({"redirect": redirect_url})
+
+
 @app.post("/offices/{office_id}/duplicate")
 async def office_duplicate(office_id: int):
     """Create a copy of the office (same config, new name) and redirect to the new office's edit page."""

--- a/src/templates/page_form.html
+++ b/src/templates/page_form.html
@@ -130,7 +130,7 @@
       {% set tclist = o.table_configs if o.table_configs and o.table_configs|length > 0 else [{'id': none, 'name': '', 'table_no': o.table_no or 1, 'table_rows': o.table_rows or 4, 'link_column': o.link_column or 1, 'party_column': o.party_column or 0, 'term_start_column': o.term_start_column or 4, 'term_end_column': o.term_end_column or 5, 'district_column': o.district_column or 0, 'dynamic_parse': o.dynamic_parse, 'read_right_to_left': o.read_right_to_left, 'find_date_in_infobox': o.find_date_in_infobox, 'years_only': o.years_only, 'parse_rowspan': o.parse_rowspan, 'consolidate_rowspan_terms': o.consolidate_rowspan_terms, 'rep_link': o.rep_link, 'party_link': o.party_link, 'enabled': o.enabled, 'use_full_page_for_table': o.use_full_page_for_table, 'term_dates_merged': o.term_dates_merged, 'party_ignore': o.party_ignore, 'district_ignore': o.district_ignore, 'district_at_large': o.district_at_large, 'notes': o.notes or ''}] %}
       <div class="table-config-blocks" data-office-id="{{ o.id }}">
       {% for tc in tclist %}
-      <div class="table-config-block" id="section-table-{{ tc.id if tc.id else (o.id ~ '-t' ~ loop.index) }}" data-tc-id="{{ tc.id or '' }}" style="margin-bottom:1.5rem; padding:1rem; border:1px solid var(--border, #ccc); border-radius:6px;">
+      <div class="table-config-block" id="section-table-{{ tc.id if tc.id else (o.id ~ '-t' ~ loop.index) }}" data-office-id="{{ o.id }}" data-tc-id="{{ tc.id or '' }}" style="margin-bottom:1.5rem; padding:1rem; border:1px solid var(--border, #ccc); border-radius:6px;">
         <input type="hidden" name="tc_id" value="{{ tc.id or '' }}">
         <h4 style="margin-top:0;">Table {{ loop.index }}</h4>
         <div class="form-row">
@@ -180,6 +180,17 @@
           <button type="button" class="btn btn-secondary btn-sm remove-table-btn">Remove table</button>
           {% if tc.id %}
           <button type="button" class="btn btn-danger btn-sm delete-table-btn" data-office-id="{{ o.id }}" data-tc-id="{{ tc.id }}">Delete table</button>
+          {% if source_page_id is not none and page_data and offices_on_page and offices_on_page|length > 1 %}
+          <select class="form-select form-select-sm move-table-select" style="width:auto; display:inline-block;" aria-label="Move to office">
+            <option value="">Move to office…</option>
+            {% for other_o in offices_on_page %}
+            {% if other_o.id != o.id %}
+            <option value="{{ other_o.id }}">{{ other_o.name or 'Office' }}</option>
+            {% endif %}
+            {% endfor %}
+          </select>
+          <button type="button" class="btn btn-secondary btn-sm move-table-btn">Move table</button>
+          {% endif %}
           {% endif %}
           <button type="button" class="btn btn-secondary btn-sm" data-action="test-config">Test config</button>
           <button type="button" class="btn btn-secondary btn-sm" data-action="preview-all">Preview all</button>
@@ -973,6 +984,53 @@
         f.action = '/offices/' + officeId + '/table/' + tcId + '/delete';
         document.body.appendChild(f);
         f.submit();
+      }
+      if (e.target.classList.contains('move-table-btn')) {
+        e.preventDefault();
+        var block = e.target.closest('.table-config-block');
+        if (!block) return;
+        var officeId = block.getAttribute('data-office-id');
+        var tcId = block.getAttribute('data-tc-id');
+        var select = block.querySelector('.move-table-select');
+        var toOfficeId = select ? select.value : '';
+        if (!officeId || !tcId || !toOfficeId) {
+          alert('Please select an office to move the table to.');
+          return;
+        }
+        function doMove(deleteSourceIfEmpty) {
+          var body = new URLSearchParams();
+          body.append('to_office_id', toOfficeId);
+          body.append('delete_source_office_if_empty', deleteSourceIfEmpty ? '1' : '');
+          fetch('/offices/' + officeId + '/table/' + tcId + '/move', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString()
+          }).then(function(r) {
+            if (r.status === 409) {
+              return r.json().then(function(d) {
+                if (d.requires_confirm && d.source_office_name) {
+                  if (confirm('This is the only table in ' + d.source_office_name + '. Moving it will leave that office with no tables. Do you want to move the table and delete that office?')) {
+                    doMove(true);
+                  }
+                } else {
+                  alert('Move failed.');
+                }
+              });
+            }
+            if (r.ok) {
+              return r.json().then(function(d) {
+                if (d.redirect) window.location = d.redirect;
+                else alert('Move failed.');
+              });
+            }
+            return r.text().then(function(t) {
+              var err = t;
+              try { var j = JSON.parse(t); if (j.error) err = j.error; } catch (_) {}
+              alert(err || 'Move failed.');
+            });
+          }).catch(function() { alert('Move failed.'); });
+        }
+        doMove(false);
       }
     });
   })();


### PR DESCRIPTION
- Add move_table() in offices.py with same-page validation, sole-table 409 error, table_no assignment, optional delete_office
- Add POST /offices/{office_id}/table/{tc_id}/move; 409 requires_confirm + source_office_name; success returns JSON redirect
- Add Move to office dropdown and button in page_form (multi-office, tc.id, multiple offices); JS fetch, 409 confirm, resubmit with delete flag