### PR TITLE
Add remote sync warning banner for unsynced local changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,9 @@ Notes:
 
 - Repo is safe to refresh: `data/`, `*.db`, `logs/`, and `debug/` are in `.gitignore`. Your DB, logs, and debug exports are not removed on pull.
 - `sample files/` is tracked so the sample script and CSV stay in the repo.
+- UI now shows a **Remote sync warning** banner when local work is not synced (uncommitted changes, local commits ahead of remote, or branch not yet pushed).
+- Recommended workflow when direct pushes to `dev` are blocked:
+  1. Create/switch to a feature branch once (`git checkout -b feature/<name>`).
+  2. Keep committing additional saves to that same branch until ready.
+  3. Push with upstream tracking (`git push -u origin feature/<name>`), then normal `git push` for later commits.
+  4. After merge, create a new feature branch for the next unit of work.

--- a/src/main.py
+++ b/src/main.py
@@ -76,6 +76,79 @@ _ui_test_job_lock = threading.Lock()
 PROCESS_TYPES = ["run", "preview_all"]
 
 
+def _run_git_command(args: list[str]) -> str:
+    """Run a git command at repo root and return stripped stdout (empty on error)."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(ROOT),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return (result.stdout or "").strip()
+    except Exception:
+        return ""
+
+
+def _get_git_sync_status() -> dict:
+    """Return git sync metadata for UI banner display."""
+    inside_repo = _run_git_command(["rev-parse", "--is-inside-work-tree"]) == "true"
+    if not inside_repo:
+        return {"unsynced": False}
+
+    branch = _run_git_command(["symbolic-ref", "--quiet", "--short", "HEAD"]) or "(detached HEAD)"
+    upstream = _run_git_command(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"])
+    dirty = bool(_run_git_command(["status", "--porcelain"]))
+    ahead = 0
+    behind = 0
+
+    if upstream:
+        counts = _run_git_command(["rev-list", "--left-right", "--count", f"HEAD...{upstream}"])
+        parts = counts.split()
+        if len(parts) == 2:
+            try:
+                behind = int(parts[0])
+                ahead = int(parts[1])
+            except ValueError:
+                ahead = 0
+                behind = 0
+
+    unsynced = dirty or ahead > 0 or not upstream
+    if not unsynced:
+        return {"unsynced": False}
+
+    if not upstream:
+        message = (
+            "Local changes are not synced to a remote branch yet. "
+            "Create/push a feature branch (for example: git push -u origin "
+            f"{branch}) because direct pushes to dev are blocked."
+        )
+    elif dirty:
+        message = (
+            "You have local edits not yet committed. Commit to this feature branch, "
+            "then push to sync with remote."
+        )
+    else:
+        message = (
+            f"You are {ahead} commit(s) ahead of {upstream}. "
+            "Push this feature branch to sync remote."
+        )
+
+    return {
+        "unsynced": True,
+        "branch": branch,
+        "upstream": upstream,
+        "ahead": ahead,
+        "behind": behind,
+        "dirty": dirty,
+        "message": message,
+    }
+
+
+templates.env.globals["git_sync_status"] = _get_git_sync_status
+
+
 class PreviewCancelled(Exception):
     """Raised when the user cancels an async preview job."""
 

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -98,3 +98,21 @@ form { max-width: 640px; }
 .storage-note { margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--text-muted); }
 .storage-note code { font-size: 0.875em; }
 .imprecise-hint { color: var(--text-muted); font-size: 0.875em; }
+
+
+.sync-banner {
+  margin: 1rem auto 0;
+  max-width: 960px;
+  padding: 0.75rem 1rem;
+  border: 1px solid #f08c00;
+  background: rgba(240, 140, 0, 0.15);
+  color: #ffd8a8;
+  border-radius: 4px;
+}
+.sync-banner code {
+  color: #ffe8cc;
+}
+.sync-banner .sync-meta {
+  margin-left: 0.75rem;
+  color: var(--text-muted);
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -44,6 +44,14 @@
       <li><a href="/report/milestones">Milestone report</a></li>
     </ul>
   </nav>
+  {% set git_sync = git_sync_status() %}
+  {% if git_sync.unsynced %}
+    <div class="sync-banner" role="alert">
+      <strong>Remote sync warning:</strong> {{ git_sync.message }}
+      {% if git_sync.branch %}<span class="sync-meta">Branch: <code>{{ git_sync.branch }}</code></span>{% endif %}
+      {% if git_sync.upstream %}<span class="sync-meta">Tracking: <code>{{ git_sync.upstream }}</code></span>{% endif %}
+    </div>
+  {% endif %}
   <main class="container{% block container_class %}{% endblock %}">
     {% block content %}{% endblock %}
     <p class="storage-note"><small>All data (offices, parties, individuals, office terms) is saved locally in <code>data/office_holder.db</code> and persists after you close the browser or restart the app.</small></p>


### PR DESCRIPTION
## Summary
- added git sync status helpers in `src/main.py` to detect unsynced local state (no upstream, uncommitted edits, or local commits ahead of remote)
- exposed sync status to Jinja via `templates.env.globals["git_sync_status"]`
- rendered a top-level warning banner in `src/templates/base.html` with branch/tracking details and action guidance
- styled the banner in `src/static/css/theme.css`
- documented feature-branch workflow and the new warning behavior in `README.md`

## Why
This makes it obvious when local edits are not yet on a remote feature branch, which helps teams where direct pushes to `dev` are forbidden.

## Validation
- `python -m py_compile src/main.py`
- manual UI check by launching the app and capturing an `/offices` screenshot with the new banner

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e71cc43e4832882f4371cbf695d47)