### PR TITLE
Add office-category filtering and category-populate run mode

### DIFF
--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -384,6 +384,7 @@ def list_pages(
     state_id: int | None = None,
     level_id: int | None = None,
     branch_id: int | None = None,
+    office_category_id: int | None = None,
     enabled: int | None = None,
     limit: int | None = None,
     office_count_filter: str = "all",
@@ -415,6 +416,15 @@ def list_pages(
         if enabled is not None and enabled in (0, 1):
             where_parts.append("p.enabled = ?")
             params.append(enabled)
+        if office_category_id is not None and office_category_id != 0:
+            where_parts.append(
+                """EXISTS (
+                    SELECT 1 FROM office_details od
+                    WHERE od.source_page_id = p.id
+                      AND od.office_category_id = ?
+                )"""
+            )
+            params.append(office_category_id)
         if office_count_filter == "gt0":
             where_parts.append("(SELECT COUNT(*) FROM office_details od WHERE od.source_page_id = p.id) > 0")
         elif office_count_filter == "eq0":
@@ -443,6 +453,37 @@ def list_pages(
         """
         cur = conn.execute(sql, params)
         return [_row_to_dict(r) for r in cur.fetchall()]
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def get_runnable_unit_ids_for_office_category(
+    office_category_id: int,
+    conn: sqlite3.Connection | None = None,
+) -> list[int]:
+    """Return runnable unit ids for enabled offices in a given office category."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        if not office_category_id:
+            return []
+        if _use_hierarchy(conn):
+            cur = conn.execute(
+                """SELECT tc.id
+                   FROM office_table_config tc
+                   JOIN office_details od ON od.id = tc.office_details_id
+                   JOIN source_pages p ON p.id = od.source_page_id
+                   WHERE od.office_category_id = ?
+                     AND tc.enabled = 1
+                     AND od.enabled = 1
+                     AND p.enabled = 1
+                   ORDER BY tc.id""",
+                (office_category_id,),
+            )
+            return [row[0] for row in cur.fetchall()]
+        return []
     finally:
         if own_conn:
             conn.close()

--- a/src/main.py
+++ b/src/main.py
@@ -147,6 +147,7 @@ def _list_return_query(
     state_id: int | None = None,
     level_id: int | None = None,
     branch_id: int | None = None,
+    office_category_id: int | None = None,
     enabled: str | None = None,
     limit: str | None = None,
     office_count: str | None = None,
@@ -161,6 +162,8 @@ def _list_return_query(
         parts.append(f"level_id={level_id}")
     if branch_id:
         parts.append(f"branch_id={branch_id}")
+    if office_category_id:
+        parts.append(f"office_category_id={office_category_id}")
     if enabled is not None and str(enabled).strip():
         parts.append("enabled=" + str(enabled).strip())
     if limit is not None and str(limit).strip():
@@ -188,6 +191,7 @@ async def offices_list(
     state_id: str | None = Query(None),
     level_id: str | None = Query(None),
     branch_id: str | None = Query(None),
+    office_category_id: str | None = Query(None),
     enabled: str | None = Query(None),
     limit: str | None = Query(None),
     office_count: str | None = Query("all"),
@@ -213,6 +217,7 @@ async def offices_list(
         sid = _parse_optional_int(state_id)
         lid = _parse_optional_int(level_id)
         bid = _parse_optional_int(branch_id)
+        ocid = _parse_optional_int(office_category_id)
         office_count_val = (office_count or "all").strip().lower()
         if office_count_val not in ("all", "gt0", "eq0"):
             office_count_val = "all"
@@ -221,6 +226,7 @@ async def offices_list(
             state_id=sid,
             level_id=lid,
             branch_id=bid,
+            office_category_id=ocid,
             enabled=enabled_int,
             limit=limit_int,
             office_count_filter=office_count_val,
@@ -228,11 +234,13 @@ async def offices_list(
         countries = db_refs.list_countries()
         levels = db_refs.list_levels()
         branches = db_refs.list_branches()
+        office_categories = db_office_category.list_office_categories()
         filter_country_id = cid
         states = db_refs.list_states(filter_country_id) if filter_country_id else []
         nav_ids = ",".join(str(p["first_office_id"]) for p in pages if p.get("first_office_id"))
         list_return_query = _list_return_query(
             country_id=cid, state_id=sid, level_id=lid, branch_id=bid,
+            office_category_id=ocid,
             enabled=enabled.strip() if enabled else None,
             limit=limit.strip() if limit else None,
             office_count=office_count_val if office_count_val != "all" else None,
@@ -249,11 +257,13 @@ async def offices_list(
                 "countries": countries,
                 "levels": levels,
                 "branches": branches,
+                "office_categories": office_categories,
                 "states": states,
                 "filter_country_id": filter_country_id,
                 "filter_state_id": sid,
                 "filter_level_id": lid,
                 "filter_branch_id": bid,
+                "filter_office_category_id": ocid,
                 "filter_enabled": enabled.strip() if enabled else "",
                 "filter_limit": limit.strip() if limit else "20",
                 "filter_office_count": office_count_val,
@@ -2009,7 +2019,11 @@ async def api_run_enabled_test_scripts():
 @app.get("/run", response_class=HTMLResponse)
 async def run_page(request: Request):
     offices = db_offices.list_offices()
-    return templates.TemplateResponse("run.html", {"request": request, "offices": offices})
+    office_categories = db_office_category.list_office_categories()
+    return templates.TemplateResponse(
+        "run.html",
+        {"request": request, "offices": offices, "office_categories": office_categories},
+    )
 
 
 def _run_job_worker(
@@ -2070,11 +2084,13 @@ def _run_job_worker(
 async def api_run(
     run_mode: str = Form("delta"),
     individual_ref: str = Form(""),
+    office_category_id: str = Form(""),
     force_overwrite: str = Form(""),
 ):
     if run_mode == "single_bio" and not individual_ref.strip():
         raise HTTPException(status_code=400, detail="Individual (ID or Wikipedia URL) required for re-run bio.")
     force_overwrite_bool = str(force_overwrite).strip().lower() in ("1", "true", "yes")
+    office_category_id_int = _parse_optional_int(office_category_id)
     run_bio = run_mode == "delta_live"
     run_office_bio = run_mode not in ("full_no_bio", "delta_no_bio", "full_no_bio_refresh", "delta_no_bio_refresh")
     refresh_table_cache = run_mode in ("full_no_bio_refresh", "delta_no_bio_refresh")
@@ -2086,6 +2102,18 @@ async def api_run(
         mode = "delta"
     else:
         mode = run_mode
+
+    office_id_list: list[int] | None = None
+    if run_mode == "populate_category_terms":
+        if not office_category_id_int:
+            raise HTTPException(status_code=400, detail="Office category is required for category populate run.")
+        office_id_list = db_offices.get_runnable_unit_ids_for_office_category(office_category_id_int)
+        if not office_id_list:
+            raise HTTPException(status_code=400, detail="No enabled office tables found for the selected office category.")
+        mode = "delta"
+        run_bio = False
+        run_office_bio = False
+        refresh_table_cache = False
     job_id = str(uuid.uuid4())
     with _run_job_lock:
         _run_job_store[job_id] = {
@@ -2101,7 +2129,7 @@ async def api_run(
         }
     thread = threading.Thread(
         target=_run_job_worker,
-        args=(job_id, mode, run_bio, run_office_bio, refresh_table_cache, False, False, None, None, individual_ref.strip() or None, force_overwrite_bool),
+        args=(job_id, mode, run_bio, run_office_bio, refresh_table_cache, False, False, None, office_id_list, individual_ref.strip() or None, force_overwrite_bool),
     )
     thread.start()
     return JSONResponse({"job_id": job_id}, status_code=202)

--- a/src/templates/offices.html
+++ b/src/templates/offices.html
@@ -64,6 +64,15 @@
       {% endfor %}
     </select>
   </div>
+  <div class="form-group" style="margin:0; min-width:12rem;">
+    <label for="filterOfficeCategory">Office category</label>
+    <select name="office_category_id" id="filterOfficeCategory" class="page-col-filter">
+      <option value="">All</option>
+      {% for oc in office_categories %}
+      <option value="{{ oc.id }}" {% if filter_office_category_id and oc.id == filter_office_category_id %}selected{% endif %}>{{ oc.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
   <div class="form-group" style="margin:0; min-width:8rem;">
     <label for="filterEnabled">On/Off</label>
     <select name="enabled" id="filterEnabled" class="page-col-filter">
@@ -102,13 +111,13 @@
   function hasFilterParams() {
     var params = new URLSearchParams(window.location.search);
     return params.has('country_id') || params.has('state_id') || params.has('level_id') ||
-           params.has('branch_id') || params.has('enabled') || params.has('limit') || params.has('office_count');
+           params.has('branch_id') || params.has('office_category_id') || params.has('enabled') || params.has('limit') || params.has('office_count');
   }
 
   function buildQueryFromForm(form) {
     var fd = new FormData(form);
     var parts = [];
-    ['country_id', 'state_id', 'level_id', 'branch_id', 'enabled', 'limit', 'office_count'].forEach(function(name) {
+    ['country_id', 'state_id', 'level_id', 'branch_id', 'office_category_id', 'enabled', 'limit', 'office_count'].forEach(function(name) {
       var v = fd.get(name);
       if (v !== null && v !== undefined && String(v).trim() !== '') parts.push(encodeURIComponent(name) + '=' + encodeURIComponent(v));
     });

--- a/src/templates/run.html
+++ b/src/templates/run.html
@@ -15,11 +15,21 @@
       <option value="delta_no_bio_refresh">Delta run (no bio, refresh cache)</option>
       <option value="bios_only">Bios only (update all individuals)</option>
       <option value="single_bio">Re-run bio for one individual</option>
+      <option value="populate_category_terms">Populate terms for office category</option>
     </select>
   </div>
   <div class="form-group" id="individualRefGroup" style="display:none;">
     <label>Individual (ID or Wikipedia URL)</label>
     <input type="text" name="individual_ref" id="individualRef" placeholder="e.g. 42 or https://en.wikipedia.org/wiki/John_Doe">
+  </div>
+  <div class="form-group" id="officeCategoryGroup" style="display:none;">
+    <label>Office category</label>
+    <select name="office_category_id" id="officeCategoryId">
+      <option value="">Select office category</option>
+      {% for oc in office_categories %}
+      <option value="{{ oc.id }}">{{ oc.name }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div class="form-group checkbox-group">
     <label><input type="checkbox" name="force_overwrite" value="1"> Force overwrite – when validation fails (new list missing existing holders), replace terms anyway</label>
@@ -89,11 +99,13 @@
 (function() {
   const runMode = document.getElementById('runMode');
   const individualRefGroup = document.getElementById('individualRefGroup');
-  function toggleIndividualRef() {
+  const officeCategoryGroup = document.getElementById('officeCategoryGroup');
+  function toggleRunModeFields() {
     individualRefGroup.style.display = runMode.value === 'single_bio' ? 'block' : 'none';
+    officeCategoryGroup.style.display = runMode.value === 'populate_category_terms' ? 'block' : 'none';
   }
-  runMode.addEventListener('change', toggleIndividualRef);
-  toggleIndividualRef();
+  runMode.addEventListener('change', toggleRunModeFields);
+  toggleRunModeFields();
 })();
 document.getElementById('runForm').addEventListener('submit', async (e) => {
   e.preventDefault();


### PR DESCRIPTION
### Motivation
- Provide the ability to filter the offices list by `office_category` so pages/offices can be scoped by category. 
- Allow running the term-population pipeline for all enabled offices within a selected `office_category`, with the existing "Force overwrite" behavior to replace terms when validation would otherwise skip.

### Description
- Added `office_category_id` support to the page listing flow and query-return helpers by extending `_list_return_query`, the `/offices` handler, and the `offices.html` template to include an Office category select and preserve the filter state.`
- Extended `src/db/offices.py::list_pages` to accept `office_category_id` and filter pages that contain offices assigned to the chosen category using an `EXISTS` predicate.
- Added `src/db/offices.py::get_runnable_unit_ids_for_office_category` to return runnable table-config ids (`office_table_config.id`) for enabled offices within a category (used to scope runs to category members).
- Updated the Run UI (`src/templates/run.html`) to include a new `populate_category_terms` run mode and an Office category selector, and updated the client-side form logic to show the selector only for that run mode.
- Updated server run API (`/api/run` in `src/main.py`) to accept `office_category_id` and, when `run_mode == 'populate_category_terms'`, resolve runnable unit IDs via the new DB helper and pass them into the existing `_run_job_worker`/`run_with_db` pipeline so the job runs only for that category; existing `force_overwrite` behavior is honored.

### Testing
- Compiled modified modules with `python -m compileall src/main.py src/db/offices.py` and compilation succeeded.
- Ran unit tests with `pytest -q`; test run produced 8 passed and 1 error (test collection error in `src/scraper/config_test.py::test_office_config` due to a missing fixture `office_row`), so the failure is unrelated to these changes and blocks a full green test run.
- Attempted automated UI smoke checks with Playwright to capture screenshots of `/run` and `/offices`, but Playwright timed out in this environment (tool timeout); a quick HTTP fetch of `/run` returned HTML (server started), providing a basic smoke validation of the new template being served.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e13eca908328ad32faa763c96f38)