### PR TITLE
Fix office form validation failures and save feedback

### DIFF
--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -176,22 +176,33 @@ def validate_office_table_config(
     if term_start_column < 1 or term_end_column < 1:
         raise ValueError("term start and term end columns must be at least 1")
 
-    # Build set of column numbers that must be pairwise distinct (only positive values count).
+    # Build list of (value, field_name) for columns that must be pairwise distinct (only positive values count).
     # When term_dates_merged, only one "term" column counts for distinctness.
-    if term_dates_merged:
-        used = [link_column, term_start_column]
-    else:
-        used = [link_column, term_start_column, term_end_column]
+    entries: list[tuple[int, str]] = []
+    entries.append((link_column, "Link column"))
+    entries.append((term_start_column, "Term start column"))
+    if not term_dates_merged:
+        entries.append((term_end_column, "Term end column"))
     if not party_ignore:
-        used.append(party_column)
+        entries.append((party_column, "Party column"))
     if not district_ignore and not district_at_large:
-        used.append(district_column)
-    # Require all positive values to be distinct
-    positive = [c for c in used if c > 0]
-    if len(positive) != len(set(positive)):
+        entries.append((district_column, "District column"))
+    positive_entries = [(v, n) for v, n in entries if v > 0]
+    values = [v for v, _ in positive_entries]
+    if len(values) != len(set(values)):
+        if not term_dates_merged and term_start_column == term_end_column and term_start_column > 0:
+            raise ValueError(
+                "Term start column and term end column must be different, or check 'Term dates merged'."
+            )
+        # Find which value is duplicated and which field names use it
+        seen: dict[int, list[str]] = {}
+        for v, n in positive_entries:
+            seen.setdefault(v, []).append(n)
+        dup_val = next(v for v, names in seen.items() if len(names) > 1)
+        names_using = seen[dup_val]
         raise ValueError(
-            "link, party, term start, term end, and district columns must all be different "
-            "(when term dates merged, term start and end may be the same)"
+            f"Duplicate column number: {dup_val}. "
+            f"{' and '.join(names_using)} both use {dup_val}. Each must use a different column number."
         )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -408,10 +408,22 @@ async def api_page_enabled(source_page_id: int, enabled: int = Form(1)):
     return JSONResponse({"ok": True})
 
 
+def _page_redirect_query(nav_q: str, list_return_q: str) -> str:
+    parts = []
+    if nav_q:
+        parts.append("nav_ids=" + nav_q)
+    if list_return_q:
+        parts.append(list_return_q)
+    return "&".join(parts)
+
+
 @app.post("/pages/{source_page_id}")
 async def page_update(request: Request, source_page_id: int):
     """Update only the page (URL, location). Used when editing one page with multiple offices."""
     form = await request.form()
+    save_all = request.headers.get("X-Save-All") == "1"
+    nav_q = (form.get("nav_ids") or "").strip()
+    list_return_q = (form.get("list_return_query") or "").strip()
     page_data = {
         "url": (form.get("url") or "").strip(),
         "country_id": int(form.get("country_id") or 0),
@@ -428,23 +440,20 @@ async def page_update(request: Request, source_page_id: int):
         from urllib.parse import quote
         offices_on_page = db_offices.list_offices_for_page(source_page_id)
         base = f"/offices/{offices_on_page[0]['id']}" if offices_on_page else "/offices"
-        nav_q = (form.get("nav_ids") or "").strip()
-        list_return_q = (form.get("list_return_query") or "").strip()
         q = "?error=" + quote(str(e))
-        if nav_q:
-            q += "&nav_ids=" + nav_q
-        if list_return_q:
-            q += "&" + list_return_q
-        return RedirectResponse(f"{base}{q}", status_code=302)
+        if nav_q or list_return_q:
+            q += "&" + _page_redirect_query(nav_q, list_return_q)
+        redirect_url = f"{base}{q}"
+        if save_all:
+            return JSONResponse({"ok": False, "error": str(e), "redirect": redirect_url})
+        return RedirectResponse(redirect_url, status_code=302)
     first_office_id = db_offices.list_offices_for_page(source_page_id)[0]["id"]
-    nav_q = (form.get("nav_ids") or "").strip()
-    list_return_q = (form.get("list_return_query") or "").strip()
     url = f"/offices/{first_office_id}?saved=1"
-    if nav_q:
-        url += "&nav_ids=" + nav_q
-    if list_return_q:
-        url += "&" + list_return_q
+    if nav_q or list_return_q:
+        url += "&" + _page_redirect_query(nav_q, list_return_q)
     url += "#section-page"
+    if save_all:
+        return JSONResponse({"ok": True, "redirect": url})
     return RedirectResponse(url, status_code=302)
 
 
@@ -520,6 +529,7 @@ async def office_edit_page(request: Request, office_id: int):
     return templates.TemplateResponse(
         "page_form.html",
         {"request": request, "office": office, "offices_on_page": offices_on_page, "source_page_id": source_page_id, "page_data": page_data, "countries": countries, "levels": levels, "branches": branches, "states": states, "nav_ids": nav_ids_raw, "nav_prev_id": nav_prev_id, "nav_next_id": nav_next_id, "nav_current": nav_current, "nav_total": nav_total, "list_return_query": list_return_query, "terms_count": terms_count, "saved": saved, "validation_error": validation_error, "form_template": "page_form"},
+        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 
 
@@ -549,6 +559,9 @@ def _form_to_table_config(form, i: int) -> dict:
             tc_id = None
     else:
         tc_id = None
+    enabled_key = "tc_enabled_" + str(tc_id) if tc_id is not None else "tc_enabled_new_" + str(i)
+    enabled_val = form.get(enabled_key)
+    enabled = enabled_val == "1" if enabled_val is not None else (_bool("enabled", "tc_enabled") if i == 0 else False)
     date_src = _get("date_source", "tc_date_source") or ""
     dist_mode = _get("district_mode", "tc_district_mode") or "column"
     return {
@@ -568,7 +581,7 @@ def _form_to_table_config(form, i: int) -> dict:
         "consolidate_rowspan_terms": _bool("consolidate_rowspan_terms", "tc_consolidate_rowspan_terms"),
         "rep_link": _bool("rep_link", "tc_rep_link"),
         "party_link": _bool("party_link", "tc_party_link"),
-        "enabled": _bool("enabled", "tc_enabled") if _get("tc_enabled", "tc_enabled") is not None else True,
+        "enabled": enabled,
         "use_full_page_for_table": _bool("use_full_page_for_table", "tc_use_full_page_for_table"),
         "term_dates_merged": _bool("term_dates_merged", "tc_term_dates_merged"),
         "party_ignore": _bool("party_ignore", "tc_party_ignore"),
@@ -616,6 +629,7 @@ async def office_update(request: Request, office_id: int):
     if tc_table_nos or tc_ids:
         n = max(len(tc_ids), len(tc_table_nos), 1)
         data["table_configs"] = [_form_to_table_config(form, i) for i in range(n)]
+    save_all = request.headers.get("X-Save-All") == "1"
     try:
         db_offices.update_office(office_id, data, office_only=office_only)
     except ValueError as e:
@@ -625,7 +639,10 @@ async def office_update(request: Request, office_id: int):
             q += "&nav_ids=" + nav_ids
         if list_return_query:
             q += "&" + list_return_query
-        return RedirectResponse(f"/offices/{office_id}{q}", status_code=302)
+        redirect_url = f"/offices/{office_id}{q}"
+        if save_all:
+            return JSONResponse({"ok": False, "error": str(e), "redirect": redirect_url})
+        return RedirectResponse(redirect_url, status_code=302)
     if action == "save":
         q = "?saved=1"
         if nav_ids:
@@ -633,10 +650,15 @@ async def office_update(request: Request, office_id: int):
         if list_return_query:
             q += "&" + list_return_query
         hash_frag = "#section-office-" + str(office_id) if office_only else ""
-        return RedirectResponse(f"/offices/{office_id}{q}{hash_frag}", status_code=302)
+        redirect_url = f"/offices/{office_id}{q}{hash_frag}"
+        if save_all:
+            return JSONResponse({"ok": True, "redirect": redirect_url})
+        return RedirectResponse(redirect_url, status_code=302)
     url = "/offices?saved=1"
     if list_return_query:
         url += "&" + list_return_query
+    if save_all:
+        return JSONResponse({"ok": True, "redirect": url})
     return RedirectResponse(url, status_code=302)
 
 

--- a/src/templates/page_form.html
+++ b/src/templates/page_form.html
@@ -18,7 +18,12 @@
 </p>
 {% endif %}
 {% if saved %}<div class="alert alert-success">Saved.</div>{% endif %}
-{% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
+{% if validation_error %}
+<div class="alert alert-error" role="alert" style="border-width:2px; font-weight:600; margin-bottom:1rem;">
+  <strong>Save failed – validation error</strong><br>
+  <span style="font-weight:normal;">{{ validation_error }}</span>
+</div>
+{% endif %}
 
 {% if source_page_id is not none and page_data and offices_on_page %}
 {# Multi-office: one page config, multiple office sections, floating outline to jump #}
@@ -98,7 +103,6 @@
       <div class="form-group checkbox-group"><label><input type="checkbox" name="allow_reuse_tables" value="1" {% if page_data.allow_reuse_tables %}checked{% endif %}> Allow reuse of tables</label></div>
       <p class="form-note">When checked, table numbers must be unique per page. When unchecked, different offices can use the same table number.</p>
       <div class="actions">
-        <button type="submit" class="btn btn-secondary save-page-btn">Save page only</button>
         <a href="/offices{% if list_return_query is defined and list_return_query %}?{{ list_return_query }}{% endif %}" class="btn btn-secondary">Cancel</a>
         <form method="post" action="/pages/{{ source_page_id }}/delete" style="display:inline;" onsubmit="return confirm('Delete this page and all its offices and tables? This cannot be undone.');">
           <button type="submit" class="btn btn-danger">Delete page</button>
@@ -178,7 +182,7 @@
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_rep_link" value="1" {% if tc.rep_link %}checked{% endif %}> Rep link</label></div>
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_party_link" value="1" {% if tc.party_link %}checked{% endif %}> Party link</label></div>
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_use_full_page_for_table" value="1" {% if tc.use_full_page_for_table %}checked{% endif %}> Use full page for table</label></div>
-          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_enabled" value="1" {% if tc.enabled %}checked{% endif %}> Table enabled</label></div>
+          <div class="form-group checkbox-group"><label><input type="hidden" name="tc_enabled_{{ tc.id if tc.id else ('new_' ~ loop.index0) }}" value="0"><input type="checkbox" name="tc_enabled_{{ tc.id if tc.id else ('new_' ~ loop.index0) }}" value="1" {% if tc.enabled %}checked{% endif %}> Table enabled</label></div>
         </div>
         <div class="form-group"><label>Notes</label><input type="text" name="tc_notes" value="{{ tc.notes or '' }}"></div>
         <div class="actions" style="margin-top:0.5rem;">
@@ -216,7 +220,6 @@
       </div>
       <button type="button" class="btn btn-secondary add-table-btn" data-office-id="{{ o.id }}" style="margin-bottom:1rem;">Add table</button>
       <div class="actions">
-        <button type="submit" class="btn btn-secondary save-office-btn">Save this office only</button>
         <a href="/offices{% if list_return_query is defined and list_return_query %}?{{ list_return_query }}{% endif %}" class="btn btn-secondary">Cancel</a>
       </div>
     </form>
@@ -868,35 +871,71 @@
       saveAllBtn.disabled = true;
       function formToBody(form) {
         form.querySelectorAll('input[disabled], select[disabled]').forEach(function(el) { el.disabled = false; });
+        form.querySelectorAll('fieldset[disabled]').forEach(function(fs) { fs.disabled = false; });
+        form.querySelectorAll('.table-config-block').forEach(function(block) {
+          var hidden = block.querySelector('input[type="hidden"][name^="tc_enabled_"]');
+          var checkbox = block.querySelector('input[type="checkbox"][name^="tc_enabled_"]');
+          if (hidden && checkbox) { hidden.value = checkbox.checked ? '1' : '0'; checkbox.removeAttribute('name'); }
+        });
         return new FormData(form);
       }
       var pageAction = pageForm.getAttribute('action') || pageForm.action;
       if (typeof pageAction !== 'string') pageAction = '';
-      fetch(pageAction, { method: 'POST', body: formToBody(pageForm) })
-        .then(function(r) {
-          if (!r.ok && r.status !== 302) throw new Error('Page save failed');
-          var idx = 0;
-          function next() {
-            if (idx >= officeForms.length) {
-              setStatus('Saved.');
-              var firstForm = officeForms[0];
-              var firstAction = firstForm ? (firstForm.getAttribute('action') || firstForm.action) : '';
-              var firstOfficeId = typeof firstAction === 'string' ? (firstAction.match(/\/offices\/(\d+)/) || [])[1] : null;
-              if (firstOfficeId) window.location.href = '/offices/' + firstOfficeId + '?saved=1';
-              else window.location.href = '/offices?saved=1';
-              return;
-            }
-            var of = officeForms[idx++];
-            var officeAction = of.getAttribute('action') || of.action;
-            if (typeof officeAction !== 'string') officeAction = '';
-            return fetch(officeAction, { method: 'POST', body: formToBody(of) }).then(function(res) {
-              if (!res.ok && res.status !== 302) throw new Error('Office save failed');
-              return next();
-            });
+      var saveAllHeaders = { 'X-Save-All': '1' };
+      function redirectIfError(res) {
+        if (res.status === 302) {
+          var loc = res.headers.get('Location') || '';
+          if (loc.indexOf('error=') !== -1) {
+            window.location.href = loc;
+            return true;
           }
-          return next();
+        }
+        return false;
+      }
+      function handleSaveAllResponse(res, fallbackRedirect) {
+        var ct = res.headers.get('Content-Type') || '';
+        if (ct.indexOf('application/json') !== -1) {
+          return res.json().then(function(data) {
+            if (data.ok === false) {
+              setStatus('Error: ' + (data.error || 'Validation failed'));
+              window.location.href = data.redirect || fallbackRedirect || window.location.pathname;
+              return Promise.reject(new Error('validation'));
+            }
+            return data;
+          });
+        }
+        if (!res.ok && res.status !== 302) return Promise.reject(new Error('Save failed'));
+        if (redirectIfError(res)) return Promise.reject(new Error('redirected'));
+        return Promise.resolve(null);
+      }
+      fetch(pageAction, { method: 'POST', headers: saveAllHeaders, body: formToBody(pageForm) })
+        .then(function(r) {
+          return handleSaveAllResponse(r, pageAction).then(function(data) {
+            var idx = 0;
+            function next() {
+              if (idx >= officeForms.length) {
+                setStatus('Saved.');
+                var firstForm = officeForms[0];
+                var firstAction = firstForm ? (firstForm.getAttribute('action') || firstForm.action) : '';
+                var firstOfficeId = typeof firstAction === 'string' ? (firstAction.match(/\/offices\/(\d+)/) || [])[1] : null;
+                if (firstOfficeId) window.location.href = '/offices/' + firstOfficeId + '?saved=1';
+                else window.location.href = '/offices?saved=1';
+                return;
+              }
+              var of = officeForms[idx++];
+              var officeAction = of.getAttribute('action') || of.action;
+              if (typeof officeAction !== 'string') officeAction = '';
+              return fetch(officeAction, { method: 'POST', headers: saveAllHeaders, body: formToBody(of) })
+                .then(function(res) {
+                  return handleSaveAllResponse(res, officeAction).then(function() { return next(); });
+                });
+            }
+            return next();
+          });
         })
         .catch(function(err) {
+          if (err && err.message === 'validation') return;
+          if (err && err.message === 'redirected') return;
           setStatus('Error: ' + (err && err.message ? err.message : 'Save failed'));
           saveAllBtn.disabled = false;
         });
@@ -967,6 +1006,8 @@
         });
         container.appendChild(clone);
         var newIdx = container.querySelectorAll('.table-config-block').length;
+        var blockIndex = newIdx - 1;
+        clone.querySelectorAll('input[name^="tc_enabled_"]').forEach(function(inp) { inp.name = 'tc_enabled_new_' + blockIndex; });
         clone.id = 'section-office-' + (container.getAttribute('data-office-id') || '') + '-t-' + newIdx;
         if (clone.querySelector('h4')) clone.querySelector('h4').textContent = 'Table ' + newIdx;
         if (typeof syncTableBlockValidation === 'function') syncTableBlockValidation(clone);


### PR DESCRIPTION
- Save-all: server returns JSON (X-Save-All: 1) so client can distinguish success from validation error; only show Saved when all requests ok
- Duplicate column: specific error naming column number and which fields use it
- Page and office update: JSON response with ok, error, redirect when header set