### PR TITLE
Migrate office table configs to infobox_role_key filters

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -1,5 +1,6 @@
 """Migration: ensure ref tables exist and offices/parties use FK columns."""
 
+import re
 import sqlite3
 
 from .connection import get_connection
@@ -68,10 +69,10 @@ def migrate_to_fk(conn=None):
         _migrate_allow_reuse_tables_and_table_no_unique(conn)
         # office_table_config: add name (table name for outline)
         _migrate_office_table_config_name(conn)
-        _migrate_infobox_role_key(conn)
         # office_category tables and office_details.office_category_id
         _migrate_office_category(conn)
         _migrate_infobox_role_key_filter(conn)
+        _migrate_office_table_config_infobox_role_key_filter_id(conn)
         # cities table and source_pages.city_id
         _migrate_city(conn)
     finally:
@@ -677,6 +678,80 @@ def _migrate_infobox_role_key_filter(conn):
             PRIMARY KEY (filter_id, branch_id)
         );
     """)
+    conn.commit()
+
+
+def _normalize_role_key(role_key: str) -> str:
+    return re.sub(r"\s+", "_", (role_key or "").strip().lower())
+
+
+def _migrate_office_table_config_infobox_role_key_filter_id(conn):
+    """Add office_table_config.infobox_role_key_filter_id and backfill from legacy infobox_role_key when present."""
+    try:
+        otc_cols = _columns(conn, "office_table_config")
+    except sqlite3.OperationalError:
+        return
+
+    if "infobox_role_key_filter_id" not in otc_cols:
+        conn.execute(
+            "ALTER TABLE office_table_config ADD COLUMN infobox_role_key_filter_id INTEGER REFERENCES infobox_role_key_filter(id)"
+        )
+        conn.commit()
+
+    if "infobox_role_key" not in otc_cols:
+        return
+
+    rows = conn.execute(
+        """SELECT tc.id, tc.infobox_role_key, p.country_id, p.level_id, p.branch_id
+               FROM office_table_config tc
+               JOIN office_details od ON od.id = tc.office_details_id
+               JOIN source_pages p ON p.id = od.source_page_id
+              WHERE tc.infobox_role_key_filter_id IS NULL
+                AND TRIM(COALESCE(tc.infobox_role_key, '')) != ''"""
+    ).fetchall()
+
+    def _ensure_filter(role_key: str, country_id: int | None, level_id: int | None, branch_id: int | None) -> int:
+        normalized = _normalize_role_key(role_key)
+        candidate_ids = [
+            r[0]
+            for r in conn.execute(
+                "SELECT id FROM infobox_role_key_filter WHERE role_key = ?",
+                (normalized,),
+            ).fetchall()
+        ]
+        for fid in candidate_ids:
+            c = {r[0] for r in conn.execute("SELECT country_id FROM infobox_role_key_filter_countries WHERE filter_id = ?", (fid,)).fetchall()}
+            l = {r[0] for r in conn.execute("SELECT level_id FROM infobox_role_key_filter_levels WHERE filter_id = ?", (fid,)).fetchall()}
+            b = {r[0] for r in conn.execute("SELECT branch_id FROM infobox_role_key_filter_branches WHERE filter_id = ?", (fid,)).fetchall()}
+            if c == ({country_id} if country_id else set()) and l == ({level_id} if level_id else set()) and b == ({branch_id} if branch_id else set()):
+                return int(fid)
+
+        scope = f"c{country_id or 0}_l{level_id or 0}_b{branch_id or 0}"
+        base_name = f"{normalized}__{scope}"
+        name = base_name
+        suffix = 2
+        while conn.execute("SELECT 1 FROM infobox_role_key_filter WHERE name = ?", (name,)).fetchone():
+            name = f"{base_name}_{suffix}"
+            suffix += 1
+        conn.execute(
+            "INSERT INTO infobox_role_key_filter (name, role_key) VALUES (?, ?)",
+            (name, normalized),
+        )
+        fid = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+        if country_id:
+            conn.execute("INSERT OR IGNORE INTO infobox_role_key_filter_countries (filter_id, country_id) VALUES (?, ?)", (fid, country_id))
+        if level_id:
+            conn.execute("INSERT OR IGNORE INTO infobox_role_key_filter_levels (filter_id, level_id) VALUES (?, ?)", (fid, level_id))
+        if branch_id:
+            conn.execute("INSERT OR IGNORE INTO infobox_role_key_filter_branches (filter_id, branch_id) VALUES (?, ?)", (fid, branch_id))
+        return fid
+
+    for tc_id, role_key, country_id, level_id, branch_id in rows:
+        fid = _ensure_filter(role_key, country_id, level_id, branch_id)
+        conn.execute(
+            "UPDATE office_table_config SET infobox_role_key_filter_id = ? WHERE id = ?",
+            (fid, tc_id),
+        )
     conn.commit()
 
 def _migrate_city(conn):

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -81,6 +81,7 @@ def _flatten_hierarchy_row(
         "district_at_large": bool(tc.get("district_at_large") if tc.get("district_at_large") is not None else 0),
         "ignore_non_links": bool(tc.get("ignore_non_links") if tc.get("ignore_non_links") is not None else 0),
         "remove_duplicates": bool(tc.get("remove_duplicates") if tc.get("remove_duplicates") is not None else 0),
+        "infobox_role_key_filter_id": tc.get("infobox_role_key_filter_id"),
         "infobox_role_key": (tc.get("infobox_role_key") or "").strip(),
         "created_at": tc.get("created_at") or od.get("created_at"),
         "alt_links": list(alt_links) if alt_links else [],
@@ -114,6 +115,7 @@ def _tc_row_to_config(rd: dict[str, Any]) -> dict[str, Any]:
         "ignore_non_links": rd.get("ignore_non_links"),
         "remove_duplicates": rd.get("remove_duplicates"),
         "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"),
+        "infobox_role_key_filter_id": rd.get("infobox_role_key_filter_id"),
         "infobox_role_key": (rd.get("infobox_role_key") or "").strip(),
         "notes": rd.get("tc_notes"),
         "name": rd.get("tc_name") or "",
@@ -143,6 +145,67 @@ def _bool(data: dict, key: str) -> bool:
     """Return True if data[key] is truthy (1, true, '1', 'true', etc.)."""
     v = data.get(key)
     return v is not None and str(v).strip().lower() in ("true", "1", "yes")
+
+def _scope_ids_for_office_details(conn: sqlite3.Connection, office_details_id: int) -> tuple[int | None, int | None, int | None]:
+    row = conn.execute(
+        """SELECT p.country_id, p.level_id, p.branch_id
+               FROM office_details od
+               JOIN source_pages p ON p.id = od.source_page_id
+              WHERE od.id = ?""",
+        (office_details_id,),
+    ).fetchone()
+    if not row:
+        return (None, None, None)
+    return (row[0], row[1], row[2])
+
+
+def _resolve_infobox_role_key_filter_id(
+    conn: sqlite3.Connection,
+    office_details_id: int,
+    tc_data: dict[str, Any],
+) -> int | None:
+    raw_id = tc_data.get("infobox_role_key_filter_id")
+    if raw_id not in (None, ""):
+        try:
+            return int(raw_id)
+        except (TypeError, ValueError):
+            pass
+    role_key = (tc_data.get("infobox_role_key") or "").strip().lower()
+    if not role_key:
+        return None
+    country_id, level_id, branch_id = _scope_ids_for_office_details(conn, office_details_id)
+    row = conn.execute(
+        """SELECT f.id
+               FROM infobox_role_key_filter f
+               LEFT JOIN infobox_role_key_filter_countries fc ON fc.filter_id = f.id
+               LEFT JOIN infobox_role_key_filter_levels fl ON fl.filter_id = f.id
+               LEFT JOIN infobox_role_key_filter_branches fb ON fb.filter_id = f.id
+              WHERE f.role_key = ?
+                AND ((? IS NULL AND fc.country_id IS NULL) OR fc.country_id = ?)
+                AND ((? IS NULL AND fl.level_id IS NULL) OR fl.level_id = ?)
+                AND ((? IS NULL AND fb.branch_id IS NULL) OR fb.branch_id = ?)
+              LIMIT 1""",
+        (role_key, country_id, country_id, level_id, level_id, branch_id, branch_id),
+    ).fetchone()
+    if row:
+        return int(row[0])
+
+    scope = f"c{country_id or 0}_l{level_id or 0}_b{branch_id or 0}"
+    base_name = f"{role_key}__{scope}"
+    name = base_name
+    i = 2
+    while conn.execute("SELECT 1 FROM infobox_role_key_filter WHERE name = ?", (name,)).fetchone():
+        name = f"{base_name}_{i}"
+        i += 1
+    conn.execute("INSERT INTO infobox_role_key_filter (name, role_key) VALUES (?, ?)", (name, role_key))
+    fid = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    if country_id:
+        conn.execute("INSERT OR IGNORE INTO infobox_role_key_filter_countries (filter_id, country_id) VALUES (?, ?)", (fid, country_id))
+    if level_id:
+        conn.execute("INSERT OR IGNORE INTO infobox_role_key_filter_levels (filter_id, level_id) VALUES (?, ?)", (fid, level_id))
+    if branch_id:
+        conn.execute("INSERT OR IGNORE INTO infobox_role_key_filter_branches (filter_id, branch_id) VALUES (?, ?)", (fid, branch_id))
+    return fid
 
 
 def validate_office_table_config(
@@ -241,6 +304,7 @@ def get_runnable_unit_ids_for_office(office_id: int, conn: sqlite3.Connection | 
         if _use_hierarchy(conn):
             cur = conn.execute(
                 """SELECT tc.id FROM office_table_config tc
