### PR TITLE
Add infobox role-key filter support to test scripts (UI + runner + tests)

### DIFF
--- a/src/db/test_test_scripts_serialization.py
+++ b/src/db/test_test_scripts_serialization.py
@@ -1,0 +1,71 @@
+import sqlite3
+
+from src.db import test_scripts as db_test_scripts
+
+
+def test_create_test_serializes_infobox_role_key_filter_id_round_trip():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    test_id = db_test_scripts.create_test(
+        {
+            "name": "serialization check",
+            "test_type": "table_config",
+            "enabled": True,
+            "html_file": "sample.html",
+            "source_url": "https://en.wikipedia.org/wiki/Sample",
+            "config_json": {
+                "table_no": 1,
+                "infobox_role_key": '"senior judge"',
+                "infobox_role_key_filter_id": 7,
+            },
+            "expected_json": [],
+        },
+        conn=conn,
+    )
+
+    row = db_test_scripts.get_test(test_id, conn=conn)
+    assert row is not None
+    assert row["config_json"]["infobox_role_key"] == '"senior judge"'
+    assert row["config_json"]["infobox_role_key_filter_id"] == 7
+
+
+def test_update_test_serializes_infobox_role_key_filter_id_round_trip():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    test_id = db_test_scripts.create_test(
+        {
+            "name": "serialization check update",
+            "test_type": "table_config",
+            "enabled": True,
+            "html_file": "sample.html",
+            "source_url": "https://en.wikipedia.org/wiki/Sample",
+            "config_json": {"table_no": 1},
+            "expected_json": [],
+        },
+        conn=conn,
+    )
+
+    db_test_scripts.update_test(
+        test_id,
+        {
+            "name": "serialization check update",
+            "test_type": "table_config",
+            "enabled": True,
+            "html_file": "sample.html",
+            "source_url": "https://en.wikipedia.org/wiki/Sample",
+            "config_json": {
+                "table_no": 1,
+                "infobox_role_key": '"associate justice"',
+                "infobox_role_key_filter_id": 9,
+            },
+            "expected_json": [],
+        },
+        conn=conn,
+    )
+
+    row = db_test_scripts.get_test(test_id, conn=conn)
+    assert row is not None
+    assert row["config_json"]["infobox_role_key"] == '"associate justice"'
+    assert row["config_json"]["infobox_role_key_filter_id"] == 9

--- a/src/main.py
+++ b/src/main.py
@@ -2191,6 +2191,7 @@ async def test_scripts_page(request: Request):
             "request": request,
             "tests": tests,
             "can_use_office_templates": db_offices.use_hierarchy(),
+            "infobox_role_key_filters": db_infobox_role_key_filter.list_infobox_role_key_filters(),
         },
     )
 

--- a/src/scraper/test_infobox_role_key.py
+++ b/src/scraper/test_infobox_role_key.py
@@ -2,6 +2,7 @@ import pytest
 
 from src.scraper.logger import Logger
 from src.scraper.table_parser import Biography, DataCleanup, parse_infobox_role_key_query
+from src.scraper.test_script_runner import run_test_script_from_html
 
 
 class _Resp:
@@ -163,3 +164,52 @@ def test_infobox_role_key_requires_quoted_terms():
 def test_infobox_role_key_rejects_unclosed_quotes():
     with pytest.raises(ValueError):
         parse_infobox_role_key_query('"judge" -"chief judge')
