### PR TITLE
Add manifest-backed parser test scripts with deterministic DB seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ flowchart LR
 ---
 
 
+
+## Parser test manifest workflow
+
+- Canonical parser test manifest: `test_scripts/manifest/parser_tests.json`.
+- Each manifest row includes: `name`, `test_type`, `html_file`, `source_url`, `config_json`, `expected_json`, `enabled`.
+- `html_file` must point to a committed local fixture path (for example `test_scripts/fixtures/...`) relative to the project root. Import validation rejects missing or absolute paths.
+- On app startup, `init_db()` seeds `parser_test_scripts` from the manifest **only when the DB table is empty**.
+- Conflict behavior is deterministic:
+  - Existing DB rows are not overwritten during startup seeding.
+  - Manifest updates do not auto-merge into non-empty DBs.
+  - To apply manifest updates to an existing DB, run explicit import with `overwrite_existing=True` in `src/db/test_scripts.py`.
+  - To publish DB edits back into source control, run explicit export from DB to the manifest (`export_manifest_from_db`).
+
 ## Windows PowerShell quick commands
 
 Use these command forms in **PowerShell** (not bash syntax):

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -47,8 +47,10 @@ def init_db(path: Path | None = None) -> None:
         conn.commit()
         from .seed import seed_reference_data
         from .migrate import migrate_to_fk
+        from . import test_scripts as db_test_scripts
         seed_reference_data(conn=conn)
         migrate_to_fk(conn=conn)
+        db_test_scripts.seed_db_from_manifest_if_empty(conn=conn)
         conn.executescript(OFFICES_PARTIES_INDEX_SQL)
         conn.commit()
     finally:

--- a/src/db/test_scripts.py
+++ b/src/db/test_scripts.py
@@ -13,11 +13,126 @@ from .utils import _row_to_dict
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 TEST_SCRIPTS_DIR = PROJECT_ROOT / "test_scripts"
+MANIFEST_PATH = TEST_SCRIPTS_DIR / "manifest" / "parser_tests.json"
 
 
 def ensure_test_scripts_dir() -> Path:
     TEST_SCRIPTS_DIR.mkdir(parents=True, exist_ok=True)
     return TEST_SCRIPTS_DIR
