### PR TITLE
Add canonical fixture naming for saved parser test scripts

### DIFF
--- a/src/db/test_scripts.py
+++ b/src/db/test_scripts.py
@@ -34,10 +34,13 @@ def _manifest_item_from_row(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _normalize_html_file_path(path_value: str) -> str:
-    rel = (path_value or "").strip()
+    rel = (path_value or "").strip().replace("\\", "/")
     if not rel:
         raise ValueError("Manifest entry html_file is required")
-    rel_path = Path(rel)
+    rel_project = rel
+    if rel_project.startswith("fixtures/"):
+        rel_project = f"test_scripts/{rel_project}"
+    rel_path = Path(rel_project)
     if rel_path.is_absolute():
         raise ValueError(f"html_file must be relative to project root: {rel}")
     target = (PROJECT_ROOT / rel_path).resolve()

--- a/src/main.py
+++ b/src/main.py
@@ -2200,7 +2200,8 @@ def _snapshot_member_pages_for_test(
     source_url: str,
     config_json: dict,
     html_content: str,
-    file_prefix: str,
+    fixture_stem: str,
+    canonical_fixture_mode: bool,
 ) -> tuple[dict, list[str], list[str], list[dict]]:
     """Return (config_with_fixtures, fetched_urls, saved_files, actual_rows) for infobox-enabled table tests."""
     cfg = dict(config_json or {})
@@ -2242,8 +2243,12 @@ def _snapshot_member_pages_for_test(
         if resp.status_code != 200:
             continue
         safe_member = re.sub(r"[^a-zA-Z0-9._-]+", "_", (member_url.split("/")[-1] or f"member_{idx+1}"))
-        rel_name = f"{file_prefix}_{safe_member}.html"
+        if canonical_fixture_mode:
+            rel_name = f"fixtures/{fixture_stem}__member_{safe_member}.html"
+        else:
+            rel_name = f"{fixture_stem}_{safe_member}.html"
         dest = db_test_scripts.TEST_SCRIPTS_DIR / rel_name
+        dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(resp.text, encoding="utf-8")
         fixtures[member_url] = rel_name
         saved_files.append(rel_name)
@@ -2263,6 +2268,18 @@ def _table_config_properties_array(config_json: dict | None) -> list[dict]:
     for key in sorted(config_json.keys()):
         out.append({"property": key, "value": config_json.get(key)})
     return out
+
+
+def _slugify_fixture_name(value: str, *, fallback: str = "fixture") -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", (value or "").strip().lower()).strip("_")
+    return slug or fallback
+
+
+def _build_primary_fixture_rel_path(*, test_name: str, source_url: str, canonical_fixture_mode: bool) -> str:
+    if canonical_fixture_mode:
+        return f"fixtures/{_slugify_fixture_name(test_name, fallback='test_script')}.html"
+    safe_page = re.sub(r"[^a-zA-Z0-9._-]+", "_", (source_url.split("/")[-1] or "wiki_page"))
+    return f"{uuid.uuid4().hex}_{safe_page}.html"
 
 def _store_test_script_result(payload: dict) -> str:
     rid = uuid.uuid4().hex
@@ -2667,6 +2684,7 @@ async def api_create_test_script(request: Request):
     expected_json = body.get("expected_json")
     overwrite_html = bool(body.get("overwrite_html", False))
     delete_existing_files = bool(body.get("delete_existing_files", False))
+    canonical_fixture_mode = body.get("canonical_fixture_mode") is not False
 
     def _expected_missing(v):
         return v is None or (isinstance(v, list) and len(v) == 0)
@@ -2686,23 +2704,32 @@ async def api_create_test_script(request: Request):
         if overwrite_html:
             if not html_content.strip():
                 raise HTTPException(status_code=400, detail="Preview first to fetch new HTML before overwriting")
-            safe_page = re.sub(r"[^a-zA-Z0-9._-]+", "_", (source_url.split("/")[-1] or "wiki_page"))
-            prefix = f"{uuid.uuid4().hex}_{safe_page}"
-            dest = db_test_scripts.TEST_SCRIPTS_DIR / f"{prefix}.html"
+            rel_html_path = _build_primary_fixture_rel_path(
+                test_name=name,
+                source_url=source_url,
+                canonical_fixture_mode=canonical_fixture_mode,
+            )
+            fixture_stem = Path(rel_html_path).stem
+            dest = db_test_scripts.TEST_SCRIPTS_DIR / rel_html_path
+            dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_text(html_content, encoding="utf-8")
-            html_file = dest.name
+            html_file = rel_html_path
 
             config_json, _member_urls, _member_files, auto_rows = _snapshot_member_pages_for_test(
                 source_url=source_url,
                 config_json=config_json,
                 html_content=html_content,
-                file_prefix=prefix,
+                fixture_stem=fixture_stem,
+                canonical_fixture_mode=canonical_fixture_mode,
             )
             if _expected_missing(expected_json):
                 expected_json = auto_rows
 
             if delete_existing_files and (existing.get("html_file") or "").strip():
-                old_path = (db_test_scripts.TEST_SCRIPTS_DIR / existing["html_file"]).resolve()
+                old_rel = (existing["html_file"] or "").strip().replace("\\", "/")
+                if old_rel.startswith("test_scripts/"):
+                    old_rel = old_rel[len("test_scripts/"):]
+                old_path = (db_test_scripts.TEST_SCRIPTS_DIR / old_rel).resolve()
                 try:
                     if db_test_scripts.TEST_SCRIPTS_DIR in old_path.parents and old_path.exists():
                         old_path.unlink()
@@ -2714,7 +2741,10 @@ async def api_create_test_script(request: Request):
                     for _, rel_name in old_fx.items():
                         if not isinstance(rel_name, str):
                             continue
-                        old_member = (db_test_scripts.TEST_SCRIPTS_DIR / rel_name).resolve()
+                        member_rel = rel_name.strip().replace("\\", "/")
+                        if member_rel.startswith("test_scripts/"):
+                            member_rel = member_rel[len("test_scripts/"):]
+                        old_member = (db_test_scripts.TEST_SCRIPTS_DIR / member_rel).resolve()
                         try:
                             if db_test_scripts.TEST_SCRIPTS_DIR in old_member.parents and old_member.exists():
                                 old_member.unlink()
@@ -2736,16 +2766,22 @@ async def api_create_test_script(request: Request):
     if not html_content.strip():
         raise HTTPException(status_code=400, detail="Preview first to fetch HTML before saving")
 
-    safe_page = re.sub(r"[^a-zA-Z0-9._-]+", "_", (source_url.split("/")[-1] or "wiki_page"))
-    prefix = f"{uuid.uuid4().hex}_{safe_page}"
-    dest = db_test_scripts.TEST_SCRIPTS_DIR / f"{prefix}.html"
+    rel_html_path = _build_primary_fixture_rel_path(
+        test_name=name,
+        source_url=source_url,
+        canonical_fixture_mode=canonical_fixture_mode,
+    )
+    fixture_stem = Path(rel_html_path).stem
+    dest = db_test_scripts.TEST_SCRIPTS_DIR / rel_html_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(html_content, encoding="utf-8")
 
     config_json, _member_urls, _member_files, auto_rows = _snapshot_member_pages_for_test(
         source_url=source_url,
         config_json=config_json,
         html_content=html_content,
-        file_prefix=prefix,
+        fixture_stem=fixture_stem,
+        canonical_fixture_mode=canonical_fixture_mode,
     )
     if _expected_missing(expected_json):
         expected_json = auto_rows
@@ -2755,11 +2791,11 @@ async def api_create_test_script(request: Request):
         "test_type": test_type,
         "enabled": enabled,
         "source_url": source_url,
-        "html_file": dest.name,
+        "html_file": rel_html_path,
         "config_json": config_json,
         "expected_json": expected_json,
     })
