### PR TITLE
Support strict quoted multi-term infobox role key queries

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,7 @@ from src.scraper.runner import run_with_db, preview_with_config, parse_full_tabl
 from src.scraper.config_test import test_office_config, get_raw_table_preview, get_all_tables_preview, get_table_html, get_table_header_from_html
 from src.scraper.test_script_runner import run_test_script, run_test_script_from_html
 from src.scraper.wiki_fetch import WIKIPEDIA_REQUEST_HEADERS, wiki_url_to_rest_html_url, normalize_wiki_url
+from src.scraper.table_parser import parse_infobox_role_key_query
 
 app = FastAPI(title="Office Holder")
 # Resolve to absolute path so template dir is correct regardless of process cwd
@@ -111,7 +112,7 @@ def _office_draft_from_body(body: dict, *, include_ref_names: bool = False) -> d
         "district_at_large": district_at_large,
         "ignore_non_links": body.get("ignore_non_links") in (True, 1, "1", "true", "TRUE"),
         "remove_duplicates": body.get("remove_duplicates") in (True, 1, "1", "true", "TRUE"),
-        "infobox_role_key": (body.get("infobox_role_key") or "").strip(),
+        "infobox_role_key": _validate_infobox_role_key(body.get("infobox_role_key")),
     }
     if include_ref_names:
         country_id = int(body.get("country_id") or 0)
@@ -174,6 +175,13 @@ def _list_return_query(
     if office_count is not None and str(office_count).strip() and str(office_count).strip() != "all":
         parts.append("office_count=" + str(office_count).strip())
     return "&".join(parts)
+
+
+def _validate_infobox_role_key(role_key: str | None) -> str:
+    """Normalize and validate strict quoted infobox role key syntax."""
+    cleaned = (role_key or "").strip()
+    parse_infobox_role_key_query(cleaned)
+    return cleaned
 
 
 def _parse_optional_int(value: str | None) -> int | None:
@@ -330,7 +338,7 @@ async def office_create(request: Request):
         "district_at_large": (form.get("district_mode") or "column") == "at_large",
         "ignore_non_links": form.get("ignore_non_links") == "1",
         "remove_duplicates": form.get("remove_duplicates") == "1",
-        "infobox_role_key": (form.get("infobox_role_key") or "").strip(),
+        "infobox_role_key": _validate_infobox_role_key(form.get("infobox_role_key")),
     }
     try:
         _validate_level_state_city(data.get("level_id"), data.get("state_id"), data.get("city_id"), data.get("branch_id"))
@@ -750,7 +758,7 @@ def _form_to_table_config(form, i: int) -> dict:
         "remove_duplicates": _bool("remove_duplicates", "tc_remove_duplicates"),
         "notes": _get("notes", "tc_notes") or "",
         "name": _get("name", "tc_name") or "",
-        "infobox_role_key": (_get("infobox_role_key", "tc_infobox_role_key") or "").strip(),
+        "infobox_role_key": _validate_infobox_role_key(_get("infobox_role_key", "tc_infobox_role_key")),
     }
 
 
@@ -788,7 +796,7 @@ async def office_update(request: Request, office_id: int):
         "district_at_large": (form.get("district_mode") or "column") == "at_large",
         "ignore_non_links": form.get("ignore_non_links") == "1",
         "remove_duplicates": form.get("remove_duplicates") == "1",
-        "infobox_role_key": (form.get("infobox_role_key") or "").strip(),
+        "infobox_role_key": _validate_infobox_role_key(form.get("infobox_role_key")),
     }
     tc_ids = form.getlist("tc_id")
     tc_table_nos = form.getlist("tc_table_no")
@@ -1095,7 +1103,7 @@ async def api_office_set_infobox_role_key(office_id: int, request: Request):
         available = [{"table_config_id": tc.get("id"), "table_no": tc.get("table_no")} for tc in tcs]
         raise HTTPException(status_code=400, detail={"message": "Provide table_no or table_config_id", "available_tables": available})
 
-    role_key = ((body or {}).get("infobox_role_key") or "").strip()
+    role_key = _validate_infobox_role_key((body or {}).get("infobox_role_key"))
     updated = db_offices.set_infobox_role_key(office_id, table_no, role_key)
     if not updated:
         available = [{"table_config_id": tc.get("id"), "table_no": tc.get("table_no")} for tc in tcs]
