### PR TITLE
Add alternative link inputs to Test Scripts table-config

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2109,7 +2109,15 @@ async def api_test_script_template_page_details(source_page_id: int):
                     "infobox_role_key": (tc.get("infobox_role_key") or "").strip(),
                 }
             )
-        office_rows.append({"id": office.get("id"), "name": office.get("name") or "", "table_configs": table_configs})
+        office_rows.append(
+            {
+                "id": office.get("id"),
+                "name": office.get("name") or "",
+                "alt_links": db_offices.list_alt_links(int(office.get("id") or 0)),
+                "alt_link_include_main": bool(office.get("alt_link_include_main")),
+                "table_configs": table_configs,
+            }
+        )
     return JSONResponse({"ok": True, "page": {"id": page.get("id"), "url": page.get("url") or ""}, "offices": office_rows})
 
 

--- a/src/templates/test_scripts.html
+++ b/src/templates/test_scripts.html
@@ -112,6 +112,17 @@
       <div class="form-group checkbox-group"><label><input type="checkbox" id="party_link"> Party link</label></div>
       <div class="form-group checkbox-group"><label><input type="checkbox" id="use_full_page_for_table"> Use full page for table fetch</label></div>
     </div>
+
+    <div class="form-row">
+      <div class="form-group" style="min-width:360px;">
+        <label>Alternative links for search (optional)</label>
+        <textarea id="alt_links" rows="3" placeholder="/wiki/Some_Office\n/wiki/Another_Office"></textarea>
+        <div class="form-note">Enter one link per line (or comma-separated). Used when finding dates in member pages.</div>
+      </div>
+      <div class="form-group checkbox-group" style="align-self:center;">
+        <label><input type="checkbox" id="alt_link_include_main"> Include main page link in search</label>
+      </div>
+    </div>
   </div>
 
   <div class="form-group">
@@ -189,6 +200,10 @@ function n(id, fallback) {
 function buildConfig() {
   const districtMode = document.getElementById('district_mode').value;
   const dateSource = document.getElementById('date_source').value;
+  const altLinks = (document.getElementById('alt_links').value || '')
+    .split(/[\n,]/)
+    .map((v) => v.trim())
+    .filter(Boolean);
   const base = {
     name: (document.getElementById('table_name').value || '').trim(),
     table_no: n('table_no', 1),
@@ -214,6 +229,8 @@ function buildConfig() {
     party_link: document.getElementById('party_link').checked,
     use_full_page_for_table: document.getElementById('use_full_page_for_table').checked,
     infobox_role_key: (document.getElementById('infobox_role_key').value || "").trim(),
+    alt_links: altLinks,
+    alt_link_include_main: document.getElementById('alt_link_include_main').checked,
   };
   return {...base, ...preservedConfigExtras};
 }
@@ -380,6 +397,9 @@ function applySelectedOfficeTemplate() {
   document.getElementById('party_link').checked = !!tc.party_link;
   document.getElementById('use_full_page_for_table').checked = !!tc.use_full_page_for_table;
   document.getElementById('infobox_role_key').value = tc.infobox_role_key || '';
+  const officeAltLinks = Array.isArray(office.alt_links) ? office.alt_links : [];
+  document.getElementById('alt_links').value = officeAltLinks.join('\n');
+  document.getElementById('alt_link_include_main').checked = !!office.alt_link_include_main;
   syncTableConfigControls();
   setOfficeTemplateMessage('Copied template values into the form. This test script remains independent from office configs.');
 }
@@ -481,6 +501,9 @@ async function editOne(id) {
     document.getElementById('party_link').checked = !!c.party_link;
     document.getElementById('use_full_page_for_table').checked = !!c.use_full_page_for_table;
     document.getElementById('infobox_role_key').value = c.infobox_role_key || '';
+    const testAltLinks = Array.isArray(c.alt_links) ? c.alt_links : [];
+    document.getElementById('alt_links').value = testAltLinks.join('\n');
+    document.getElementById('alt_link_include_main').checked = !!c.alt_link_include_main;
 
     document.getElementById('expected_json').value = t.expected_json ? JSON.stringify(t.expected_json, null, 2) : '';
     document.getElementById('editModeName').textContent = `${t.name || ''} (#${t.id})`;


### PR DESCRIPTION
### Motivation
- Tests that search member pages need a way to supply fallback Wikipedia links so the parser can find member infoboxes or dates when the main page link is insufficient.
- The test-script UI currently had no input for `alt_links` or `alt_link_include_main`, preventing users from providing these search aids when building `config_json` for previews and saved tests.

### Description
- Added a multiline `alt_links` textarea and an `alt_link_include_main` checkbox to the Test Scripts table-config form in `src/templates/test_scripts.html` so users can enter one link per line or comma-separated values.
- Wired the new inputs into `buildConfig()` so `alt_links` and `alt_link_include_main` are included in the produced `config_json` used by preview/save flows.
- Restored these fields when editing a saved test and when copying an office template into the test form (UI reads `config_json.alt_links` and `config_json.alt_link_include_main`).
- Extended the office-template details API payload in `src/main.py` to include office-level `alt_links` and `alt_link_include_main` so the template-copy UI can populate the new inputs.

### Testing
- Ran `python -m compileall src` and the code compiled without errors.
- Started the app with `python -m uvicorn src.main:app` and exercised the `/test-scripts` page via an automated Playwright script that opened the page and captured a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b39eb5dd48328a4b1103bce74cd70)