-    return JSONResponse({"ok": True, "id": new_test_id, "html_file": dest.name, "updated": False})
+    return JSONResponse({"ok": True, "id": new_test_id, "html_file": rel_html_path, "updated": False})
 
 
 @app.post("/api/test-scripts/{test_id}/enabled")

--- a/src/scraper/test_script_runner.py
+++ b/src/scraper/test_script_runner.py
@@ -26,7 +26,10 @@ TEST_SCRIPTS_DIR = PROJECT_ROOT / "test_scripts"
 
 
 def _fixture_path(name: str) -> Path:
-    return (TEST_SCRIPTS_DIR / (name or "")).resolve()
+    rel = (name or "").strip().replace("\\", "/")
+    if rel.startswith("test_scripts/"):
+        rel = rel[len("test_scripts/"):]
+    return (TEST_SCRIPTS_DIR / rel).resolve()
 
 
 def _load_member_fixture_html(cfg: dict[str, Any]) -> dict[str, str]:
@@ -115,7 +118,7 @@ DEFAULT_TABLE_CONFIG = {
 
 
 def _load_html(html_file: str) -> str:
-    path = (TEST_SCRIPTS_DIR / (html_file or "")).resolve()
+    path = _fixture_path(html_file)
     if TEST_SCRIPTS_DIR not in path.parents and path != TEST_SCRIPTS_DIR:
         raise ValueError("Invalid html path")
     if not path.exists():

--- a/src/scraper/test_script_runner_path_resolution.py
+++ b/src/scraper/test_script_runner_path_resolution.py
@@ -1,0 +1,11 @@
+from src.scraper import test_script_runner
+
+
+def test_fixture_path_accepts_test_scripts_prefix() -> None:
+    p = test_script_runner._fixture_path("test_scripts/fixtures/example.html")
+    assert p == test_script_runner.TEST_SCRIPTS_DIR / "fixtures/example.html"
+
+
+def test_fixture_path_accepts_relative_fixture_path() -> None:
+    p = test_script_runner._fixture_path("fixtures/example.html")
+    assert p == test_script_runner.TEST_SCRIPTS_DIR / "fixtures/example.html"

--- a/src/test_fixture_naming.py
+++ b/src/test_fixture_naming.py
@@ -1,0 +1,21 @@
+import re
+
+from src.main import _build_primary_fixture_rel_path
+
+
+def test_primary_fixture_uses_canonical_slug() -> None:
+    rel = _build_primary_fixture_rel_path(
+        test_name="My Fancy Test!",
+        source_url="https://en.wikipedia.org/wiki/Sample",
+        canonical_fixture_mode=True,
+    )
+    assert rel == "fixtures/my_fancy_test.html"
+
+
+def test_primary_fixture_uuid_mode_preserved() -> None:
+    rel = _build_primary_fixture_rel_path(
+        test_name="My Fancy Test!",
+        source_url="https://en.wikipedia.org/wiki/Sample",
+        canonical_fixture_mode=False,
+    )
+    assert re.match(r"^[a-f0-9]{32}_Sample\.html$", rel)


### PR DESCRIPTION
### Motivation
- Make committed parser fixtures deterministic and readable in Git by introducing canonical fixture names instead of always using UUIDs. 
- Preserve UUID-based names for ephemeral/local-only captures so existing workflows are unaffected.
- Ensure member-page snapshots created for infobox parsing follow the same deterministic convention so fixtures are consistent and easy to review.

### Description
- Add `canonical_fixture_mode` handling to `/api/test-scripts` create/update flows and use `_build_primary_fixture_rel_path` to produce either `test_scripts/fixtures/{slugified_test_name}.html` (canonical) or the previous `UUID_page.html` names (ephemeral). (changes: `src/main.py`)
- Change `_snapshot_member_pages_for_test` to accept a `fixture_stem` and `canonical_fixture_mode` and write member fixtures as `fixtures/{fixture_stem}__member_{safe_member}.html` in canonical mode while preserving old behavior for UUID-mode, and ensure parent directories are created. (changes: `src/main.py`)
- Add `_slugify_fixture_name` and `_build_primary_fixture_rel_path` helpers to generate deterministic fixture paths derived from test names. (changes: `src/main.py`)
- Normalize fixture path handling in the test-runner and manifest loader by accepting both `fixtures/...` and `test_scripts/fixtures/...` references and resolving them under `test_scripts/`. (changes: `src/scraper/test_script_runner.py`, `src/db/test_scripts.py`)
- Update overwrite/delete flows to normalize stored html paths before removing files so canonical fixture paths and legacy paths are handled safely. (changes: `src/main.py`)
- Add unit tests for canonical vs UUID primary fixture naming and for fixture path resolution. (added: `src/test_fixture_naming.py`, `src/scraper/test_script_runner_path_resolution.py`)

### Testing
- Ran the new unit tests with `PYTHONPATH=. pytest -q src/test_fixture_naming.py src/scraper/test_script_runner_path_resolution.py` and all tests passed (4 passed) with 2 deprecation warnings from FastAPI.  All added tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e67e297088328ba1b2e8608be1760)