### PR TITLE
Add parser fixture manifest validation script and CI gate

### DIFF
--- a/.github/workflows/validate-parser-fixtures.yml
+++ b/.github/workflows/validate-parser-fixtures.yml
@@ -1,0 +1,22 @@
+name: Validate Parser Fixtures
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate-parser-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate parser fixture manifest
+        run: python scripts/validate_parser_fixtures.py

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ flowchart LR
 
 ## Parser test manifest workflow
 
+### Test scripts
+
+- Validate parser fixtures before commit or deploy:
+  ```bash
+  python scripts/validate_parser_fixtures.py
+  ```
+- Optional: validate a custom manifest path:
+  ```bash
+  python scripts/validate_parser_fixtures.py path/to/parser_tests.json
+  ```
+- The validator checks required manifest keys, verifies `html_file` fixture paths exist, and enforces that `config_json` and `expected_json` are JSON objects/arrays. It exits non-zero with per-entry error messages when any fixture row is broken.
+
 - Canonical parser test manifest: `test_scripts/manifest/parser_tests.json`.
 - Each manifest row includes: `name`, `test_type`, `html_file`, `source_url`, `config_json`, `expected_json`, `enabled`.
 - `html_file` must point to a committed local fixture path (for example `test_scripts/fixtures/...`) relative to the project root. Import validation rejects missing or absolute paths.

--- a/scripts/validate_parser_fixtures.py
+++ b/scripts/validate_parser_fixtures.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Validate parser fixture manifest references and JSON value shapes."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = PROJECT_ROOT / "test_scripts" / "manifest" / "parser_tests.json"
+REQUIRED_KEYS = (
+    "name",
+    "test_type",
+    "html_file",
+    "source_url",
+    "config_json",
+    "expected_json",
+    "enabled",
+)
+
+
+def _entry_label(index: int, entry: Any) -> str:
+    if isinstance(entry, dict):
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip():
+            return f"entry[{index}] '{name}'"
+    return f"entry[{index}]"
+
+
+def validate_manifest(manifest_path: Path) -> list[str]:
+    errors: list[str] = []
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [f"Manifest not found: {manifest_path}"]
+    except json.JSONDecodeError as exc:
+        return [f"Manifest is not valid JSON: {manifest_path} ({exc})"]
+
+    if not isinstance(payload, list):
+        return [f"Manifest root must be a JSON array: {manifest_path}"]
+
+    for index, entry in enumerate(payload):
+        label = _entry_label(index, entry)
+
+        if not isinstance(entry, dict):
+            errors.append(f"{label}: manifest entry must be a JSON object")
+            continue
+
+        missing_keys = [key for key in REQUIRED_KEYS if key not in entry]
+        if missing_keys:
+            errors.append(f"{label}: missing required keys: {', '.join(missing_keys)}")
+
+        html_file = entry.get("html_file")
+        if not isinstance(html_file, str) or not html_file.strip():
+            errors.append(f"{label}: html_file must be a non-empty string")
+        else:
+            html_path = Path(html_file.strip())
+            if html_path.is_absolute():
+                errors.append(f"{label}: html_file must be a relative path, got absolute path '{html_file}'")
+            elif not (PROJECT_ROOT / html_path).is_file():
+                errors.append(f"{label}: html_file does not exist at '{html_file}'")
+
+        for key in ("config_json", "expected_json"):
+            value = entry.get(key)
+            if not isinstance(value, (dict, list)):
+                actual = type(value).__name__
+                errors.append(f"{label}: {key} must be a JSON object or array, got {actual}")
+
+    return errors
+
+
+def main() -> int:
+    manifest_path = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else DEFAULT_MANIFEST
+    errors = validate_manifest(manifest_path)
+
+    if errors:
+        print(f"Parser fixture validation failed for {manifest_path}:")
+        for err in errors:
+            print(f"- {err}")
+        return 1
+
+    print(f"Parser fixture validation passed for {manifest_path} ({len(json.loads(manifest_path.read_text(encoding='utf-8')))} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Prevent broken parser test fixtures from being merged by validating the manifest and referenced HTML fixtures early.
- Provide a lightweight, deterministic check that `config_json` and `expected_json` shapes and `html_file` paths are correct before deploy.

### Description

- Add `scripts/validate_parser_fixtures.py` which loads the manifest, enforces required keys, checks that `html_file` is a relative path that exists, and verifies `config_json`/`expected_json` are JSON objects/arrays while emitting clear per-entry error messages.
- Add a GitHub Actions workflow `.github/workflows/validate-parser-fixtures.yml` that runs `python scripts/validate_parser_fixtures.py` on `pull_request` and `push` to `main` to block broken references in CI.
- Update `README.md` under the parser test manifest section with usage examples for the validator and a short description of the checks performed.

### Testing

- Ran `python scripts/validate_parser_fixtures.py` against the default manifest and it exited successfully with: "Parser fixture validation passed".
- The new CI workflow is configured to run the same validation command on PRs and pushes to `main` (no runtime CI run was executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e68e18e948328a6b73c6568048446)