### PR TITLE
Fix SQL placeholder mismatch in office_table_config INSERTs

### DIFF
--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -799,7 +799,7 @@ def _insert_one_table_config(
               term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
               parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
               term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, consolidate_rowspan_terms, notes, name, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
         (
             od_id,
             int(tc.get("table_no", 1)),
@@ -1183,7 +1183,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                                   term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
                                   parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
                                   term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, consolidate_rowspan_terms, notes, name, created_at, updated_at)
-                               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
                             (
                                 office_id,
                                 int(tc.get("table_no", 1)),


### PR DESCRIPTION
### Motivation
- Saving an office with an additional table config raised a SQLite binding/count error because the `INSERT INTO office_table_config` listed both `notes` and `name` columns but the VALUES clause had one fewer `?` placeholder than values supplied.

### Description
- Added the missing `?` placeholder to the `INSERT INTO office_table_config` in the helper `_insert_one_table_config` so placeholders match the listed columns (including `name`).
- Applied the identical placeholder fix to the `INSERT` used in the `update_office` branch that inserts new table configs during office edits/saves.

### Testing
- Ran `python -m py_compile src/db/offices.py src/main.py` and it completed without errors.
- Executed an in-memory SQLite snippet that calls `_insert_one_table_config` and verified the row was inserted (`rows 1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fa4571508328bb2e96d810de95e8)