+                   LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                    JOIN office_details od ON od.id = tc.office_details_id AND od.enabled = 1
                    JOIN source_pages p ON p.id = od.source_page_id AND p.enabled = 1
                    WHERE tc.office_details_id = ? AND tc.enabled = 1""",
@@ -269,10 +333,11 @@ def list_runnable_units(conn: sqlite3.Connection | None = None) -> list[dict[str
                       tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                       tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                       tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                      tc.consolidate_rowspan_terms, tc.infobox_role_key, tc.notes AS tc_notes, tc.created_at
+                      tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, rkf.role_key AS infobox_role_key, tc.notes AS tc_notes, tc.created_at
                FROM source_pages p
                JOIN office_details od ON od.source_page_id = p.id AND od.enabled = 1
                JOIN office_table_config tc ON tc.office_details_id = od.id AND tc.enabled = 1
+               LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                WHERE p.enabled = 1
                ORDER BY p.id, od.id, tc.id"""
         )
@@ -294,7 +359,7 @@ def list_runnable_units(conn: sqlite3.Connection | None = None) -> list[dict[str
             )
             p = {"url": rd.get("url"), "country_id": rd.get("country_id"), "state_id": rd.get("state_id"), "city_id": rd.get("city_id"), "level_id": rd.get("level_id"), "branch_id": rd.get("branch_id"), "notes": rd.get("page_notes"), "enabled": rd.get("page_enabled")}
             od = {"id": od_id, "name": rd.get("name"), "department": rd.get("department"), "notes": rd.get("notes"), "alt_link_include_main": rd.get("alt_link_include_main"), "enabled": rd.get("od_enabled")}
-            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "ignore_non_links": rd.get("ignore_non_links"), "remove_duplicates": rd.get("remove_duplicates"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "infobox_role_key": rd.get("infobox_role_key"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
+            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "ignore_non_links": rd.get("ignore_non_links"), "remove_duplicates": rd.get("remove_duplicates"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "infobox_role_key_filter_id": rd.get("infobox_role_key_filter_id"), "infobox_role_key": rd.get("infobox_role_key"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
             flat = _flatten_hierarchy_row(p, od, tc, c, s, lv, b, alt_links)
             flat["id"] = rd["office_table_config_id"]
             flat["office_details_id"] = od_id
@@ -322,10 +387,11 @@ def list_offices(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                          tc.consolidate_rowspan_terms, tc.infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, rkf.role_key AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
+                   LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                    ORDER BY p.id, od.id, tc.table_no, tc.id"""
             )
             rows = cur.fetchall()
@@ -352,7 +418,7 @@ def list_offices(conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]
                         table_configs.append(_tc_row_to_config(rd))
                 table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
                 first_tc = table_configs[0] if table_configs else {}
-                tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "infobox_role_key": first_tc.get("infobox_role_key"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+                tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "infobox_role_key_filter_id": first_tc.get("infobox_role_key_filter_id"), "infobox_role_key": first_tc.get("infobox_role_key"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
                 flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
                 flat["id"] = od_id
                 flat["source_page_id"] = rd0.get("page_id")
@@ -477,6 +543,7 @@ def get_runnable_unit_ids_for_office_category(
             cur = conn.execute(
                 """SELECT tc.id
                    FROM office_table_config tc
+                   LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                    JOIN office_details od ON od.id = tc.office_details_id
                    JOIN source_pages p ON p.id = od.source_page_id
                    WHERE od.office_category_id = ?
@@ -507,10 +574,11 @@ def get_office(office_id: int, conn: sqlite3.Connection | None = None) -> dict[s
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                          tc.consolidate_rowspan_terms, tc.infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, rkf.role_key AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
+                   LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                    WHERE od.id = ?""",
                 (office_id,),
             )
@@ -533,7 +601,7 @@ def get_office(office_id: int, conn: sqlite3.Connection | None = None) -> dict[s
                     table_configs.append(_tc_row_to_config(rd))
             table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
             first_tc = table_configs[0] if table_configs else {}
-            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "infobox_role_key": first_tc.get("infobox_role_key"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "infobox_role_key_filter_id": first_tc.get("infobox_role_key_filter_id"), "infobox_role_key": first_tc.get("infobox_role_key"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
             flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
             flat["id"] = od_id
             flat["source_page_id"] = rd0.get("page_id")
@@ -747,10 +815,11 @@ def list_offices_for_page(source_page_id: int, conn: sqlite3.Connection | None =
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                          tc.consolidate_rowspan_terms, tc.infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, rkf.role_key AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
+                   LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                    WHERE p.id = ?
                    ORDER BY od.id, tc.table_no, tc.id""",
             (source_page_id,),
@@ -780,7 +849,7 @@ def list_offices_for_page(source_page_id: int, conn: sqlite3.Connection | None =
                     table_configs.append(_tc_row_to_config(rd))
             table_configs.sort(key=lambda x: (x.get("table_no") or 0, x.get("id") or 0))
             first_tc = table_configs[0] if table_configs else {}
-            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "infobox_role_key": first_tc.get("infobox_role_key"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
+            tc_flat = {"table_no": first_tc.get("table_no"), "table_rows": first_tc.get("table_rows"), "link_column": first_tc.get("link_column"), "party_column": first_tc.get("party_column"), "term_start_column": first_tc.get("term_start_column"), "term_end_column": first_tc.get("term_end_column"), "district_column": first_tc.get("district_column"), "dynamic_parse": first_tc.get("dynamic_parse"), "read_right_to_left": first_tc.get("read_right_to_left"), "find_date_in_infobox": first_tc.get("find_date_in_infobox"), "parse_rowspan": first_tc.get("parse_rowspan"), "rep_link": first_tc.get("rep_link"), "party_link": first_tc.get("party_link"), "enabled": first_tc.get("enabled"), "use_full_page_for_table": first_tc.get("use_full_page_for_table"), "years_only": first_tc.get("years_only"), "term_dates_merged": first_tc.get("term_dates_merged"), "party_ignore": first_tc.get("party_ignore"), "district_ignore": first_tc.get("district_ignore"), "district_at_large": first_tc.get("district_at_large"), "ignore_non_links": first_tc.get("ignore_non_links"), "remove_duplicates": first_tc.get("remove_duplicates"), "consolidate_rowspan_terms": first_tc.get("consolidate_rowspan_terms"), "infobox_role_key_filter_id": first_tc.get("infobox_role_key_filter_id"), "infobox_role_key": first_tc.get("infobox_role_key"), "notes": first_tc.get("notes"), "created_at": first_tc.get("created_at")}
             flat = _flatten_hierarchy_row(p, od, tc_flat, c, s, lv, b, alt_links)
             flat["id"] = od_id
             flat["source_page_id"] = rd0.get("page_id")
@@ -841,7 +910,7 @@ def _insert_one_table_config(
         """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
               term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
               parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
-              term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, remove_duplicates, consolidate_rowspan_terms, infobox_role_key, notes, name, created_at, updated_at)
+              term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, remove_duplicates, consolidate_rowspan_terms, infobox_role_key_filter_id, notes, name, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
         (
             od_id,
@@ -868,7 +937,7 @@ def _insert_one_table_config(
             1 if tc.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
             1 if tc.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
             1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
-            (tc.get("infobox_role_key") or "").strip(),
+            _resolve_infobox_role_key_filter_id(conn, od_id, tc),
             tc.get("notes") or "",
             tc.get("name") or "",
         ),
@@ -1218,7 +1287,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                                   term_start_column=?, term_end_column=?, district_column=?, dynamic_parse=?, read_right_to_left=?,
                                   find_date_in_infobox=?, parse_rowspan=?, rep_link=?, party_link=?, enabled=?, use_full_page_for_table=?,
                                   years_only=?, term_dates_merged=?, party_ignore=?, district_ignore=?, district_at_large=?, ignore_non_links=?, remove_duplicates=?,
-                                  consolidate_rowspan_terms=?, infobox_role_key=?, notes=?, name=?, updated_at=datetime('now') WHERE id=?""",
+                                  consolidate_rowspan_terms=?, infobox_role_key_filter_id=?, notes=?, name=?, updated_at=datetime('now') WHERE id=?""",
                             (
                                 tc_table_no,
                                 int(tc.get("table_rows", 4)),
@@ -1243,7 +1312,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                                 1 if tc.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
-                                (tc.get("infobox_role_key") or "").strip(),
+                                _resolve_infobox_role_key_filter_id(conn, office_id, tc),
                                 tc.get("notes") or "",
                                 tc.get("name") or "",
                                 existing_tc_id,
@@ -1256,7 +1325,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                             """INSERT INTO office_table_config (office_details_id, table_no, table_rows, link_column, party_column,
                                   term_start_column, term_end_column, district_column, dynamic_parse, read_right_to_left, find_date_in_infobox,
                                   parse_rowspan, rep_link, party_link, enabled, use_full_page_for_table, years_only,
-                                  term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, remove_duplicates, consolidate_rowspan_terms, infobox_role_key, notes, name, created_at, updated_at)
+                                  term_dates_merged, party_ignore, district_ignore, district_at_large, ignore_non_links, remove_duplicates, consolidate_rowspan_terms, infobox_role_key_filter_id, notes, name, created_at, updated_at)
                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))""",
                             (
                                 office_id,
@@ -1283,7 +1352,7 @@ def update_office(office_id: int, data: dict[str, Any], conn: sqlite3.Connection
                                 1 if tc.get("ignore_non_links") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("remove_duplicates") in (True, 1, "TRUE", "true", "1") else 0,
                                 1 if tc.get("consolidate_rowspan_terms") in (True, 1, "TRUE", "true", "1") else 0,
-                                (tc.get("infobox_role_key") or "").strip(),
+                                _resolve_infobox_role_key_filter_id(conn, office_id, tc),
                                 tc.get("notes") or "",
                                 tc.get("name") or "",
                             ),
@@ -1399,7 +1468,7 @@ def set_infobox_role_key(
     """Set infobox_role_key for one office/table_no. Returns True when a row was updated.
 
     Hierarchy mode: updates office_table_config by (office_details_id, table_no).
-    Legacy mode: updates offices row (table_no ignored, single config per office).
+    Legacy mode: no-op (returns False); infobox role key is hierarchy-only now.
     """
     own_conn = conn is None
     if own_conn:
@@ -1409,18 +1478,13 @@ def set_infobox_role_key(
         if _use_hierarchy(conn):
             cur = conn.execute(
                 """UPDATE office_table_config
-                       SET infobox_role_key = ?, updated_at = datetime('now')
+                       SET infobox_role_key_filter_id = ?, updated_at = datetime('now')
                      WHERE office_details_id = ? AND table_no = ?""",
-                (key, office_id, int(table_no or 1)),
+                (_resolve_infobox_role_key_filter_id(conn, int(office_id), {"infobox_role_key": key}), office_id, int(table_no or 1)),
             )
             conn.commit()
             return cur.rowcount > 0
-        cur = conn.execute(
-            "UPDATE offices SET infobox_role_key = ? WHERE id = ?",
-            (key, office_id),
-        )
-        conn.commit()
-        return cur.rowcount > 0
+        return False
     finally:
         if own_conn:
             conn.close()
@@ -1443,26 +1507,22 @@ def set_infobox_role_key_by_table_config_id(
     try:
         key = (infobox_role_key or "").strip()
         if _use_hierarchy(conn):
+            scope_row = conn.execute(
+                "SELECT office_details_id FROM office_table_config WHERE id = ?",
+                (int(office_table_config_id),),
+            ).fetchone()
+            if not scope_row:
+                return False
+            filter_id = _resolve_infobox_role_key_filter_id(conn, int(scope_row[0]), {"infobox_role_key": key})
             cur = conn.execute(
                 """UPDATE office_table_config
-                       SET infobox_role_key = ?, updated_at = datetime('now')
+                       SET infobox_role_key_filter_id = ?, updated_at = datetime('now')
                      WHERE id = ?""",
-                (key, int(office_table_config_id)),
+                (filter_id, int(office_table_config_id)),
             )
             conn.commit()
             return cur.rowcount > 0
-        row = conn.execute(
-            "SELECT id FROM offices WHERE id = ?",
-            (int(office_table_config_id),),
-        ).fetchone()
-        if not row:
-            return False
-        cur = conn.execute(
-            "UPDATE offices SET infobox_role_key = ? WHERE id = ?",
-            (key, int(office_table_config_id)),
-        )
-        conn.commit()
-        return cur.rowcount > 0
+        return False
     finally:
         if own_conn:
             conn.close()
@@ -1498,6 +1558,7 @@ def get_office_by_table_config_id(
                           tc.ignore_non_links, tc.remove_duplicates, tc.consolidate_rowspan_terms,
                           tc.infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_table_config tc
+                   LEFT JOIN infobox_role_key_filter rkf ON rkf.id = tc.infobox_role_key_filter_id
                    JOIN office_details od ON od.id = tc.office_details_id
                    JOIN source_pages p ON p.id = od.source_page_id
                    WHERE tc.id = ?""",
@@ -1563,7 +1624,7 @@ def get_office_by_table_config_id(
                 "ignore_non_links": rd.get("ignore_non_links"),
                 "remove_duplicates": rd.get("remove_duplicates"),
                 "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"),
-                "infobox_role_key": rd.get("infobox_role_key"),
+                "infobox_role_key_filter_id": rd.get("infobox_role_key_filter_id"), "infobox_role_key": rd.get("infobox_role_key"),
                 "notes": rd.get("tc_notes"),
                 "created_at": rd.get("created_at"),
             }

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -159,7 +159,7 @@ CREATE TABLE IF NOT EXISTS office_table_config (
     ignore_non_links INTEGER NOT NULL DEFAULT 0,
     remove_duplicates INTEGER NOT NULL DEFAULT 0,
     consolidate_rowspan_terms INTEGER NOT NULL DEFAULT 0,
-    infobox_role_key TEXT NOT NULL DEFAULT '',
+    infobox_role_key_filter_id INTEGER REFERENCES infobox_role_key_filter(id),
     notes TEXT,
     name TEXT,
     created_at TEXT DEFAULT (datetime('now')),


### PR DESCRIPTION
### Motivation
- Replace raw per-row `infobox_role_key` text with reusable, scoped filter records so role-key normalization and reuse are possible across table configs.
- Backfill existing raw keys into filter records while keeping legacy column presence for compatibility during migration and rollout.

### Description
- Schema: changed `office_table_config` to store `infobox_role_key_filter_id` as a FK to `infobox_role_key_filter(id)` instead of relying on raw text in the canonical table definition (`src/db/schema.py`).
- Migration: added a forward migration `_migrate_office_table_config_infobox_role_key_filter_id` that creates the filter tables if missing, adds the `infobox_role_key_filter_id` column when absent, normalizes and deduplicates existing `infobox_role_key` values into scoped filter records (by `country_id`/`level_id`/`branch_id`), and writes resolved filter IDs back to `office_table_config` while leaving legacy text data intact (`src/db/migrate.py`).
- DB read/write: updated `src/db/offices.py` to persist and return `infobox_role_key_filter_id`, to resolve and expose a parser-compatible `infobox_role_key` by joining to `infobox_role_key_filter.role_key`, and to create/resolve scoped filter rows when inserting/updating table configs.
- Cleanup behavior: removed legacy fallbacks that wrote to `offices.infobox_role_key` from the setter paths so application logic now prefers hierarchy-level filter ids (legacy text column kept for compatibility during migration).

### Testing
- Ran static compile checks with `python -m py_compile src/db/offices.py src/db/migrate.py src/db/schema.py` which succeeded.
- Ran the full test suite with `pytest -q` and all tests passed (`15 passed`, with 4 warnings unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b91d8d5bc832883651269aca29d7d)