### PR TITLE
Add infobox role key filter reference data management

### DIFF
--- a/src/db/infobox_role_key_filter.py
+++ b/src/db/infobox_role_key_filter.py
@@ -1,0 +1,210 @@
+"""Infobox role key filters, scoped by country/level/branch."""
+
+import sqlite3
+from typing import Any
+
+from .connection import get_connection
+from .utils import _row_to_dict
+
+
+def list_infobox_role_key_filters(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
+    """Return all infobox role key filters."""
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        cur = conn.execute("SELECT id, name, role_key FROM infobox_role_key_filter ORDER BY name")
+        return [_row_to_dict(r) for r in cur.fetchall()]
+    finally:
+        if own:
+            conn.close()
+
+
+def get_infobox_role_key_filter(filter_id: int, conn: sqlite3.Connection | None = None) -> dict[str, Any] | None:
+    """Return filter dict with scope ids. None if not found."""
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, name, role_key FROM infobox_role_key_filter WHERE id = ?", (filter_id,)
+        ).fetchone()
+        if not row:
+            return None
+        d = _row_to_dict(row)
+        d["country_ids"] = [
+            r[0]
+            for r in conn.execute(
+                "SELECT country_id FROM infobox_role_key_filter_countries WHERE filter_id = ?", (filter_id,)
+            ).fetchall()
+        ]
+        d["level_ids"] = [
+            r[0]
+            for r in conn.execute(
+                "SELECT level_id FROM infobox_role_key_filter_levels WHERE filter_id = ?", (filter_id,)
+            ).fetchall()
+        ]
+        d["branch_ids"] = [
+            r[0]
+            for r in conn.execute(
+                "SELECT branch_id FROM infobox_role_key_filter_branches WHERE filter_id = ?", (filter_id,)
+            ).fetchall()
+        ]
+        return d
+    finally:
+        if own:
+            conn.close()
+
+
+def create_infobox_role_key_filter(
+    name: str,
+    role_key: str,
+    country_ids: list[int],
+    level_ids: list[int],
+    branch_ids: list[int],
+    conn: sqlite3.Connection | None = None,
+) -> int:
+    """Insert filter and scope rows. Empty scope list = all."""
+    name = (name or "").strip()
+    role_key = (role_key or "").strip()
+    if not name:
+        raise ValueError("Filter name is required")
+    if not role_key:
+        raise ValueError("Role key is required")
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        conn.execute("INSERT INTO infobox_role_key_filter (name, role_key) VALUES (?, ?)", (name, role_key))
+        filter_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        for cid in country_ids:
+            if cid:
+                conn.execute(
+                    "INSERT INTO infobox_role_key_filter_countries (filter_id, country_id) VALUES (?, ?)",
+                    (filter_id, cid),
+                )
+        for lid in level_ids:
+            if lid:
+                conn.execute(
+                    "INSERT INTO infobox_role_key_filter_levels (filter_id, level_id) VALUES (?, ?)",
+                    (filter_id, lid),
+                )
+        for bid in branch_ids:
+            if bid:
+                conn.execute(
+                    "INSERT INTO infobox_role_key_filter_branches (filter_id, branch_id) VALUES (?, ?)",
+                    (filter_id, bid),
+                )
+        conn.commit()
+        return filter_id
+    except sqlite3.IntegrityError as e:
+        if "UNIQUE" in str(e):
+            raise ValueError("A filter with this name already exists") from e
+        raise
+    finally:
+        if own:
+            conn.close()
+
+
+def update_infobox_role_key_filter(
+    filter_id: int,
+    name: str,
+    role_key: str,
+    country_ids: list[int],
+    level_ids: list[int],
+    branch_ids: list[int],
+    conn: sqlite3.Connection | None = None,
+) -> bool:
+    """Update filter and replace scope rows."""
+    name = (name or "").strip()
+    role_key = (role_key or "").strip()
+    if not name:
+        raise ValueError("Filter name is required")
+    if not role_key:
+        raise ValueError("Role key is required")
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        cur = conn.execute(
+            "UPDATE infobox_role_key_filter SET name = ?, role_key = ? WHERE id = ?",
+            (name, role_key, filter_id),
+        )
+        if cur.rowcount == 0:
+            return False
+        conn.execute("DELETE FROM infobox_role_key_filter_countries WHERE filter_id = ?", (filter_id,))
+        conn.execute("DELETE FROM infobox_role_key_filter_levels WHERE filter_id = ?", (filter_id,))
+        conn.execute("DELETE FROM infobox_role_key_filter_branches WHERE filter_id = ?", (filter_id,))
+        for cid in country_ids:
+            if cid:
+                conn.execute(
+                    "INSERT INTO infobox_role_key_filter_countries (filter_id, country_id) VALUES (?, ?)",
+                    (filter_id, cid),
+                )
+        for lid in level_ids:
+            if lid:
+                conn.execute(
+                    "INSERT INTO infobox_role_key_filter_levels (filter_id, level_id) VALUES (?, ?)",
+                    (filter_id, lid),
+                )
+        for bid in branch_ids:
+            if bid:
+                conn.execute(
+                    "INSERT INTO infobox_role_key_filter_branches (filter_id, branch_id) VALUES (?, ?)",
+                    (filter_id, bid),
+                )
+        conn.commit()
+        return True
+    except sqlite3.IntegrityError as e:
+        if "UNIQUE" in str(e):
+            raise ValueError("A filter with this name already exists") from e
+        raise
+    finally:
+        if own:
+            conn.close()
+
+
+def delete_infobox_role_key_filter(filter_id: int, conn: sqlite3.Connection | None = None) -> None:
+    """Delete filter and scope rows."""
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        conn.execute("DELETE FROM infobox_role_key_filter_countries WHERE filter_id = ?", (filter_id,))
+        conn.execute("DELETE FROM infobox_role_key_filter_levels WHERE filter_id = ?", (filter_id,))
+        conn.execute("DELETE FROM infobox_role_key_filter_branches WHERE filter_id = ?", (filter_id,))
+        conn.execute("DELETE FROM infobox_role_key_filter WHERE id = ?", (filter_id,))
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+
+
+def list_filters_for_context(
+    country_id: int | None,
+    level_id: int | None,
+    branch_id: int | None,
+    conn: sqlite3.Connection | None = None,
+) -> list[dict[str, Any]]:
+    """Return filters valid for this context. Empty scoped list means all."""
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        where = """
+        (NOT EXISTS (SELECT 1 FROM infobox_role_key_filter_countries c WHERE c.filter_id = f.id)
+         OR (? IS NOT NULL AND EXISTS (SELECT 1 FROM infobox_role_key_filter_countries c WHERE c.filter_id = f.id AND c.country_id = ?)))
+        AND (NOT EXISTS (SELECT 1 FROM infobox_role_key_filter_levels l WHERE l.filter_id = f.id)
+         OR (? IS NOT NULL AND EXISTS (SELECT 1 FROM infobox_role_key_filter_levels l WHERE l.filter_id = f.id AND l.level_id = ?)))
+        AND (NOT EXISTS (SELECT 1 FROM infobox_role_key_filter_branches b WHERE b.filter_id = f.id)
+         OR (? IS NOT NULL AND EXISTS (SELECT 1 FROM infobox_role_key_filter_branches b WHERE b.filter_id = f.id AND b.branch_id = ?)))
+        """
+        params: list[Any] = [country_id, country_id, level_id, level_id, branch_id, branch_id]
+        cur = conn.execute(
+            f"SELECT f.id, f.name, f.role_key FROM infobox_role_key_filter f WHERE {where} ORDER BY f.name",
+            params,
+        )
+        return [_row_to_dict(r) for r in cur.fetchall()]
+    finally:
+        if own:
+            conn.close()

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -71,6 +71,7 @@ def migrate_to_fk(conn=None):
         _migrate_infobox_role_key(conn)
         # office_category tables and office_details.office_category_id
         _migrate_office_category(conn)
