### PR TITLE
Fix RTL dynamic parse link detection regression

### DIFF
--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -293,18 +293,20 @@ class DataCleanup:
       sy = int(year_match.group(0))
       return (sy, sy)
 
-  def find_link_and_data_columns( self , row , max_column_index = None ):
+  def find_link_and_data_columns( self , row , max_column_index = None , min_column_index = 0 ):
       # Dynamic identification of the link column and subsequent data columns.
-      # If max_column_index is set (0-based), only consider cells up to that index so we never
-      # pick a link from a non-data column (e.g. President column) when it appears after term dates.
+      # If min/max bounds are set (0-based), only consider cells in that range so we can keep
+      # dynamic parse constrained for both LTR and RTL tables.
       # #region agent log
       try:
           _log_path = Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log"
-          open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_link_and_data_columns", "message": "entry", "data": {"len_row": len(row), "max_column_index": max_column_index}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
+          open(_log_path, "a", encoding="utf-8").write(json.dumps({"location": "table_parser:find_link_and_data_columns", "message": "entry", "data": {"len_row": len(row), "max_column_index": max_column_index, "min_column_index": min_column_index}, "timestamp": __import__("time").time() * 1000, "hypothesisId": "H2"}) + "\n")
       except Exception:
           pass
       # #endregion
       for i, cell in enumerate(row):
+          if i < min_column_index:
+              continue
           if max_column_index is not None and i > max_column_index:
               break
           try:
@@ -1250,11 +1252,22 @@ class Offices:
     term_end_column = table_config_to_parse["term_end_column"]
     district_column = table_config_to_parse["district_column"]
 
-    # Only search columns up to and including term_end_column so we never pick the link from
-    # a column after the term dates (e.g. Lt. Governor or President column).
-    max_link_col = max(0, term_end_column) if term_end_column is not None and term_end_column >= 0 else None
+    # Constrain dynamic link search to expected side of term columns.
+    # LTR: link should be at/before term columns. RTL: link should be at/after term columns.
+    read_rtl = bool(table_config_to_parse.get("read_columns_right_to_left"))
+    min_link_col = 0
+    max_link_col = None
+    if term_end_column is not None and term_end_column >= 0:
+        if read_rtl:
+            min_link_col = max(0, term_end_column)
+        else:
+            max_link_col = max(0, term_end_column)
     link_column_old = link_column
-    link_column_result = self.DataCleanup.find_link_and_data_columns(cells, max_column_index=max_link_col)
+    link_column_result = self.DataCleanup.find_link_and_data_columns(
+        cells,
+        max_column_index=max_link_col,
+        min_column_index=min_link_col,
+    )
 
     # Stop loop if no link is found
     if link_column_result is None:
@@ -1709,6 +1722,4 @@ class Biography:
           pass
       # #endregion
       return ([("YYYY-00-00", "YYYY-00-00")], infobox_items if infobox_items else ["No dates found (placeholder)."])
-
-
 

--- a/src/scraper/test_table_parser_dynamic_parse.py
+++ b/src/scraper/test_table_parser_dynamic_parse.py
@@ -1,0 +1,63 @@
+from bs4 import BeautifulSoup
+
+from src.scraper.table_parser import DataCleanup, Offices
+
+
+class _NoopLogger:
+    def log(self, *_args, **_kwargs):
+        return None
+
+    def debug_log(self, *_args, **_kwargs):
+        return None
+
+
+def _cells_from_row_html(row_html: str):
+    soup = BeautifulSoup(f"<table><tr>{row_html}</tr></table>", "html.parser")
+    return soup.find("tr").find_all(["td", "th"])
+
+
+def test_find_link_and_data_columns_respects_bounds():
+    cleanup = DataCleanup(_NoopLogger())
+    cells = _cells_from_row_html(
+        """
+        <td><a href='/wiki/Ignore'>Ignore</a></td>
+        <td>Term start</td>
+        <td>Term end</td>
+        <td><a href='/wiki/Expected'>Expected</a></td>
+        """
+    )
+
+    assert cleanup.find_link_and_data_columns(cells, min_column_index=2) == 3
+    assert cleanup.find_link_and_data_columns(cells, max_column_index=2) == 0
+
+
+def test_dynamic_parse_rtl_searches_to_the_right_of_term_columns():
+    logger = _NoopLogger()
+    cleanup = DataCleanup(logger)
+    offices = Offices(logger, biography=None, data_cleanup=cleanup)
+
+    # In RTL tables, person link appears to the right of term columns. There is an earlier
+    # non-person link to the left that should be ignored by dynamic parse.
+    cells = _cells_from_row_html(
+        """
+        <td><a href='/wiki/NotPerson'>Not person</a></td>
+        <td>Democratic</td>
+        <td>Jan 3, 2013 – Jan 3, 2025</td>
+        <td><a href='/wiki/Brian_Schatz'>Brian Schatz</a></td>
+        """
+    )
+
+    ok, cfg = offices.process_dynamic_parse(
+        cells,
+        {
+            "link_column": -1,
+            "party_column": 1,
+            "term_start_column": 2,
+            "term_end_column": 2,
+            "district_column": 0,
+            "read_columns_right_to_left": True,
+        },
+    )
+
+    assert ok is True
+    assert cfg["link_column"] == 3


### PR DESCRIPTION
### Motivation
- Dynamic link detection stopped finding person links in right-to-left (RTL) table layouts, causing rows (e.g., Hawaii senators) to be skipped or mis-parsed. 
- The intent is to constrain dynamic link search to the correct side of the term columns depending on layout direction.
- Tests were added to protect against regressions in RTL/LTR dynamic parsing.

### Description
- Extended `DataCleanup.find_link_and_data_columns` to accept a `min_column_index` parameter in addition to `max_column_index` so dynamic searches can be constrained to a column range. 
- Updated `Offices.process_dynamic_parse` to compute direction-aware bounds (`min_link_col` / `max_link_col`) based on `read_columns_right_to_left` and to call `find_link_and_data_columns` with both bounds. 
- Added `src/scraper/test_table_parser_dynamic_parse.py` with focused tests that validate bounds behavior and that RTL dynamic parse selects the right-side person link.

### Testing
- Ran the new focused unit tests with `PYTHONPATH=. pytest -q src/scraper/test_table_parser_dynamic_parse.py` and observed `2 passed`.
- Local network fetch against live Wikipedia failed in this environment due to a proxy/tunnel error (403), so live-page validation could not be performed here. 
- The change is covered by the new tests which simulate RTL and bound scenarios and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cb90e79483289ba9ad3073b9c6ba)