### PR TITLE
Add remove_duplicates table config and dedupe parsed rows

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -57,6 +57,7 @@ def migrate_to_fk(conn=None):
         # Add term_dates_merged, party_ignore, district_ignore, district_at_large to offices
         _migrate_offices_parsing_options(conn)
         _migrate_ignore_non_links(conn)
+        _migrate_remove_duplicates(conn)
         # Add is_dead_link to individuals if missing
         _migrate_individuals_dead_link(conn)
         # Alt links: new table, backfill from offices.alt_link, verify, then drop offices.alt_link
@@ -511,7 +512,7 @@ def _migrate_to_page_office_table_hierarchy(conn):
                   table_no, table_rows, link_column, party_column, term_start_column, term_end_column, district_column,
                   dynamic_parse, read_right_to_left, find_date_in_infobox, parse_rowspan, consolidate_rowspan_terms,
                   rep_link, party_link, alt_link_include_main, use_full_page_for_table, years_only,
-                  term_dates_merged, party_ignore, district_ignore, district_at_large, created_at
+                  term_dates_merged, party_ignore, district_ignore, district_at_large, remove_duplicates, created_at
            FROM offices ORDER BY id"""
     ).fetchall()
 
@@ -549,8 +550,8 @@ def _migrate_to_page_office_table_hierarchy(conn):
             """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
                   term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
                   parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
-                  term_dates_merged, party_ignore, district_ignore, district_at_large, consolidate_rowspan_terms, notes, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
+                  term_dates_merged, party_ignore, district_ignore, district_at_large, remove_duplicates, consolidate_rowspan_terms, notes, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
             (
                 od_id,
                 int(o["table_no"] or 1),
@@ -573,6 +574,7 @@ def _migrate_to_page_office_table_hierarchy(conn):
                 1 if o["party_ignore"] else 0,
                 1 if o["district_ignore"] else 0,
                 1 if o["district_at_large"] else 0,
+                1 if o.get("remove_duplicates") else 0,
                 1 if o["consolidate_rowspan_terms"] else 0,
                 o["notes"] or None,
             ),
@@ -683,4 +685,15 @@ def _migrate_ignore_non_links(conn):
     otc_cols = _columns(conn, "office_table_config")
     if "ignore_non_links" not in otc_cols:
         conn.execute("ALTER TABLE office_table_config ADD COLUMN ignore_non_links INTEGER NOT NULL DEFAULT 0")
+    conn.commit()
+
+
+def _migrate_remove_duplicates(conn):
+    """Add remove_duplicates to offices and office_table_config if missing."""
+    offices_cols = _columns(conn, "offices")
+    if "remove_duplicates" not in offices_cols:
+        conn.execute("ALTER TABLE offices ADD COLUMN remove_duplicates INTEGER NOT NULL DEFAULT 0")
+    otc_cols = _columns(conn, "office_table_config")
+    if "remove_duplicates" not in otc_cols:
+        conn.execute("ALTER TABLE office_table_config ADD COLUMN remove_duplicates INTEGER NOT NULL DEFAULT 0")
     conn.commit()

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -80,6 +80,7 @@ def _flatten_hierarchy_row(
         "district_ignore": bool(tc.get("district_ignore") if tc.get("district_ignore") is not None else 0),
         "district_at_large": bool(tc.get("district_at_large") if tc.get("district_at_large") is not None else 0),
         "ignore_non_links": bool(tc.get("ignore_non_links") if tc.get("ignore_non_links") is not None else 0),
+        "remove_duplicates": bool(tc.get("remove_duplicates") if tc.get("remove_duplicates") is not None else 0),
         "created_at": tc.get("created_at") or od.get("created_at"),
         "alt_links": list(alt_links) if alt_links else [],
     }
@@ -110,6 +111,7 @@ def _tc_row_to_config(rd: dict[str, Any]) -> dict[str, Any]:
         "district_ignore": rd.get("district_ignore"),
         "district_at_large": rd.get("district_at_large"),
         "ignore_non_links": rd.get("ignore_non_links"),
+        "remove_duplicates": rd.get("remove_duplicates"),
         "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"),
         "notes": rd.get("tc_notes"),
         "name": rd.get("tc_name") or "",