@@ -1157,7 +1165,7 @@ async def api_table_config_set_infobox_role_key(table_config_id: int, request: R
         body = await request.json()
     except Exception:
         body = {}
-    role_key = ((body or {}).get("infobox_role_key") or "").strip()
+    role_key = _validate_infobox_role_key((body or {}).get("infobox_role_key"))
     updated = db_offices.set_infobox_role_key_by_table_config_id(table_config_id, role_key)
     if not updated:
         raise HTTPException(status_code=404, detail=f"Table config {table_config_id} not found")

--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -47,6 +47,54 @@ def _dates_from_cell_data_sort_value(cell):
   return (vals[0], vals[-1])
 
 
+def parse_infobox_role_key_query(raw_query: str) -> tuple[list[str], list[str]]:
+  """Parse infobox role query into (includes, excludes) with strict quoting.
+
+  Accepted examples:
+  - "judge"
+  - "judge" "associate justice" -"chief judge" -"senior judge"
+  """
+  expr = (raw_query or "").strip()
+  if not expr:
+    return ([], [])
+
+  includes: list[str] = []
+  excludes: list[str] = []
+  pos = 0
+  n = len(expr)
+
+  def _normalize_role_text(text: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", (text or "").lower())).strip()
+
+  while pos < n:
+    while pos < n and expr[pos].isspace():
+      pos += 1
+    if pos >= n:
+      break
+    neg = False
+    if expr[pos] == "-":
+      neg = True
+      pos += 1
+      if pos >= n:
+        raise ValueError("Invalid infobox role key: trailing '-' must be followed by a quoted term.")
+    if expr[pos] != '"':
+      raise ValueError("Invalid infobox role key: every term must be quoted (use -\"term\" for excludes).")
+    pos += 1
+    end = expr.find('"', pos)
+    if end == -1:
+      raise ValueError("Invalid infobox role key: unclosed quoted term.")
+    term = _normalize_role_text(expr[pos:end])
+    if not term:
+      raise ValueError("Invalid infobox role key: empty quoted terms are not allowed.")
+    if neg:
+      excludes.append(term)
+    else:
+      includes.append(term)
+    pos = end + 1
+
+  return (includes, excludes)
+
+
 def _emit_merged_run(run, years_only, out):
   """Merge a run of consecutive term rows into one row; append to out."""
   # #region agent log
@@ -1658,23 +1706,7 @@ class Biography:
                       # `hay` and `phrase` are already normalized to lowercase words/spaces.
                       return re.search(r"(^|\s)" + re.escape(phrase) + r"(\s|$)", hay) is not None
 
-                  def _parse_role_query(expr: str) -> tuple[list[str], list[str]]:
-                      includes: list[str] = []
-                      excludes: list[str] = []
-                      # Supports terms like: judge -"chief judge" -"senior judge"
-                      for m in re.finditer(r'(-?)"([^"]+)"|(-?)(\S+)', expr or ""):
-                          neg = bool((m.group(1) or m.group(3) or "").strip())
-                          raw = (m.group(2) or m.group(4) or "").strip()
-                          term = _normalize_role_text(raw)
-                          if not term:
-                              continue
-                          if neg:
-                              excludes.append(term)
-                          else:
-                              includes.append(term)
-                      return includes, excludes
-
-                  role_includes, role_excludes = _parse_role_query(role_key)
+                  role_includes, role_excludes = parse_infobox_role_key_query(role_key_raw)
 
                   def _role_matches(text: str) -> bool:
                       if not role_key:
@@ -1682,12 +1714,8 @@ class Biography:
                       hay = _normalize_role_text(text)
                       if not hay:
                           return False
-                      if not role_includes and not role_excludes:
-                          needle = _normalize_role_text(role_key)
-                          return _contains_phrase(hay, needle) if needle else True
-                      for inc in role_includes:
-                          if not _contains_phrase(hay, inc):
-                              return False
+                      if role_includes and not any(_contains_phrase(hay, inc) for inc in role_includes):
+                          return False
                       for exc in role_excludes:
                           if _contains_phrase(hay, exc):
                               return False

--- a/src/scraper/test_infobox_role_key.py
+++ b/src/scraper/test_infobox_role_key.py
@@ -1,5 +1,7 @@
+import pytest
+
 from src.scraper.logger import Logger
-from src.scraper.table_parser import Biography, DataCleanup
+from src.scraper.table_parser import Biography, DataCleanup, parse_infobox_role_key_query
 
 
 class _Resp:
@@ -44,6 +46,8 @@ def _build_infobox_html_with_all_three_roles() -> str:
       <tr><td><b>In office</b><br>January 1, 1990 – January 1, 2000</td></tr>
       <tr><th>Judge of the <a href="/wiki/District_Court_for_the_Northern_Mariana_Islands">District Court</a></th></tr>
       <tr><td><b>In office</b><br>January 1, 1980 – January 1, 1990</td></tr>
+      <tr><th>Associate Justice of the <a href="/wiki/District_Court_for_the_Northern_Mariana_Islands">District Court</a></th></tr>
+      <tr><td><b>In office</b><br>January 1, 1970 – January 1, 1980</td></tr>
     </table>
     """
 
@@ -65,7 +69,7 @@ def test_find_term_dates_filters_by_infobox_role_key(monkeypatch):
             "rep_link": False,
             "alt_links": ["/wiki/District_Court_for_the_Northern_Mariana_Islands"],
             "alt_link_include_main": False,
-            "infobox_role_key": "senior judge",
+            "infobox_role_key": "\"senior judge\"",
         },
         {"office_state": ""},
         "",
@@ -116,7 +120,7 @@ def test_find_term_dates_role_key_matches_when_first_link_is_not_office(monkeypa
             "rep_link": False,
             "alt_links": ["/wiki/District_Court_for_the_Northern_Mariana_Islands"],
             "alt_link_include_main": False,
-            "infobox_role_key": "senior judge",
+            "infobox_role_key": "\"senior judge\"",
         },
         {"office_state": ""},
         "",
@@ -142,10 +146,20 @@ def test_find_term_dates_role_key_supports_excludes(monkeypatch):
             "rep_link": False,
             "alt_links": ["/wiki/District_Court_for_the_Northern_Mariana_Islands"],
             "alt_link_include_main": False,
-            "infobox_role_key": 'judge -"chief judge" -"senior judge"',
+            "infobox_role_key": '"judge" "associate justice" -"chief judge" -"senior judge"',
         },
         {"office_state": ""},
         "",
     )
 
-    assert terms == [("1980-01-01", "1990-01-01")]
+    assert terms == [("1980-01-01", "1990-01-01"), ("1970-01-01", "1980-01-01")]
+
+
+def test_infobox_role_key_requires_quoted_terms():
+    with pytest.raises(ValueError):
+        parse_infobox_role_key_query('judge -"chief judge"')
+
+
+def test_infobox_role_key_rejects_unclosed_quotes():
+    with pytest.raises(ValueError):
+        parse_infobox_role_key_query('"judge" -"chief judge')


### PR DESCRIPTION
### Motivation

- Allow users to specify multiple include/exclude role phrases for infobox matching (e.g. `"judge" "associate justice" -"chief judge" -"senior judge"`) and require explicit quoting so terms are unambiguous. 

### Description

- Added `parse_infobox_role_key_query` to `src/scraper/table_parser.py` to parse strict quoted include/exclude terms and raise `ValueError` for malformed expressions (unquoted terms, trailing `-`, unclosed quotes, empty quoted terms). 
- Changed infobox matching to treat multiple include terms as OR (matches if any include hits) and apply excludes as blocking filters. 
- Wired validation into save/creation/API paths by adding `_validate_infobox_role_key` in `src/main.py` and using it when building drafts, saving/updating offices, and in the infobox-role-key API endpoints. 
- Updated tests in `src/scraper/test_infobox_role_key.py` to cover multi-key includes, excludes, and invalid syntax cases and adjusted sample infobox HTML used in tests.

### Testing

- Ran the focused unit tests with `PYTHONPATH=. pytest -q src/scraper/test_infobox_role_key.py`, which completed successfully: `6 passed, 4 warnings`.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b339ac9748328b1ccd474c9d2373b)