+        _migrate_infobox_role_key_filter(conn)
         # cities table and source_pages.city_id
         _migrate_city(conn)
     finally:
@@ -649,6 +650,34 @@ def _migrate_office_category(conn):
         )
         conn.commit()
 
+
+
+
+def _migrate_infobox_role_key_filter(conn):
+    """Create infobox_role_key_filter and junction tables if missing."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS infobox_role_key_filter (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            role_key TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS infobox_role_key_filter_countries (
+            filter_id INTEGER NOT NULL REFERENCES infobox_role_key_filter(id),
+            country_id INTEGER NOT NULL REFERENCES countries(id),
+            PRIMARY KEY (filter_id, country_id)
+        );
+        CREATE TABLE IF NOT EXISTS infobox_role_key_filter_levels (
+            filter_id INTEGER NOT NULL REFERENCES infobox_role_key_filter(id),
+            level_id INTEGER NOT NULL REFERENCES levels(id),
+            PRIMARY KEY (filter_id, level_id)
+        );
+        CREATE TABLE IF NOT EXISTS infobox_role_key_filter_branches (
+            filter_id INTEGER NOT NULL REFERENCES infobox_role_key_filter(id),
+            branch_id INTEGER NOT NULL REFERENCES branches(id),
+            PRIMARY KEY (filter_id, branch_id)
+        );
+    """)
+    conn.commit()
 
 def _migrate_city(conn):
     """Create cities table if missing; add city_id to source_pages if missing."""

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -58,6 +58,28 @@ CREATE TABLE IF NOT EXISTS office_category_branches (
     PRIMARY KEY (category_id, branch_id)
 );
 