+
+
+def _manifest_item_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": row.get("name") or "",
+        "test_type": row.get("test_type") or "table_config",
+        "html_file": row.get("html_file") or "",
+        "source_url": row.get("source_url") or "",
+        "config_json": row.get("config_json") or {},
+        "expected_json": row.get("expected_json"),
+        "enabled": bool(row.get("enabled", True)),
+    }
+
+
+def _normalize_html_file_path(path_value: str) -> str:
+    rel = (path_value or "").strip()
+    if not rel:
+        raise ValueError("Manifest entry html_file is required")
+    rel_path = Path(rel)
+    if rel_path.is_absolute():
+        raise ValueError(f"html_file must be relative to project root: {rel}")
+    target = (PROJECT_ROOT / rel_path).resolve()
+    if not target.exists() or not target.is_file():
+        raise ValueError(f"html_file path does not exist: {rel}")
+    return rel_path.as_posix()
+
+
+def load_manifest(manifest_path: Path = MANIFEST_PATH) -> list[dict[str, Any]]:
+    if not manifest_path.exists():
+        return []
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("Parser test manifest must be a JSON array")
+    normalized: list[dict[str, Any]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("Each parser test manifest entry must be a JSON object")
+        normalized.append(
+            {
+                "name": (item.get("name") or "").strip(),
+                "test_type": (item.get("test_type") or "table_config").strip(),
+                "html_file": _normalize_html_file_path(item.get("html_file") or ""),
+                "source_url": (item.get("source_url") or "").strip(),
+                "config_json": item.get("config_json") if isinstance(item.get("config_json"), dict) else {},
+                "expected_json": item.get("expected_json"),
+                "enabled": bool(item.get("enabled", True)),
+            }
+        )
+    return normalized
+
+
+def export_manifest_from_db(manifest_path: Path = MANIFEST_PATH, conn: sqlite3.Connection | None = None) -> int:
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        rows = list_tests(conn=conn)
+        payload = [_manifest_item_from_row(r) for r in sorted(rows, key=lambda x: x.get("name") or "")]
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        return len(payload)
+    finally:
+        if own:
+            conn.close()
+
+
+def import_manifest_to_db(
+    manifest_path: Path = MANIFEST_PATH,
+    conn: sqlite3.Connection | None = None,
+    *,
+    overwrite_existing: bool = False,
+) -> dict[str, int]:
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        _ensure_table(conn)
+        imported = 0
+        skipped = 0
+        updated = 0
+        for item in load_manifest(manifest_path=manifest_path):
+            name = (item.get("name") or "").strip()
+            if not name:
+                raise ValueError("Manifest entry name is required")
+            existing = conn.execute("SELECT id FROM parser_test_scripts WHERE name = ?", (name,)).fetchone()
+            if existing:
+                if overwrite_existing:
+                    update_test(int(existing["id"]), item, conn=conn)
+                    updated += 1
+                else:
+                    skipped += 1
+                continue
+            create_test(item, conn=conn)
+            imported += 1
+        return {"imported": imported, "updated": updated, "skipped": skipped}
+    finally:
+        if own:
+            conn.close()
+
+
+def seed_db_from_manifest_if_empty(manifest_path: Path = MANIFEST_PATH, conn: sqlite3.Connection | None = None) -> int:
+    own = conn is None
+    if own:
+        conn = get_connection()
+    try:
+        _ensure_table(conn)
+        count = int(conn.execute("SELECT COUNT(*) FROM parser_test_scripts").fetchone()[0])
+        if count > 0:
+            return 0
+        result = import_manifest_to_db(manifest_path=manifest_path, conn=conn, overwrite_existing=False)
+        return int(result.get("imported", 0))
+    finally:
+        if own:
+            conn.close()
 
 
 def _ensure_table(conn: sqlite3.Connection) -> None:

--- a/src/db/test_test_scripts_manifest_sync.py
+++ b/src/db/test_test_scripts_manifest_sync.py
@@ -1,0 +1,99 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from src.db import test_scripts as db_test_scripts
+
+
+FIXTURE_REL_PATH = "test_scripts/fixtures/sample_parser_fixture.html"
+
+
+def _memory_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_import_manifest_to_db_inserts_rows(tmp_path: Path):
+    manifest = tmp_path / "parser_tests.json"
+    manifest.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "manifest-one",
+                    "test_type": "table_config",
+                    "html_file": FIXTURE_REL_PATH,
+                    "source_url": "https://example.test",
+                    "config_json": {"table_no": 1},
+                    "expected_json": [{"name": "Jane"}],
+                    "enabled": True,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    conn = _memory_conn()
+    try:
+        result = db_test_scripts.import_manifest_to_db(manifest_path=manifest, conn=conn)
+        assert result == {"imported": 1, "updated": 0, "skipped": 0}
+        rows = db_test_scripts.list_tests(conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["name"] == "manifest-one"
+    finally:
+        conn.close()
+
+
+def test_seed_db_from_manifest_if_empty_only_seeds_once(tmp_path: Path):
+    manifest = tmp_path / "parser_tests.json"
+    manifest.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "seeded-test",
+                    "test_type": "table_config",
+                    "html_file": FIXTURE_REL_PATH,
+                    "source_url": "https://example.test",
+                    "config_json": {"table_no": 1},
+                    "expected_json": [],
+                    "enabled": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    conn = _memory_conn()
+    try:
+        seeded = db_test_scripts.seed_db_from_manifest_if_empty(manifest_path=manifest, conn=conn)
+        assert seeded == 1
+        seeded_again = db_test_scripts.seed_db_from_manifest_if_empty(manifest_path=manifest, conn=conn)
+        assert seeded_again == 0
+        assert len(db_test_scripts.list_tests(conn=conn)) == 1
+    finally:
+        conn.close()
+
+
+def test_export_manifest_from_db_round_trip(tmp_path: Path):
+    conn = _memory_conn()
+    try:
+        db_test_scripts.create_test(
+            {
+                "name": "exported",
+                "test_type": "table_config",
+                "html_file": FIXTURE_REL_PATH,
+                "source_url": "https://example.test",
+                "config_json": {"table_no": 1},
+                "expected_json": [{"name": "Jane Doe"}],
+                "enabled": True,
+            },
+            conn=conn,
+        )
+        out_manifest = tmp_path / "out.json"
+        count = db_test_scripts.export_manifest_from_db(manifest_path=out_manifest, conn=conn)
+        assert count == 1
+        payload = json.loads(out_manifest.read_text(encoding="utf-8"))
+        assert payload[0]["name"] == "exported"
+        assert payload[0]["html_file"] == FIXTURE_REL_PATH
+    finally:
+        conn.close()

--- a/test_scripts/fixtures/sample_parser_fixture.html
+++ b/test_scripts/fixtures/sample_parser_fixture.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Sample Parser Fixture</title></head>
+  <body>
+    <table class="wikitable">
+      <tr><th>Name</th><th>Term start</th><th>Term end</th></tr>
+      <tr><td><a href="/wiki/Jane_Doe">Jane Doe</a></td><td>2020</td><td>2024</td></tr>
+    </table>
+  </body>
+</html>

--- a/test_scripts/manifest/parser_tests.json
+++ b/test_scripts/manifest/parser_tests.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "sample_parser_fixture",
+    "test_type": "table_config",
+    "html_file": "test_scripts/fixtures/sample_parser_fixture.html",
+    "source_url": "https://en.wikipedia.org/wiki/Example",
+    "config_json": {
+      "table_no": 1,
+      "table_rows": 1,
+      "link_column": 1,
+      "term_start_column": 2,
+      "term_end_column": 3
+    },
+    "expected_json": [
+      {
+        "name": "Jane Doe",
+        "term_start": "2020",
+        "term_end": "2024"
+      }
+    ],
+    "enabled": false
+  }
+]


