### PR TITLE
Add Render deployment config and Google OAuth authentication

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+services:
+  - type: web
+    name: office-holder
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn src.main:app --host 0.0.0.0 --port $PORT
+    plan: free
+    disk:
+      name: app-data
+      mountPath: /data
+      sizeGB: 1
+    envVars:
+      - key: OFFICE_HOLDER_DB_PATH
+        value: /data/office_holder.db
+      - key: SECRET_KEY
+        generateValue: true
+      - key: GOOGLE_CLIENT_ID
+        sync: false
+      - key: GOOGLE_CLIENT_SECRET
+        sync: false
+      - key: ALLOWED_EMAIL
+        sync: false
+      - key: APP_BASE_URL
+        sync: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ fastapi>=0.100.0
 uvicorn[standard]>=0.22.0
 jinja2>=3.1.0
 python-multipart>=0.0.6
+
+# Auth
+authlib>=1.3.0
+httpx>=0.27.0
+itsdangerous>=2.1.0

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -22,14 +22,17 @@ def get_db_path() -> Path:
 
 
 def get_log_dir() -> Path:
-    """Return the path to the logs directory."""
+    """Return the path to the logs directory. When OFFICE_HOLDER_DB_PATH is set, logs live next to the DB."""
+    env_path = os.environ.get("OFFICE_HOLDER_DB_PATH")
+    if env_path:
+        return Path(env_path).parent / "logs"
     return LOG_DIR
 
 
 def ensure_data_dir() -> None:
     """Create data and logs directories if they don't exist."""
     DATA_DIR.mkdir(parents=True, exist_ok=True)
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    get_log_dir().mkdir(parents=True, exist_ok=True)
 
 
 def get_connection(path: Path | None = None) -> sqlite3.Connection:

--- a/src/main.py
+++ b/src/main.py
@@ -30,6 +30,8 @@ from fastapi import FastAPI, File, Request, Form, HTTPException, Query, UploadFi
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+from authlib.integrations.starlette_client import OAuth
 
 from src.db.connection import init_db, get_connection
 from src.db import offices as db_offices
@@ -48,6 +50,72 @@ from src.scraper.test_script_runner import run_test_script, run_test_script_from
 from src.scraper.wiki_fetch import WIKIPEDIA_REQUEST_HEADERS, wiki_url_to_rest_html_url, normalize_wiki_url
 
 app = FastAPI(title="Office Holder")
+app.add_middleware(SessionMiddleware, secret_key=os.environ.get("SECRET_KEY", "dev-only-insecure-key"))
+
+# Google OAuth setup
+_oauth = OAuth()
+_oauth.register(
+    name="google",
+    client_id=os.environ.get("GOOGLE_CLIENT_ID"),
+    client_secret=os.environ.get("GOOGLE_CLIENT_SECRET"),
+    server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+    client_kwargs={"scope": "openid email profile"},
+)
+
+_ALLOWED_EMAIL = os.environ.get("ALLOWED_EMAIL", "")
+_APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
+_AUTH_ENABLED = bool(os.environ.get("GOOGLE_CLIENT_ID"))
+
+# Auth middleware — skips public paths and dev mode (no GOOGLE_CLIENT_ID set)
+_PUBLIC_PATHS = {"/login", "/auth/google", "/auth/google/callback"}
+
+
+@app.middleware("http")
+async def require_login(request: Request, call_next):
+    if not _AUTH_ENABLED:
+        return await call_next(request)
+    if request.url.path in _PUBLIC_PATHS or request.url.path.startswith("/static"):
+        return await call_next(request)
+    if not request.session.get("user_email"):
+        return RedirectResponse("/login")
+    return await call_next(request)
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.get("/auth/google")
+async def auth_google(request: Request):
+    redirect_uri = (_APP_BASE_URL.rstrip("/") + "/auth/google/callback") if _APP_BASE_URL else str(request.url_for("auth_google_callback"))
+    return await _oauth.google.authorize_redirect(request, redirect_uri)
+
+
+@app.get("/auth/google/callback", name="auth_google_callback")
+async def auth_google_callback(request: Request):
+    try:
+        token = await _oauth.google.authorize_access_token(request)
+    except Exception:
+        return HTMLResponse("<h2>Authentication failed. <a href='/login'>Try again</a>.</h2>", status_code=400)
+    user_info = token.get("userinfo") or {}
+    email = user_info.get("email", "")
+    if not email or email.lower() != _ALLOWED_EMAIL.lower():
+        return HTMLResponse(
+            "<h2>Access denied.</h2><p>This app is restricted to a single authorised account.</p>"
+            "<p><a href='/login'>Back to login</a></p>",
+            status_code=403,
+        )
+    request.session["user_email"] = email
+    return RedirectResponse("/")
+
+
+@app.get("/logout")
+async def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse("/login")
+
+
 # Resolve to absolute path so template dir is correct regardless of process cwd
 TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -3307,11 +3375,14 @@ async def office_preview_page(request: Request, office_id: int):
     if not office:
         raise HTTPException(status_code=404)
     # #region agent log