+
+
+def test_run_test_script_resolves_infobox_role_key_from_filter_id(monkeypatch):
+    captured = {}
+
+    def fake_parse(office_row, selected_table_html, _url):
+        captured["role_key"] = office_row.get("infobox_role_key")
+        return []
+
+    monkeypatch.setattr("src.scraper.test_script_runner.get_infobox_role_key_filter", lambda fid: {"id": fid, "role_key": '"senior judge"'})
+    monkeypatch.setattr("src.scraper.test_script_runner.parse_full_table_for_export", fake_parse)
+
+    html = "<table><tr><th>Name</th></tr><tr><td>A</td></tr></table>"
+    result = run_test_script_from_html(
+        test_type="table_config",
+        html_content=html,
+        config_json={
+            "table_no": 1,
+            "infobox_role_key": '"chief judge"',
+            "infobox_role_key_filter_id": 42,
+        },
+    )
+
+    assert result["actual"] == []
+    assert captured["role_key"] == '"senior judge"'
+
+
+def test_run_test_script_keeps_legacy_infobox_role_key_when_filter_missing(monkeypatch):
+    captured = {}
+
+    def fake_parse(office_row, selected_table_html, _url):
+        captured["role_key"] = office_row.get("infobox_role_key")
+        return []
+
+    monkeypatch.setattr("src.scraper.test_script_runner.get_infobox_role_key_filter", lambda _fid: None)
+    monkeypatch.setattr("src.scraper.test_script_runner.parse_full_table_for_export", fake_parse)
+
+    html = "<table><tr><th>Name</th></tr><tr><td>A</td></tr></table>"
+    run_test_script_from_html(
+        test_type="table_config",
+        html_content=html,
+        config_json={
+            "table_no": 1,
+            "infobox_role_key": '"senior judge"',
+            "infobox_role_key_filter_id": 9999,
+        },
+    )
+
+    assert captured["role_key"] == '"senior judge"'

--- a/src/scraper/test_script_runner.py
+++ b/src/scraper/test_script_runner.py
@@ -15,6 +15,7 @@ from src.scraper.logger import Logger
 from src.scraper import parse_core
 from src.scraper.runner import parse_full_table_for_export
 from src.scraper.wiki_fetch import wiki_url_to_rest_html_url, normalize_wiki_url
+from src.db.infobox_role_key_filter import get_infobox_role_key_filter
 from src.db.connection import ensure_data_dir, get_log_dir
 
 
@@ -165,7 +166,20 @@ def run_test_script_from_html(
     expected_json: Any = None,
 ) -> dict[str, Any]:
     parsed_type = (test_type or "table_config").strip()
-    cfg = config_json or {}
+    cfg = dict(config_json or {})
+    if parsed_type == "table_config":
+        raw_filter_id = cfg.get("infobox_role_key_filter_id")
+        filter_id = None
+        if isinstance(raw_filter_id, str):
+            raw_filter_id = raw_filter_id.strip()
+        if isinstance(raw_filter_id, int):
+            filter_id = raw_filter_id
+        elif isinstance(raw_filter_id, str) and raw_filter_id.isdigit():
+            filter_id = int(raw_filter_id)
+        if filter_id:
+            role_filter = get_infobox_role_key_filter(filter_id)
+            if role_filter and (role_filter.get("role_key") or "").strip():
+                cfg["infobox_role_key"] = (role_filter.get("role_key") or "").strip()
     if parsed_type == "table_config":
         actual = _run_table_test(html_content, cfg, source_url.strip())
     elif parsed_type == "infobox":

--- a/src/templates/test_scripts.html
+++ b/src/templates/test_scripts.html
@@ -105,7 +105,16 @@
           <option value="years_only">Table has years only</option>
         </select>
       </div>
-      <div class="form-group"><label>Infobox role key (optional) <span title="Use exact role phrase (e.g. &quot;chief judge&quot;, &quot;senior judge&quot;). &quot;judge&quot; can also match those rows.">ⓘ</span></label><input type="text" id="infobox_role_key" placeholder="e.g. senior judge"></div>
+      <div class="form-group">
+        <label>Infobox role key filter (optional)</label>
+        <select id="infobox_role_key_filter_id">
+          <option value="">— None —</option>
+          {% for f in infobox_role_key_filters or [] %}
+          <option value="{{ f.id }}">{{ f.name }}{% if f.role_key %} — {{ f.role_key }}{% endif %}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group"><label>Infobox role key (effective text) <span title="Legacy scripts store key text directly. Selecting a filter will populate this value so behavior stays unchanged.">ⓘ</span></label><input type="text" id="infobox_role_key" placeholder='e.g. "senior judge"'></div>
       <div class="form-group checkbox-group"><label><input type="checkbox" id="parse_rowspan"> Parse rowspan</label></div>
       <div class="form-group checkbox-group"><label><input type="checkbox" id="consolidate_rowspan_terms"> Consolidate consecutive terms (rowspan)</label></div>
       <div class="form-group checkbox-group"><label><input type="checkbox" id="rep_link"> Rep link</label></div>