@@ -264,7 +266,7 @@ def list_runnable_units(conn: sqlite3.Connection | None = None) -> list[dict[str
                       tc.id AS office_table_config_id, tc.table_no, tc.table_rows, tc.link_column, tc.party_column,
                       tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                       tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
-                      tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links,
+                      tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
                       tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.created_at
                FROM source_pages p
                JOIN office_details od ON od.source_page_id = p.id AND od.enabled = 1
@@ -290,7 +292,7 @@ def list_runnable_units(conn: sqlite3.Connection | None = None) -> list[dict[str
             )
             p = {"url": rd.get("url"), "country_id": rd.get("country_id"), "state_id": rd.get("state_id"), "city_id": rd.get("city_id"), "level_id": rd.get("level_id"), "branch_id": rd.get("branch_id"), "notes": rd.get("page_notes"), "enabled": rd.get("page_enabled")}
             od = {"id": od_id, "name": rd.get("name"), "department": rd.get("department"), "notes": rd.get("notes"), "alt_link_include_main": rd.get("alt_link_include_main"), "enabled": rd.get("od_enabled")}
-            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
+            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "ignore_non_links": rd.get("ignore_non_links"), "remove_duplicates": rd.get("remove_duplicates"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
             flat = _flatten_hierarchy_row(p, od, tc, c, s, lv, b, alt_links)
             flat["id"] = rd["office_table_config_id"]
             flat["office_details_id"] = od_id
@@ -317,7 +319,7 @@ def list_offices(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]
                           tc.id AS tc_id, tc.table_no, tc.table_rows, tc.link_column, tc.party_column,
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
-                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links,
+                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
                           tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
@@ -348,7 +350,7 @@ def list_offices(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]
                         table_configs.append(_tc_row_to_config(rd))
                 table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
                 first_tc = table_configs[0] if table_configs else {}
-                tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+                tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
                 flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
                 flat["id"] = od_id
                 flat["source_page_id"] = rd0.get("page_id")
@@ -502,7 +504,7 @@ def get_office(office_id: int, conn: sqlite3.Connection | None = None) -> dict[s
                           tc.id AS tc_id, tc.table_no, tc.table_rows, tc.link_column, tc.party_column,
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
-                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links,
+                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
                           tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
@@ -529,7 +531,7 @@ def get_office(office_id: int, conn: sqlite3.Connection | None = None) -> dict[s
                     table_configs.append(_tc_row_to_config(rd))
             table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
             first_tc = table_configs[0] if table_configs else {}
-            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
             flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
             flat["id"] = od_id
             flat["source_page_id"] = rd0.get("page_id")
@@ -742,7 +744,7 @@ def list_offices_for_page(source_page_id: int, conn: sqlite3.Connection | None =
                           tc.id AS tc_id, tc.table_no, tc.table_rows, tc.link_column, tc.party_column,
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
-                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links,
+                          tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
                           tc.consolidate_rowspan_terms, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
@@ -776,7 +778,7 @@ def list_offices_for_page(source_page_id: int, conn: sqlite3.Connection | None =
                     table_configs.append(_tc_row_to_config(rd))
             table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
             first_tc = table_configs[0] if table_configs else {}
-            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
             flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
             flat["id"] = od_id
             flat["source_page_id"] = rd0.get("page_id")
@@ -798,7 +800,7 @@ def _insert_one_table_config(
         """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
               term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
               parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
-              term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, consolidate_rowspan_terms, notes, name, created_at, updated_at)
+              term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, remove_duplicates, consolidate_rowspan_terms, notes, name, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
         (
             od_id,
@@ -823,6 +825,7 @@ def _insert_one_table_config(
             1 if tc.get("district_ignore") in (True, 1, "TRUE", "true", "1") else 0,
             1 if tc.get("district_at_large") in (True, 1, "TRUE", "true", "1") else 0,
             1 if tc.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
+            1 if tc.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
             1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
             tc.get("notes") or "",
             tc.get("name") or "",
@@ -1145,7 +1148,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                             """UPDATE office_table_config SET table_no=?, table_rows=?, link_column=?, party_column=?,
                                   term_start_column=?, term_end_column=?, district_column=?, dynamic_parse=?, read_right_to_left=?,
                                   find_date_in_infobox=?, parse_rowspan=?, rep_link=?, party_link=?, enabled=?, use_full_page_for_table=?,
-                                  years_only=?, term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?, ignore_non_links=?,
+                                  years_only=?, term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?, ignore_non_links=?, remove_duplicates=?,
                                   consolidate_rowspan_terms=?, notes=?, name=?, updated_at=datetime('now') WHERE id=?""",
                             (
                                 int(tc.get("table_no", 1)),
@@ -1169,6 +1172,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                                 1 if tc.get("district_ignore") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("district_at_large") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
                                 tc.get("notes") or "",
                                 tc.get("name") or "",
@@ -1182,7 +1186,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                             """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
                                   term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
                                   parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
-                                  term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, consolidate_rowspan_terms, notes, name, created_at, updated_at)
+                                  term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, remove_duplicates, consolidate_rowspan_terms, notes, name, created_at, updated_at)
                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
                             (
                                 office_id,
@@ -1207,6 +1211,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                                 1 if tc.get("district_ignore") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("district_at_large") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
+                                1 if tc.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
                                 tc.get("notes") or "",
                                 tc.get("name") or "",
@@ -1232,7 +1237,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                 term_start_column=?, term_end_column=?, district_column=?,
                 dynamic_parse=?, read_right_to_left=?, find_date_in_infobox=?,
                 parse_rowspan=?, consolidate_rowspan_terms=?, rep_link=?, party_link=?, alt_link_include_main=?, use_full_page_for_table=?, years_only=?,
-                term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?, ignore_non_links=?
+                term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?, ignore_non_links=?, remove_duplicates=?
             WHERE id=?""",
             (
                 country_id,
@@ -1266,6 +1271,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                 1 if district_ignore else 0,
                 1 if district_at_large else 0,
                 1 if row_data.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
+                1 if row_data.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
                 office_id,
             ),
         )
@@ -1603,6 +1609,7 @@ def office_row_to_table_config(row: dict[str, Any], alt_links: list[str] | None 
         "district_ignore": bool(row.get("district_ignore")),
         "district_at_large": bool(row.get("district_at_large")),
         "ignore_non_links": bool(row.get("ignore_non_links")),
+        "remove_duplicates": bool(row.get("remove_duplicates")),
     }
 
 

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -135,6 +135,7 @@ CREATE TABLE IF NOT EXISTS office_table_config (
     district_ignore INTEGER NOT NULL DEFAULT 0,
     district_at_large INTEGER NOT NULL DEFAULT 0,
     ignore_non_links INTEGER NOT NULL DEFAULT 0,
+    remove_duplicates INTEGER NOT NULL DEFAULT 0,
     consolidate_rowspan_terms INTEGER NOT NULL DEFAULT 0,
     notes TEXT,
     name TEXT,
@@ -179,6 +180,7 @@ CREATE TABLE IF NOT EXISTS offices (
     district_ignore INTEGER NOT NULL DEFAULT 0,
     district_at_large INTEGER NOT NULL DEFAULT 0,
     ignore_non_links INTEGER NOT NULL DEFAULT 0,
+    remove_duplicates INTEGER NOT NULL DEFAULT 0,
     created_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/main.py
+++ b/src/main.py
@@ -109,6 +109,7 @@ def _office_draft_from_body(body: dict, *, include_ref_names: bool = False) -> d
         "district_ignore": district_ignore,
         "district_at_large": district_at_large,
         "ignore_non_links": body.get("ignore_non_links") in (True, 1, "1", "true", "TRUE"),
+        "remove_duplicates": body.get("remove_duplicates") in (True, 1, "1", "true", "TRUE"),
     }
     if include_ref_names:
         country_id = int(body.get("country_id") or 0)
@@ -325,6 +326,7 @@ async def office_create(request: Request):
         "district_ignore": (form.get("district_mode") or "column") == "no_district",
         "district_at_large": (form.get("district_mode") or "column") == "at_large",
         "ignore_non_links": form.get("ignore_non_links") == "1",
+        "remove_duplicates": form.get("remove_duplicates") == "1",
     }
     try:
         _validate_level_state_city(data.get("level_id"), data.get("state_id"), data.get("city_id"), data.get("branch_id"))
@@ -489,6 +491,7 @@ async def office_add_to_page(request: Request):
         "party_ignore": bool(first.get("party_ignore")),
         "district_ignore": bool(first.get("district_ignore")),
         "ignore_non_links": bool(first.get("ignore_non_links")),
+        "remove_duplicates": bool(first.get("remove_duplicates")),
         "district_at_large": bool(first.get("district_at_large")),
     }
     try:
@@ -739,6 +742,7 @@ def _form_to_table_config(form, i: int) -> dict:
         "district_ignore": dist_mode == "no_district",
         "district_at_large": dist_mode == "at_large",
         "ignore_non_links": _bool("ignore_non_links", "tc_ignore_non_links"),
+        "remove_duplicates": _bool("remove_duplicates", "tc_remove_duplicates"),
         "notes": _get("notes", "tc_notes") or "",
         "name": _get("name", "tc_name") or "",
     }
@@ -777,6 +781,7 @@ async def office_update(request: Request, office_id: int):
         "district_ignore": (form.get("district_mode") or "column") == "no_district",
         "district_at_large": (form.get("district_mode") or "column") == "at_large",
         "ignore_non_links": form.get("ignore_non_links") == "1",
+        "remove_duplicates": form.get("remove_duplicates") == "1",
     }
     tc_ids = form.getlist("tc_id")
     tc_table_nos = form.getlist("tc_table_no")
@@ -926,6 +931,7 @@ async def office_duplicate(office_id: int):
         "party_ignore": bool(office.get("party_ignore")),
         "district_ignore": bool(office.get("district_ignore")),
         "ignore_non_links": bool(office.get("ignore_non_links")),
+        "remove_duplicates": bool(office.get("remove_duplicates")),
         "district_at_large": bool(office.get("district_at_large")),
     }
     table_configs = office.get("table_configs")
@@ -2594,6 +2600,7 @@ def _export_job_worker(job_id: str, office_name: str, config: dict):
             "district_ignore": _config_bool_export(config.get("district_ignore")),
             "district_at_large": _config_bool_export(config.get("district_at_large")),
             "ignore_non_links": _config_bool_export(config.get("ignore_non_links")),
+            "remove_duplicates": _config_bool_export(config.get("remove_duplicates")),
             "country_name": "", "level_name": "", "branch_name": "", "state_name": "",
         }
         full_rows = parse_full_table_for_export(office_row, table_html, url, progress_callback=progress_callback)
@@ -2914,6 +2921,7 @@ async def api_office_debug_export(request: Request):
                 "party_ignore": _config_bool(config.get("party_ignore")),
                 "district_ignore": _config_bool(config.get("district_ignore")),
                 "district_at_large": _config_bool(config.get("district_at_large")),
+                "remove_duplicates": _config_bool(config.get("remove_duplicates")),
                 "country_name": "", "level_name": "", "branch_name": "", "state_name": "",
             }
             full_rows = parse_full_table_for_export(office_row, table_html, office_row["url"])

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -55,6 +55,8 @@ def parse_full_table_for_export(
         cached_table_html=table_html, progress_callback=progress_callback,
     )
     years_only = bool(office_row.get("years_only"))
+    if bool(office_row.get("remove_duplicates")):
+        table_data = _dedupe_parsed_rows(table_data, years_only=years_only)
     rows_out = []
     for row in table_data:
         normalized = _normalize_row_for_import(row, years_only=years_only, include_no_link=True)
@@ -233,6 +235,30 @@ def _holder_keys_from_parsed_rows(
             end_key = (term_end_val if term_end_val is not None else "") or (str(term_end_year) if term_end_year is not None else "")
         keys.add((wiki_url, start_key, end_key))
     return keys
+
+
+def _dedupe_parsed_rows(table_data: list[dict], years_only: bool) -> list[dict]:
+    """Remove duplicate parsed rows by (wiki link, term start, term end, party, district).
+    Uses normalized term values so the behavior matches the DB-write path."""
+    seen: set[tuple[str, str, str, str, str]] = set()
+    out: list[dict] = []
+    for row in table_data:
+        normalized = _normalize_row_for_import(row, years_only=years_only)
+        if normalized is None and (row.get("Wiki Link") or "") in ("", "No link") and row.get("_name_from_table"):
+            normalized = _normalize_row_for_import(row, years_only=years_only, include_no_link=True)
+        if normalized is None:
+            out.append(row)
+            continue
+        _, term_start_val, term_end_val, _ts_imp, _te_imp, term_start_year, term_end_year = normalized
+        wiki_link = row.get("Wiki Link") or ""
+        term_start_key = term_start_val if term_start_val is not None else (str(term_start_year) if term_start_year is not None else "")
+        term_end_key = term_end_val if term_end_val is not None else (str(term_end_year) if term_end_year is not None else "")
+        key = (wiki_link, term_start_key, term_end_key, (row.get("Party") or ""), (row.get("District") or ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(row)
+    return out
 
 
 def run_with_db(
@@ -629,6 +655,8 @@ def run_with_db(
         )
         if max_rows_per_table is not None and max_rows_per_table >= 0:
             table_data = table_data[: max_rows_per_table]
+        if bool(office_row.get("remove_duplicates")):
+            table_data = _dedupe_parsed_rows(table_data, years_only=bool(office_row.get("years_only")))
 
         if has_existing and len(table_data) == 0:
             logger.log(f"Repopulate validation failed for {office_name}: table parsed to zero rows (existing had {len(existing_terms)}). Keeping existing terms.", True)
@@ -1102,6 +1130,8 @@ def preview_with_config(
             cached_table_html=cached_table_html, progress_callback=progress_callback,
             max_rows=max_rows,
         )
+        if bool(office_row.get("remove_duplicates")):
+            table_data = _dedupe_parsed_rows(table_data, years_only=bool(office_row.get("years_only")))
     except Exception as e:
         raw_max = max_rows if max_rows is not None else 100
         raw = get_raw_table_preview(url, int(office_row.get("table_no") or 1), raw_max)

--- a/src/templates/page_form.html
+++ b/src/templates/page_form.html
@@ -158,7 +158,7 @@
       </div>
       <div class="form-group checkbox-group"><label><input type="checkbox" name="alt_link_include_main" value="1" {% if o.alt_link_include_main %}checked{% endif %}> Include main office link in search</label></div>
       <h3>Table parsing</h3>
-      {% set tclist = o.table_configs if o.table_configs and o.table_configs|length > 0 else [{'id': none, 'name': '', 'table_no': o.table_no or 1, 'table_rows': o.table_rows or 4, 'link_column': o.link_column or 1, 'party_column': o.party_column or 0, 'term_start_column': o.term_start_column or 4, 'term_end_column': o.term_end_column or 5, 'district_column': o.district_column or 0, 'dynamic_parse': o.dynamic_parse, 'read_right_to_left': o.read_right_to_left, 'find_date_in_infobox': o.find_date_in_infobox, 'years_only': o.years_only, 'parse_rowspan': o.parse_rowspan, 'consolidate_rowspan_terms': o.consolidate_rowspan_terms, 'rep_link': o.rep_link, 'party_link': o.party_link, 'enabled': o.enabled, 'use_full_page_for_table': o.use_full_page_for_table, 'term_dates_merged': o.term_dates_merged, 'party_ignore': o.party_ignore, 'district_ignore': o.district_ignore, 'district_at_large': o.district_at_large, 'ignore_non_links': o.ignore_non_links, 'notes': o.notes or ''}] %}
+      {% set tclist = o.table_configs if o.table_configs and o.table_configs|length > 0 else [{'id': none, 'name': '', 'table_no': o.table_no or 1, 'table_rows': o.table_rows or 4, 'link_column': o.link_column or 1, 'party_column': o.party_column or 0, 'term_start_column': o.term_start_column or 4, 'term_end_column': o.term_end_column or 5, 'district_column': o.district_column or 0, 'dynamic_parse': o.dynamic_parse, 'read_right_to_left': o.read_right_to_left, 'find_date_in_infobox': o.find_date_in_infobox, 'years_only': o.years_only, 'parse_rowspan': o.parse_rowspan, 'consolidate_rowspan_terms': o.consolidate_rowspan_terms, 'rep_link': o.rep_link, 'party_link': o.party_link, 'enabled': o.enabled, 'use_full_page_for_table': o.use_full_page_for_table, 'term_dates_merged': o.term_dates_merged, 'party_ignore': o.party_ignore, 'district_ignore': o.district_ignore, 'district_at_large': o.district_at_large, 'ignore_non_links': o.ignore_non_links, 'remove_duplicates': o.remove_duplicates, 'notes': o.notes or ''}] %}
       <div class="table-config-blocks" data-office-id="{{ o.id }}">
       {% for tc in tclist %}
       <div class="table-config-block" id="section-table-{{ tc.id if tc.id else (o.id ~ '-t' ~ loop.index) }}" data-office-id="{{ o.id }}" data-tc-id="{{ tc.id or '' }}" style="margin-bottom:1.5rem; padding:1rem; border:1px solid var(--border, #ccc); border-radius:6px;">
@@ -180,6 +180,7 @@
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_term_dates_merged_{{ loop.index0 }}" value="1" {% if tc.term_dates_merged %}checked{% endif %}> Term dates merged</label></div>
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_party_ignore" value="1" {% if tc.party_ignore %}checked{% endif %}> Ignore party</label></div>
           <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_ignore_non_links" value="1" {% if tc.ignore_non_links %}checked{% endif %}> Ignore non-links</label></div>
+          <div class="form-group checkbox-group"><label><input type="checkbox" name="tc_remove_duplicates" value="1" {% if tc.remove_duplicates %}checked{% endif %}> Remove duplicates</label></div>
           <div class="form-group">
             <label>District</label>
             <select name="tc_district_mode">
@@ -368,6 +369,7 @@
     <div class="form-group checkbox-group">
       <label><input type="checkbox" name="party_ignore" value="1" id="partyIgnore" {% if office and office.party_ignore %}checked{% endif %}> Ignore party</label>
       <label><input type="checkbox" name="ignore_non_links" value="1" id="ignoreNonLinks" {% if office and office.ignore_non_links %}checked{% endif %}> Ignore non-links</label>
+      <label><input type="checkbox" name="remove_duplicates" value="1" {% if office and office.remove_duplicates %}checked{% endif %}> Remove duplicates</label>
       <p class="form-note">Do not extract party; store null. Party column is grayed out — do not enter.</p>
     </div>
     <div class="form-group" id="districtModeGroup">
@@ -789,6 +791,7 @@
       term_dates_merged: !!form.term_dates_merged?.checked,
       party_ignore: !!form.party_ignore?.checked,
       ignore_non_links: !!form.ignore_non_links?.checked,
+      remove_duplicates: !!form.remove_duplicates?.checked,
       district_ignore: (form.district_mode?.value || 'column') === 'no_district',
       district_at_large: (form.district_mode?.value || 'column') === 'at_large'
     };
@@ -853,6 +856,7 @@
       term_dates_merged: elChecked('term_dates_merged', 'tc_term_dates_merged'),
       party_ignore: elChecked('party_ignore', 'tc_party_ignore'),
       ignore_non_links: elChecked('ignore_non_links', 'tc_ignore_non_links'),
+      remove_duplicates: elChecked('remove_duplicates', 'tc_remove_duplicates'),
       district_ignore: distMode() === 'no_district',
       district_at_large: distMode() === 'at_large'
     };


### PR DESCRIPTION
### Motivation
- Provide a per-table boolean config `remove_duplicates` to remove duplicate parsed rows before DB insert by comparing wiki link, term start, term end, party, and district.
- Ensure preview/debug export behavior matches run behavior when duplicates are filtered so users see the same rows that will be persisted.

### Description
- Added `remove_duplicates` column to `office_table_config` and legacy `offices` schema and included a migration helper `_migrate_remove_duplicates` that adds the column when missing. (`src/db/schema.py`, `src/db/migrate.py`).
- Wired `remove_duplicates` through the server form/draft and CRUD paths so it is saved, loaded, and exposed to the scraper as part of `office_row_to_table_config` and draft builders. (`src/main.py`, `src/db/offices.py`, `src/templates/page_form.html`).
- Implemented `_dedupe_parsed_rows` in `src/scraper/runner.py` which normalizes rows (same logic as DB write path) and deduplicates by `(wiki link, term start, term end, party, district)`.
- Apply deduplication when `remove_duplicates` is enabled in the main run path, preview path, and debug export path so preview/export/run are consistent (`src/scraper/runner.py`).

### Testing
- Ran `python -m py_compile src/main.py src/db/offices.py src/db/migrate.py src/scraper/runner.py` and compilation succeeded. (passed)
- Ran targeted unit tests with `PYTHONPATH=. pytest -q src/scraper/test_dynamic_parse_bounds.py` which passed (`8 passed`).
- Ran full `pytest -q` which reported a pre-existing test collection error unrelated to this change (`src/scraper/config_test.py::test_office_config` missing fixture `office_row`), so full test-suite run was not green.
- Started the app with `uvicorn src.main:app` and captured a screenshot of the updated config UI to validate the new checkboxes (artifact included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699902849da483288e1312de35b730e8)