### PR TITLE
Restructure run status progress into nested office/table/infobox/bio buckets

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2341,10 +2341,46 @@ def _run_job_worker(
     individual_id_list: list[int] | None = None,
     force_overwrite: bool = False,
 ):
+    def _default_run_progress() -> dict:
+        return {
+            "office": {"current": 0, "total": 1, "message": "Starting…"},
+            "table": {"current": 0, "total": 0, "message": ""},
+            "infobox": {"current": 0, "total": 0, "message": ""},
+            "bio": {"current": 0, "total": 0, "message": ""},
+        }
+
+    def _phase_bucket(phase: str) -> str:
+        p = (phase or "").strip().lower()
+        if p in ("bio", "living"):
+            return "bio"
+        if p == "infobox":
+            return "infobox"
+        if p == "table":
+            return "table"
+        return "office"
+
     def progress_callback(phase: str, current: int, total: int, message: str, extra: dict):
         with _run_job_lock:
             if job_id in _run_job_store:
-                _run_job_store[job_id].update({
+                job = _run_job_store[job_id]
+                progress = job.get("progress")
+                if not isinstance(progress, dict):
+                    progress = _default_run_progress()
+                for bucket_name, defaults in _default_run_progress().items():
+                    bucket = progress.get(bucket_name)
+                    if not isinstance(bucket, dict):
+                        progress[bucket_name] = dict(defaults)
+                bucket_name = _phase_bucket(phase)
+                bucket = progress[bucket_name]
+                bucket.update({
+                    "current": current,
+                    "total": total,
+                    "message": message,
+                })
+                job["progress"] = progress
+
+                # Legacy top-level fields for existing polling clients.
+                job.update({
                     "phase": phase,
                     "current": current,
                     "total": total,
@@ -2447,6 +2483,12 @@ async def api_run(
     with _run_job_lock:
         _run_job_store[job_id] = {
             "status": "running",
+            "progress": {
+                "office": {"current": 0, "total": 1, "message": "Starting…"},
+                "table": {"current": 0, "total": 0, "message": ""},
+                "infobox": {"current": 0, "total": 0, "message": ""},
+                "bio": {"current": 0, "total": 0, "message": ""},
+            },
             "phase": "init",
             "current": 0,
             "total": 1,


### PR DESCRIPTION
### Motivation
- Make `/api/run/status/{job_id}` provide richer, structured progress so UI and API consumers can observe separate office/table/infobox/bio progress buckets instead of a single flat phase payload.
- Ensure progress updates from the scraper merge into the appropriate bucket rather than overwriting a global phase/current/total state.
- Preserve compatibility for existing polling clients by continuing to populate legacy top-level `phase/current/total/message` fields during migration.

### Description
- Added a nested `progress` object initialized on job start with buckets `office`, `table`, `infobox`, and `bio`, each containing `{current, total, message}`. (see `api_run` job initialization in `src/main.py`).
- Implemented `_default_run_progress()` and `_phase_bucket()` helpers and changed `_run_job_worker`'s `progress_callback` to merge incoming updates into the correct bucket instead of replacing global fields. (see `progress_callback` in `src/main.py`).
- Added defensive normalization to repair or create the `progress` structure if missing or malformed so older jobs do not break.
- Kept backward compatibility by still updating legacy top-level `phase`, `current`, `total`, `message`, and `extra` on each callback update for existing clients.

### Testing
- Compiled the modified module with `python -m py_compile src/main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b56a2f2a0832895a63b5bf91556a8)