### PR TITLE
Support legacy basename fixture names in test HTML loader and add unit test

### DIFF
--- a/src/scraper/test_script_runner.py
+++ b/src/scraper/test_script_runner.py
@@ -118,9 +118,16 @@ DEFAULT_TABLE_CONFIG = {
 
 
 def _load_html(html_file: str) -> str:
-    path = _fixture_path(html_file)
+    raw_name = (html_file or "").strip()
+    path = _fixture_path(raw_name)
     if TEST_SCRIPTS_DIR not in path.parents and path != TEST_SCRIPTS_DIR:
         raise ValueError("Invalid html path")
+    # Backward compatibility: older DB rows stored basename-only fixture names.
+    # If a direct lookup fails, also try test_scripts/fixtures/<basename>.
+    if not path.exists() and raw_name and "/" not in raw_name.replace("\\", "/"):
+        fallback = (TEST_SCRIPTS_DIR / "fixtures" / raw_name).resolve()
+        if TEST_SCRIPTS_DIR in fallback.parents and fallback.exists():
+            path = fallback
     if not path.exists():
         raise ValueError(f"HTML file not found: {html_file}")
     return path.read_text(encoding="utf-8")

--- a/src/scraper/test_script_runner_path_resolution.py
+++ b/src/scraper/test_script_runner_path_resolution.py
@@ -9,3 +9,16 @@ def test_fixture_path_accepts_test_scripts_prefix() -> None:
 def test_fixture_path_accepts_relative_fixture_path() -> None:
     p = test_script_runner._fixture_path("fixtures/example.html")
     assert p == test_script_runner.TEST_SCRIPTS_DIR / "fixtures/example.html"
+
+
+def test_load_html_supports_legacy_basename_pointing_to_fixtures(tmp_path, monkeypatch) -> None:
+    scripts_dir = tmp_path / "test_scripts"
+    fixtures_dir = scripts_dir / "fixtures"
+    fixtures_dir.mkdir(parents=True)
+    sample = fixtures_dir / "legacy_name.html"
+    sample.write_text("<html>ok</html>", encoding="utf-8")
+
+    monkeypatch.setattr(test_script_runner, "TEST_SCRIPTS_DIR", scripts_dir)
+
+    out = test_script_runner._load_html("legacy_name.html")
+    assert out == "<html>ok</html>"


### PR DESCRIPTION
### Motivation
- Ensure backward compatibility with older DB rows that stored only the basename of fixture HTML files so tests can load those files without requiring full paths.
### Description
- Trim input and pass the normalized name to `_fixture_path` by using `raw_name = (html_file or "").strip()` and `path = _fixture_path(raw_name)` to avoid issues with surrounding whitespace.
- If a direct lookup fails for a basename-only input, attempt a fallback lookup under `TEST_SCRIPTS_DIR / "fixtures" / <basename>` and use it when present and safe.
- Add a unit test `test_load_html_supports_legacy_basename_pointing_to_fixtures` in `test_script_runner_path_resolution.py` that verifies loading a basename-only fixture works against a temporary `test_scripts/fixtures` directory.
### Testing
- Ran the path-resolution tests including the new `test_load_html_supports_legacy_basename_pointing_to_fixtures` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5f9e32508328a2bab7e8ddb6aaf9)