-    import json
-    from pathlib import Path
-    _log_path = Path(__file__).resolve().parent.parent / ".cursor" / "debug.log"
-    with open(_log_path, "a", encoding="utf-8") as _f:
-        _f.write(json.dumps({"location": "main.py:office_preview_page", "message": "preview page using run_with_db", "data": {"office_id": office_id, "url": (office.get("url") or "")[:80], "table_no": office.get("table_no"), "hypothesisId": "H3"}, "timestamp": __import__("time").time() * 1000}) + "\n")
+    try:
+        import json
+        from pathlib import Path
+        _log_path = Path(__file__).resolve().parent.parent / ".cursor" / "debug.log"
+        with open(_log_path, "a", encoding="utf-8") as _f:
+            _f.write(json.dumps({"location": "main.py:office_preview_page", "message": "preview page using run_with_db", "data": {"office_id": office_id, "url": (office.get("url") or "")[:80], "table_no": office.get("table_no"), "hypothesisId": "H3"}, "timestamp": __import__("time").time() * 1000}) + "\n")
+    except Exception:
+        pass
     # #endregion
     unit_ids = db_offices.get_runnable_unit_ids_for_office(office_id) or [office_id]
     result = run_with_db(

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -73,7 +73,13 @@ def get_table_html_cached(url: str, table_no: int = 1, refresh: bool = False, us
     Returns {"table_no", "num_tables", "html": "<table>...</table>"} or {"error": "..."}.
     """
     # #region agent log
-    _debug_log = lambda loc, msg, data: (_open := open(Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log", "a", encoding="utf-8"), _open.write(json.dumps({"location": loc, "message": msg, "data": data, "timestamp": __import__("time").time() * 1000}) + "\n"), _open.close())
+    def _debug_log(loc, msg, data):
+        try:
+            _open = open(Path(__file__).resolve().parent.parent.parent / ".cursor" / "debug.log", "a", encoding="utf-8")
+            _open.write(json.dumps({"location": loc, "message": msg, "data": data, "timestamp": __import__("time").time() * 1000}) + "\n")
+            _open.close()
+        except Exception:
+            pass
     # #endregion
     url = (url or "").strip()
     if not url:

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sign in — Office Holder</title>
+  <link rel="stylesheet" href="/static/css/theme.css">
+  <style>
+    .login-wrap {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 60vh;
+      gap: 1.5rem;
+    }
+    .login-card {
+      padding: 2.5rem 3rem;
+      border: 1px solid var(--border, #444);
+      border-radius: 8px;
+      text-align: center;
+      max-width: 360px;
+      width: 100%;
+    }
+    .login-card h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1.4rem;
+    }
+    .login-card p {
+      margin: 0 0 1.5rem;
+      opacity: 0.7;
+      font-size: 0.9rem;
+    }
+    .btn-google {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 0.6rem 1.4rem;
+      font-size: 1rem;
+      border-radius: 4px;
+      text-decoration: none;
+      background: #4285f4;
+      color: #fff;
+      font-weight: 500;
+    }
+    .btn-google:hover { background: #3367d6; }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <div class="login-wrap">
+      <div class="login-card">
+        <h1>Office Holder</h1>
+        <p>Sign in to continue</p>
+        <a class="btn-google" href="/auth/google">
+          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+            <path fill="#fff" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z"/>
+            <path fill="#fff" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
+            <path fill="#fff" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"/>
+            <path fill="#fff" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
+          </svg>
+          Sign in with Google
+        </a>
+      </div>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
- render.yaml: defines free-tier web service with 1GB persistent disk at /data
- requirements.txt: add authlib, httpx, itsdangerous for OAuth
- src/main.py: add SessionMiddleware, Google OAuth routes (/login, /auth/google, /auth/google/callback, /logout), and require_login middleware (auto-disabled when GOOGLE_CLIENT_ID is not set)
- src/db/connection.py: fix get_log_dir() to derive log path from OFFICE_HOLDER_DB_PATH when set, so logs land on the persistent disk on Render
- src/scraper/table_cache.py: wrap _debug_log in try/except so .cursor/debug.log writes silently fail on Render
- src/templates/login.html: minimal Google sign-in page matching app style