@@ -185,6 +194,7 @@ let editingOriginalHtmlFile = null;
 let preservedConfigExtras = {};
 let officeTemplatePages = [];
 let officeTemplateOffices = [];
+const infoboxRoleKeyFilters = {{ (infobox_role_key_filters or []) | tojson }};
 
 function parseJsonOrEmpty(text) {
   const t = (text || '').trim();
@@ -204,6 +214,7 @@ function buildConfig() {
     .split(/[\n,]/)
     .map((v) => v.trim())
     .filter(Boolean);
+  const selectedFilterIdRaw = (document.getElementById('infobox_role_key_filter_id')?.value || '').trim();
   const base = {
     name: (document.getElementById('table_name').value || '').trim(),
     table_no: n('table_no', 1),
@@ -229,10 +240,46 @@ function buildConfig() {
     party_link: document.getElementById('party_link').checked,
     use_full_page_for_table: document.getElementById('use_full_page_for_table').checked,
     infobox_role_key: (document.getElementById('infobox_role_key').value || "").trim(),
+    infobox_role_key_filter_id: selectedFilterIdRaw && selectedFilterIdRaw !== '__legacy__' ? parseInt(selectedFilterIdRaw, 10) : null,
     alt_links: altLinks,
     alt_link_include_main: document.getElementById('alt_link_include_main').checked,
   };
-  return {...base, ...preservedConfigExtras};
+  const config = {...base, ...preservedConfigExtras};
+  if (!config.infobox_role_key_filter_id) delete config.infobox_role_key_filter_id;
+  return config;
+}
+
+function syncInfoboxRoleKeyFromFilterSelection() {
+  const select = document.getElementById('infobox_role_key_filter_id');
+  const input = document.getElementById('infobox_role_key');
+  if (!select || !input) return;
+  const selected = (select.value || '').trim();
+  if (!selected || selected === '__legacy__') return;
+  const filter = infoboxRoleKeyFilters.find((row) => String(row.id) === selected);
+  if (filter && typeof filter.role_key === 'string') input.value = filter.role_key;
+}
+
+function setInfoboxRoleKeyControls(roleKey, filterId) {
+  const select = document.getElementById('infobox_role_key_filter_id');
+  const input = document.getElementById('infobox_role_key');
+  if (!select || !input) return;
+  const keyText = (roleKey || '').trim();
+  const normalizedFilterId = (filterId === null || filterId === undefined) ? '' : String(filterId).trim();
+  const hasKnownOption = normalizedFilterId && infoboxRoleKeyFilters.some((row) => String(row.id) === normalizedFilterId);
+  const legacyOption = select.querySelector('option[value="__legacy__"]');
+  if (legacyOption) legacyOption.remove();
+  if (hasKnownOption) {
+    select.value = normalizedFilterId;
+  } else if (keyText) {
+    const opt = document.createElement('option');
+    opt.value = '__legacy__';
+    opt.textContent = 'Legacy/custom key text';
+    select.appendChild(opt);
+    select.value = '__legacy__';
+  } else {
+    select.value = '';
+  }
+  input.value = keyText;
 }
 
 function setOfficeTemplateMessage(message, isError = false) {
@@ -396,7 +443,7 @@ function applySelectedOfficeTemplate() {
   document.getElementById('rep_link').checked = !!tc.rep_link;
   document.getElementById('party_link').checked = !!tc.party_link;
   document.getElementById('use_full_page_for_table').checked = !!tc.use_full_page_for_table;
-  document.getElementById('infobox_role_key').value = tc.infobox_role_key || '';
+  setInfoboxRoleKeyControls(tc.infobox_role_key || '', tc.infobox_role_key_filter_id);
   const officeAltLinks = Array.isArray(office.alt_links) ? office.alt_links : [];
   document.getElementById('alt_links').value = officeAltLinks.join('\n');
   document.getElementById('alt_link_include_main').checked = !!office.alt_link_include_main;
@@ -500,7 +547,7 @@ async function editOne(id) {
     document.getElementById('rep_link').checked = !!c.rep_link;
     document.getElementById('party_link').checked = !!c.party_link;
     document.getElementById('use_full_page_for_table').checked = !!c.use_full_page_for_table;
-    document.getElementById('infobox_role_key').value = c.infobox_role_key || '';
+    setInfoboxRoleKeyControls(c.infobox_role_key || '', c.infobox_role_key_filter_id);
     const testAltLinks = Array.isArray(c.alt_links) ? c.alt_links : [];
     document.getElementById('alt_links').value = testAltLinks.join('\n');
     document.getElementById('alt_link_include_main').checked = !!c.alt_link_include_main;
@@ -521,6 +568,7 @@ function cancelEditMode() {
   editingTestId = null;
   editingOriginalHtmlFile = null;
   preservedConfigExtras = {};
+  setInfoboxRoleKeyControls('', null);
   document.getElementById('editModeBanner').style.display = 'none';
   document.getElementById('editModeName').textContent = '';
   document.getElementById('saveBtn').textContent = 'Save test script';
@@ -693,5 +741,8 @@ if (officeTemplateSearchBtn) {
   });
   document.getElementById('applyOfficeTemplateBtn').addEventListener('click', applySelectedOfficeTemplate);
 }
+const infoboxRoleKeyFilterSelect = document.getElementById('infobox_role_key_filter_id');
+if (infoboxRoleKeyFilterSelect) infoboxRoleKeyFilterSelect.addEventListener('change', syncInfoboxRoleKeyFromFilterSelection);
+setInfoboxRoleKeyControls('', null);
 </script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Allow test scripts to reference the new `infobox_role_key_filter` rows by `infobox_role_key_filter_id` while keeping existing `infobox_role_key` behavior for legacy scripts. 
- Let users pick a scoped role-key filter from the Test Scripts UI and still see/edit the effective key text used by the parser. 
- Ensure saved test-script JSON round-trips the optional filter id field without breaking existing fixtures.

### Description
- Update `run_test_script_from_html` in `src/scraper/test_script_runner.py` to accept `infobox_role_key_filter_id`, resolve it via `get_infobox_role_key_filter`, and populate `infobox_role_key` with the filter's `role_key` when present while remaining backward-compatible with legacy key text. 
- Add `get_infobox_role_key_filter` import and make a shallow copy of `config_json` before modifying it. 
- Pass `infobox_role_key_filters` into the `/test-scripts` template context in `src/main.py` for the UI to render a dropdown. 
- Update `src/templates/test_scripts.html` to add a filter dropdown, preserve/edit an effective `infobox_role_key` input, include `infobox_role_key_filter_id` in the built config JSON, and add JS helpers `syncInfoboxRoleKeyFromFilterSelection` and `setInfoboxRoleKeyControls` to keep filter selection and legacy/custom text in sync (also wire template copy/edit flows to handle filter id). 
- Add/adjust tests: extend `src/scraper/test_infobox_role_key.py` with runner-level tests that verify filter-id resolution and legacy fallback, and add `src/db/test_test_scripts_serialization.py` to verify `config_json` serialization round-trips include `infobox_role_key_filter_id`.

### Testing
- Ran unit tests with `PYTHONPATH=. pytest -q src/scraper/test_infobox_role_key.py src/db/test_test_scripts_serialization.py` and all tests passed. 
- Launched the app with `PYTHONPATH=. uvicorn src.main:app` and exercised `/test-scripts` to verify the UI changes (screenshot captured). 
- Verified that creating/updating test-script records preserves both `infobox_role_key` text and optional `infobox_role_key_filter_id` through DB serialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b94fcd4088328a5a0fdeae33f7bb6)