### PR DESCRIPTION
### Motivation

- Provide a canonical, source-controlled manifest for parser tests so test inputs and expected outputs are tracked in the repo.
- Allow bi-directional sync between the SQLite `parser_test_scripts` table and the manifest to make review and CI reproducible.
- Ensure `html_file` references are committed fixtures (relative to project root) and seed the DB from the manifest deterministically on fresh installs.

### Description

- Add a canonical manifest file `test_scripts/manifest/parser_tests.json` and a sample fixture `test_scripts/fixtures/sample_parser_fixture.html` with the required fields (`name`, `test_type`, `html_file`, `source_url`, `config_json`, `expected_json`, `enabled`).
- Extend `src/db/test_scripts.py` with manifest helpers and validation: `MANIFEST_PATH`, `load_manifest`, `_normalize_html_file_path`, `_manifest_item_from_row`, `import_manifest_to_db(overwrite_existing=False)`, `export_manifest_from_db`, and `seed_db_from_manifest_if_empty` which validates `html_file` is relative and exists.
- Wire startup seeding by calling `db_test_scripts.seed_db_from_manifest_if_empty(conn=...)` from `src/db/connection.py:init_db()` so the table is populated from the manifest only when empty.
- Document deterministic conflict behavior and workflow guidance in `README.md` and add unit tests `src/db/test_test_scripts_manifest_sync.py` to exercise import/export and one-time seeding behavior.

### Testing

- Ran the parser-test unit suite with `PYTHONPATH=. pytest -q src/db/test_test_scripts_serialization.py src/db/test_test_scripts_manifest_sync.py` and all tests passed (`5 passed`).
- An initial `pytest` run without `PYTHONPATH=.` failed to collect due to module path resolution, which is addressed by running with `PYTHONPATH=.` as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e66d0e7c48328813e0856515fd6ba)