### PR TITLE
Resolve infobox role-key filter IDs in preview/export and fix migrated role_key format

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -73,6 +73,7 @@ def migrate_to_fk(conn=None):
         _migrate_office_category(conn)
         _migrate_infobox_role_key_filter(conn)
         _migrate_office_table_config_infobox_role_key_filter_id(conn)
+        _migrate_infobox_role_key_filter_role_key_format(conn)
         # cities table and source_pages.city_id
         _migrate_city(conn)
     finally:
@@ -682,7 +683,7 @@ def _migrate_infobox_role_key_filter(conn):
 
 
 def _normalize_role_key(role_key: str) -> str:
-    return re.sub(r"\s+", "_", (role_key or "").strip().lower())
+    return re.sub(r"\s+", " ", (role_key or "").strip().lower())
 
 
 def _migrate_office_table_config_infobox_role_key_filter_id(conn):
@@ -753,6 +754,35 @@ def _migrate_office_table_config_infobox_role_key_filter_id(conn):
             (fid, tc_id),
         )
     conn.commit()
+
+
+def _migrate_infobox_role_key_filter_role_key_format(conn):
+    """Repair legacy migrated role_key expressions that were normalized with underscores.
+
+    Early migrations converted whitespace to underscores, which breaks quoted include/exclude
+    parsing for expressions such as "associate justice" -"chief justice".
+    """
+    try:
+        rows = conn.execute(
+            "SELECT id, role_key FROM infobox_role_key_filter "
+            "WHERE INSTR(role_key, CHAR(34)) > 0 AND INSTR(role_key, '_') > 0"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return
+    if not rows:
+        return
+
+    changed = False
+    for fid, role_key in rows:
+        original = (role_key or "").strip()
+        if not original:
+            continue
+        fixed = re.sub(r"\s+", " ", original.replace("_", " ")).strip()
+        if fixed and fixed != original:
+            conn.execute("UPDATE infobox_role_key_filter SET role_key = ? WHERE id = ?", (fixed, int(fid)))
+            changed = True
+    if changed:
+        conn.commit()
 
 def _migrate_city(conn):
     """Create cities table if missing; add city_id to source_pages if missing."""

--- a/src/main.py
+++ b/src/main.py
@@ -112,8 +112,11 @@ def _office_draft_from_body(body: dict, *, include_ref_names: bool = False) -> d
         "district_at_large": district_at_large,
         "ignore_non_links": body.get("ignore_non_links") in (True, 1, "1", "true", "TRUE"),
         "remove_duplicates": body.get("remove_duplicates") in (True, 1, "1", "true", "TRUE"),
-        "infobox_role_key": (body.get("infobox_role_key") or "").strip(),
+        "infobox_role_key_filter_id": _validate_infobox_role_key_filter_id(body.get("infobox_role_key_filter_id")),
     }
+    draft["infobox_role_key"] = (body.get("infobox_role_key") or "").strip() or _resolve_infobox_role_key_from_filter_id(
+        draft.get("infobox_role_key_filter_id")
+    )
     if include_ref_names:
         country_id = int(body.get("country_id") or 0)
         draft["country_name"] = db_refs.get_country_name(country_id)
@@ -193,6 +196,20 @@ def _validate_infobox_role_key_filter_id(filter_id: str | int | None) -> int | N
     if not db_infobox_role_key_filter.get_infobox_role_key_filter(fid):
         raise ValueError(f"Infobox role key filter {fid} was not found")
     return fid
+
+
+def _resolve_infobox_role_key_from_filter_id(filter_id: str | int | None) -> str:
+    """Resolve filter id to role_key text; return empty string when missing/unset."""
+    try:
+        fid = _validate_infobox_role_key_filter_id(filter_id)
+    except ValueError:
+        return ""
+    if not fid:
+        return ""
+    f = db_infobox_role_key_filter.get_infobox_role_key_filter(fid)
+    if not f:
+        return ""
+    return (f.get("role_key") or "").strip()
 
 
 def _parse_optional_int(value: str | None) -> int | None:
@@ -3072,8 +3089,12 @@ def _export_job_worker(job_id: str, office_name: str, config: dict):
             "district_at_large": _config_bool_export(config.get("district_at_large")),
             "ignore_non_links": _config_bool_export(config.get("ignore_non_links")),
             "remove_duplicates": _config_bool_export(config.get("remove_duplicates")),
+            "infobox_role_key_filter_id": config.get("infobox_role_key_filter_id"),
             "country_name": "", "level_name": "", "branch_name": "", "state_name": "",
         }
