### PR TITLE
Fix term dates merged validation for multiple table configs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -676,6 +676,12 @@ def _form_to_table_config(form, i: int) -> dict:
     def _bool(key_flat: str, key_tc: str) -> bool:
         v = _get(key_flat, key_tc)
         return v in (True, "1", 1, "true", "TRUE")
+    def _term_dates_merged_for_index(f, idx: int, get_fn, bool_fn) -> bool:
+        # Per-index name so each table config gets its own value (unchecked checkboxes omit the key).
+        v = f.get("tc_term_dates_merged_" + str(idx))
+        if v is not None and str(v).strip() != "":
+            return str(v).strip().lower() in ("true", "1", "yes")
+        return bool_fn("term_dates_merged", "tc_term_dates_merged")
     tc_id = _get("tc_id", "tc_id")
     if tc_id is not None and str(tc_id).strip() != "":
         try:
@@ -708,7 +714,7 @@ def _form_to_table_config(form, i: int) -> dict:
         "party_link": _bool("party_link", "tc_party_link"),
         "enabled": enabled,
         "use_full_page_for_table": _bool("use_full_page_for_table", "tc_use_full_page_for_table"),
-        "term_dates_merged": _bool("term_dates_merged", "tc_term_dates_merged"),
+        "term_dates_merged": _term_dates_merged_for_index(form, i, _get, _bool),
         "party_ignore": _bool("party_ignore", "tc_party_ignore"),
         "district_ignore": dist_mode == "no_district",
         "district_at_large": dist_mode == "at_large",

--- a/src/templates/page_form.html
+++ b/src/templates/page_form.html
@@ -177,7 +177,7 @@
           <div class="form-group"><label>District column</label><input type="number" name="tc_district_column" value="{{ tc.district_column or 0 }}" min="0"></div>
         </div>
         <div class="form-row">
-          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_term_dates_merged" value="1" {% if tc.term_dates_merged %}checked{% endif %}> Term dates merged</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_term_dates_merged_{{ loop.index0 }}" value="1" {% if tc.term_dates_merged %}checked{% endif %}> Term dates merged</label></div>
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_party_ignore" value="1" {% if tc.party_ignore %}checked{% endif %}> Ignore party</label></div>
           <div class="form-group">
             <label>District</label>
@@ -797,7 +797,7 @@
     var of = officeForm;
     var block = tableBlock || of;
     function el(name, tcName) {
-      var b = block.querySelector && block.querySelector('[name="' + tcName + '"]');
+      var b = block.querySelector && (tcName === 'tc_term_dates_merged' ? block.querySelector('[name^="tc_term_dates_merged"]') : block.querySelector('[name="' + tcName + '"]'));
       if (b) return b;
       return of[name] || block[name];
     }
@@ -855,7 +855,7 @@
   }
   function syncTableBlockValidation(block) {
     if (!block || !block.querySelector) return;
-    var mergedCb = block.querySelector('input[name="tc_term_dates_merged"]');
+    var mergedCb = block.querySelector('input[name^="tc_term_dates_merged"]');
     var termStartInput = block.querySelector('input[name="tc_term_start_column"]');
     var termEndInput = block.querySelector('input[name="tc_term_end_column"]');
     var termEndGroup = termEndInput && termEndInput.closest('.form-group');
@@ -1131,6 +1131,8 @@
         var newIdx = container.querySelectorAll('.table-config-block').length;
         var blockIndex = newIdx - 1;
         clone.querySelectorAll('input[name^="tc_enabled_"]').forEach(function(inp) { inp.name = 'tc_enabled_new_' + blockIndex; });
+        var mergedCb = clone.querySelector('input[name^="tc_term_dates_merged"]');
+        if (mergedCb) mergedCb.name = 'tc_term_dates_merged_' + blockIndex;
         clone.id = 'section-office-' + (container.getAttribute('data-office-id') || '') + '-t-' + newIdx;
         if (clone.querySelector('h4')) clone.querySelector('h4').textContent = 'Table ' + newIdx;
         if (typeof syncTableBlockValidation === 'function') syncTableBlockValidation(clone);
@@ -1139,7 +1141,13 @@
         e.preventDefault();
         var block = e.target.closest('.table-config-block');
         var container = block && block.closest('.table-config-blocks');
-        if (block && container && container.querySelectorAll('.table-config-block').length > 1) block.remove();
+        if (block && container && container.querySelectorAll('.table-config-block').length > 1) {
+          block.remove();
+          container.querySelectorAll('.table-config-block').forEach(function(blk, idx) {
+            var m = blk.querySelector('input[name^="tc_term_dates_merged"]');
+            if (m) m.name = 'tc_term_dates_merged_' + idx;
+          });
+        }
       }
       if (e.target.classList.contains('delete-table-btn')) {
         e.preventDefault();


### PR DESCRIPTION
Use per-index checkbox names (tc_term_dates_merged_0, _1, ...) so each table config gets its own value. Previously all shared the same name; only one value was submitted and assigned to index 0, so the second config got term_dates_merged=false and failed when term start/end were the same column.