+-- Infobox role key filter: optional label per infobox role key; scoped by country/level/branch (empty = all)
+CREATE TABLE IF NOT EXISTS infobox_role_key_filter (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    role_key TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS infobox_role_key_filter_countries (
+    filter_id INTEGER NOT NULL REFERENCES infobox_role_key_filter(id),
+    country_id INTEGER NOT NULL REFERENCES countries(id),
+    PRIMARY KEY (filter_id, country_id)
+);
+CREATE TABLE IF NOT EXISTS infobox_role_key_filter_levels (
+    filter_id INTEGER NOT NULL REFERENCES infobox_role_key_filter(id),
+    level_id INTEGER NOT NULL REFERENCES levels(id),
+    PRIMARY KEY (filter_id, level_id)
+);
+CREATE TABLE IF NOT EXISTS infobox_role_key_filter_branches (
+    filter_id INTEGER NOT NULL REFERENCES infobox_role_key_filter(id),
+    branch_id INTEGER NOT NULL REFERENCES branches(id),
+    PRIMARY KEY (filter_id, branch_id)
+);
+
 -- Individuals: one row per person (keyed by Wikipedia URL)
 CREATE TABLE IF NOT EXISTS individuals (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,7 @@ from src.db import offices as db_offices
 from src.db import parties as db_parties
 from src.db import refs as db_refs
 from src.db import office_category as db_office_category
+from src.db import infobox_role_key_filter as db_infobox_role_key_filter
 from src.db import individuals as db_individuals
 from src.db import office_terms as db_office_terms
 from src.db import reports as db_reports
@@ -1930,6 +1931,125 @@ async def refs_office_category_delete(category_id: int):
     except ValueError as e:
         from urllib.parse import quote
         return RedirectResponse("/refs/office-categories?error=" + quote(str(e)), status_code=302)
+
+
+# ---------- Infobox role key filters (reference data) ----------
+@app.get("/refs/infobox-role-key-filters", response_class=HTMLResponse)
+async def refs_infobox_role_key_filters_list(request: Request):
+    saved = request.query_params.get("saved") == "1"
+    error = request.query_params.get("error") or None
+    filters = db_infobox_role_key_filter.list_infobox_role_key_filters()
+    return templates.TemplateResponse(
+        "refs_infobox_role_key_filters.html",
+        {"request": request, "filters": filters, "saved": saved, "error": error},
+    )
+
+
+@app.get("/refs/infobox-role-key-filters/new", response_class=HTMLResponse)
+async def refs_infobox_role_key_filter_new(request: Request):
+    countries = db_refs.list_countries()
+    levels = db_refs.list_levels()
+    branches = db_refs.list_branches()
+    return templates.TemplateResponse(
+        "refs_infobox_role_key_filter_form.html",
+        {"request": request, "filter_obj": None, "countries": countries, "levels": levels, "branches": branches},
+    )
+
+
+@app.post("/refs/infobox-role-key-filters/new")
+async def refs_infobox_role_key_filter_create(request: Request):
+    form = await request.form()
+    name = (form.get("name") or "").strip()
+    role_key = (form.get("role_key") or "").strip()
+    country_ids = _form_ids(form, "country_ids")
+    level_ids = _form_ids(form, "level_ids")
+    branch_ids = _form_ids(form, "branch_ids")
+    try:
+        db_infobox_role_key_filter.create_infobox_role_key_filter(name, role_key, country_ids, level_ids, branch_ids)
+        return RedirectResponse("/refs/infobox-role-key-filters?saved=1", status_code=302)
+    except ValueError as e:
+        countries = db_refs.list_countries()
+        levels = db_refs.list_levels()
+        branches = db_refs.list_branches()
+        return templates.TemplateResponse(
+            "refs_infobox_role_key_filter_form.html",
+            {
+                "request": request,
+                "filter_obj": None,
+                "countries": countries,
+                "levels": levels,
+                "branches": branches,
+                "validation_error": str(e),
+                "form_name": name,
+                "form_role_key": role_key,
+                "form_country_ids": country_ids,
+                "form_level_ids": level_ids,
+                "form_branch_ids": branch_ids,
+            },
+        )
+
+
+@app.get("/refs/infobox-role-key-filters/{filter_id}", response_class=HTMLResponse)
+async def refs_infobox_role_key_filter_edit(request: Request, filter_id: int):
+    filter_obj = db_infobox_role_key_filter.get_infobox_role_key_filter(filter_id)
+    if not filter_obj:
+        raise HTTPException(status_code=404)
+    countries = db_refs.list_countries()
+    levels = db_refs.list_levels()
+    branches = db_refs.list_branches()
+    return templates.TemplateResponse(
+        "refs_infobox_role_key_filter_form.html",
+        {"request": request, "filter_obj": filter_obj, "countries": countries, "levels": levels, "branches": branches},
+    )
+
+
+@app.post("/refs/infobox-role-key-filters/{filter_id}")
+async def refs_infobox_role_key_filter_update(request: Request, filter_id: int):
+    form = await request.form()
+    name = (form.get("name") or "").strip()
+    role_key = (form.get("role_key") or "").strip()
+    country_ids = _form_ids(form, "country_ids")
+    level_ids = _form_ids(form, "level_ids")
+    branch_ids = _form_ids(form, "branch_ids")
+    try:
+        updated = db_infobox_role_key_filter.update_infobox_role_key_filter(
+            filter_id, name, role_key, country_ids, level_ids, branch_ids
+        )
+        if not updated:
+            raise HTTPException(status_code=404)
+        return RedirectResponse("/refs/infobox-role-key-filters?saved=1", status_code=302)
+    except ValueError as e:
+        filter_obj = db_infobox_role_key_filter.get_infobox_role_key_filter(filter_id)
+        if not filter_obj:
+            raise HTTPException(status_code=404)
+        filter_obj = {
+            **filter_obj,
+            "name": name,
+            "role_key": role_key,
+            "country_ids": country_ids,
+            "level_ids": level_ids,
+            "branch_ids": branch_ids,
+        }
+        countries = db_refs.list_countries()
+        levels = db_refs.list_levels()
+        branches = db_refs.list_branches()
+        return templates.TemplateResponse(
+            "refs_infobox_role_key_filter_form.html",
+            {
+                "request": request,
+                "filter_obj": filter_obj,
+                "countries": countries,
+                "levels": levels,
+                "branches": branches,
+                "validation_error": str(e),
+            },
+        )
+
+
+@app.post("/refs/infobox-role-key-filters/{filter_id}/delete")
+async def refs_infobox_role_key_filter_delete(filter_id: int):
+    db_infobox_role_key_filter.delete_infobox_role_key_filter(filter_id)
+    return RedirectResponse("/refs/infobox-role-key-filters", status_code=302)
 
 
 # ---------- Reference data (for dropdowns) ----------

--- a/src/templates/refs.html
+++ b/src/templates/refs.html
@@ -10,5 +10,6 @@
   <li><a href="/refs/branches">Branches</a></li>
   <li><a href="/refs/cities">Cities</a></li>
   <li><a href="/refs/office-categories">Office categories</a></li>
+  <li><a href="/refs/infobox-role-key-filters">Infobox role key filters</a></li>
 </ul>
 {% endblock %}

--- a/src/templates/refs_infobox_role_key_filter_form.html
+++ b/src/templates/refs_infobox_role_key_filter_form.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block title %}{{ "Edit" if filter_obj else "New" }} infobox role key filter – Office Holder{% endblock %}
+{% block content %}
+<h1>{{ "Edit" if filter_obj else "New" }} infobox role key filter</h1>
+{% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
+<p class="form-note">Leave a list empty (select none) for "All". Otherwise only the selected values apply for that dimension.</p>
+<form method="post" action="{% if filter_obj %}/refs/infobox-role-key-filters/{{ filter_obj.id }}{% else %}/refs/infobox-role-key-filters/new{% endif %}">
+  <div class="form-group">
+    <label for="name">Name</label>
+    <input type="text" id="name" name="name" value="{{ filter_obj.name if filter_obj else (form_name if form_name is defined else '') }}" required placeholder="Filter name">
+  </div>
+  <div class="form-group">
+    <label for="role_key">Role key</label>
+    <input type="text" id="role_key" name="role_key" value="{{ filter_obj.role_key if filter_obj else (form_role_key if form_role_key is defined else '') }}" required placeholder="Infobox role key">
+  </div>
+  <div class="form-group">
+    <label for="country_ids">Countries (optional; leave empty for all)</label>
+    <select id="country_ids" name="country_ids" multiple size="6">
+      {% for c in countries %}
+      <option value="{{ c.id }}" {% if filter_obj and c.id in (filter_obj.country_ids or []) %}selected{% elif form_country_ids is defined and c.id in form_country_ids %}selected{% endif %}>{{ c.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="level_ids">Levels (optional; leave empty for all)</label>
+    <select id="level_ids" name="level_ids" multiple size="4">
+      {% for l in levels %}
+      <option value="{{ l.id }}" {% if filter_obj and l.id in (filter_obj.level_ids or []) %}selected{% elif form_level_ids is defined and l.id in form_level_ids %}selected{% endif %}>{{ l.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="branch_ids">Branches (optional; leave empty for all)</label>
+    <select id="branch_ids" name="branch_ids" multiple size="4">
+      {% for b in branches %}
+      <option value="{{ b.id }}" {% if filter_obj and b.id in (filter_obj.branch_ids or []) %}selected{% elif form_branch_ids is defined and b.id in form_branch_ids %}selected{% endif %}>{{ b.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="actions">
+    <button type="submit" class="btn">Save</button>
+    <a href="/refs/infobox-role-key-filters" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/src/templates/refs_infobox_role_key_filters.html
+++ b/src/templates/refs_infobox_role_key_filters.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Infobox role key filters – Office Holder{% endblock %}
+{% block content %}
+<h1>Infobox role key filters</h1>
+{% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
+{% if error %}<div class="alert alert-error">{{ error }}</div>{% endif %}
+<div class="actions">
+  <a href="/refs/infobox-role-key-filters/new" class="btn">Add infobox role key filter</a>
+  <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
+</div>
+{% if filters %}
+<table class="table">
+  <thead>
+    <tr><th>Name</th><th>Role key</th><th></th></tr>
+  </thead>
+  <tbody>
+    {% for f in filters %}
+    <tr>
+      <td><a href="/refs/infobox-role-key-filters/{{ f.id }}">{{ f.name or '—' }}</a></td>
+      <td><code>{{ f.role_key or '—' }}</code></td>
+      <td>
+        <a href="/refs/infobox-role-key-filters/{{ f.id }}" class="btn btn-sm btn-secondary">Edit</a>
+        <form action="/refs/infobox-role-key-filters/{{ f.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete this filter?');">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No infobox role key filters yet. <a href="/refs/infobox-role-key-filters/new">Add one</a>.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Provide a way to manage mappings from infobox `role_key` values to human-friendly labels that can be scoped by `country`, `level`, and `branch`.  
- Expose CRUD and context-aware listing so the scraper/UI can apply role-key-specific behavior per region or jurisdiction.

### Description
- Added a new DB module `src/db/infobox_role_key_filter.py` implementing `list/get/create/update/delete` and `list_filters_for_context(country_id, level_id, branch_id)` with the same "empty list means all" semantics as office categories.  
- Extended the schema in `src/db/schema.py` with `infobox_role_key_filter(id, name, role_key)` and junction tables for countries, levels, and branches, and added a corresponding migration `_migrate_infobox_role_key_filter` invoked from `migrate_to_fk` in `src/db/migrate.py`.  
- Added FastAPI routes in `src/main.py` for listing (`/refs/infobox-role-key-filters`), creating, editing, and deleting filters and wired in the new DB module.  
- Added UI templates `src/templates/refs_infobox_role_key_filters.html` and `src/templates/refs_infobox_role_key_filter_form.html` and a discoverability link on `src/templates/refs.html`.

### Testing
- Ran `python -m compileall src` to ensure the new modules and templates compile successfully (succeeded).  
- Started the app with `python -m uvicorn src.main:app --host 0.0.0.0 --port 8000` and verified startup and clean shutdown (succeeded).  
- Captured a UI screenshot of `/refs/infobox-role-key-filters` via Playwright to validate the new list page renders (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b90cd3d8c832899670737bd7bc5ae)