+        office_row["infobox_role_key"] = (config.get("infobox_role_key") or "").strip() or _resolve_infobox_role_key_from_filter_id(
+            office_row.get("infobox_role_key_filter_id")
+        )
         full_rows = parse_full_table_for_export(office_row, table_html, url, progress_callback=progress_callback)
         timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
         safe_name = _sanitize_debug_filename(office_name)
@@ -3393,8 +3414,12 @@ async def api_office_debug_export(request: Request):
                 "district_ignore": _config_bool(config.get("district_ignore")),
                 "district_at_large": _config_bool(config.get("district_at_large")),
                 "remove_duplicates": _config_bool(config.get("remove_duplicates")),
+                "infobox_role_key_filter_id": config.get("infobox_role_key_filter_id"),
                 "country_name": "", "level_name": "", "branch_name": "", "state_name": "",
             }
+            office_row["infobox_role_key"] = (config.get("infobox_role_key") or "").strip() or _resolve_infobox_role_key_from_filter_id(
+                office_row.get("infobox_role_key_filter_id")
+            )
             full_rows = parse_full_table_for_export(office_row, table_html, office_row["url"])
         except Exception as e:
             full_rows = []

--- a/src/test_main_infobox_filter_resolution.py
+++ b/src/test_main_infobox_filter_resolution.py
@@ -1,0 +1,40 @@
+from src import main
+
+
+def test_office_draft_resolves_infobox_role_key_from_filter_id(monkeypatch):
+    monkeypatch.setattr(
+        main.db_infobox_role_key_filter,
+        "get_infobox_role_key_filter",
+        lambda fid: {"id": fid, "role_key": '"judge" -"chief judge"'} if int(fid) == 7 else None,
+    )
+
+    body = {
+        "country_id": 1,
+        "url": "https://en.wikipedia.org/wiki/Example",
+        "name": "Judge",
+        "infobox_role_key_filter_id": 7,
+        "find_date_in_infobox": True,
+    }
+
+    draft = main._office_draft_from_body(body, include_ref_names=False)
+    assert draft["infobox_role_key_filter_id"] == 7
+    assert draft["infobox_role_key"] == '"judge" -"chief judge"'
+
+
+def test_office_draft_prefers_explicit_infobox_role_key_over_filter(monkeypatch):
+    monkeypatch.setattr(
+        main.db_infobox_role_key_filter,
+        "get_infobox_role_key_filter",
+        lambda fid: {"id": fid, "role_key": '"judge" -"chief judge"'},
+    )
+
+    body = {
+        "country_id": 1,
+        "url": "https://en.wikipedia.org/wiki/Example",
+        "name": "Judge",
+        "infobox_role_key_filter_id": 7,
+        "infobox_role_key": '"associate justice" -"chief justice"',
+    }
+
+    draft = main._office_draft_from_body(body, include_ref_names=False)
+    assert draft["infobox_role_key"] == '"associate justice" -"chief justice"'


### PR DESCRIPTION
### Motivation
- Ensure preview and debug-export code paths apply include/exclude infobox role-key expressions when only an `infobox_role_key_filter_id` is provided, and repair legacy migrations that converted spaces to underscores in stored `role_key` expressions.
- Prevent empty/missing `infobox_role_key` from causing the parser to skip excludes like `-"chief judge"` during preview/export.

### Description
- Update `_office_draft_from_body` to accept and validate `infobox_role_key_filter_id` and to populate `infobox_role_key` from the referenced filter when an explicit key was not provided.
- Add `_resolve_infobox_role_key_from_filter_id(filter_id)` helper that resolves a filter id to its `role_key` text (returns empty string for missing/invalid ids).
- Resolve filter IDs to `infobox_role_key` in the debug/export worker and the debug preview/export paths so `parse_full_table_for_export` and `preview_with_config` receive the effective role-key expression.
- In `src/db/migrate.py`, change `_normalize_role_key` to normalize whitespace to single spaces instead of underscores and add `_migrate_infobox_role_key_filter_role_key_format` to repair legacy filter rows that contain quotes and underscores; wire the repair into migration flow.
- Add regression tests `src/test_main_infobox_filter_resolution.py` covering resolution from filter id and precedence of explicit `infobox_role_key` over a filter.

### Testing
- Ran `python -m py_compile src/main.py src/db/migrate.py` which succeeded with no syntax errors.
- Ran `PYTHONPATH=. pytest -q src/test_main_infobox_filter_resolution.py src/scraper/test_infobox_role_key.py src/db/test_test_scripts_serialization.py` and all tests passed (`12 passed`).
- Attempted `python scripts/test_debug_export.py debug/Judge_2026-02-22T17-11-36.txt` but the referenced debug file is not present in this environment, so that local export validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9046fbcc83289ecf7f664cb0ac1d)