### PR TITLE
Phase 5: HTML hash-based delta skip for unchanged offices

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -80,6 +80,7 @@ def migrate_to_fk(conn=None):
         # cities table and source_pages.city_id
         _migrate_city(conn)
         _migrate_source_pages_disable_auto_table_update(conn)
+        _migrate_office_table_config_html_hash(conn)
     finally:
         if own_conn:
             conn.close()
@@ -948,4 +949,15 @@ def _migrate_infobox_role_key(conn):
         conn.execute("ALTER TABLE offices ADD COLUMN infobox_role_key TEXT NOT NULL DEFAULT ''")
         changed = True
     if changed:
+        conn.commit()
+
+
+def _migrate_office_table_config_html_hash(conn):
+    """Add last_html_hash to office_table_config if missing."""
+    try:
+        cols = _columns(conn, "office_table_config")
+    except sqlite3.OperationalError:
+        return
+    if "last_html_hash" not in cols:
+        conn.execute("ALTER TABLE office_table_config ADD COLUMN last_html_hash TEXT")
         conn.commit()

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -404,7 +404,7 @@ def list_runnable_units(conn: sqlite3.Connection | None = None) -> list[dict[str
                       tc.term_start_column, tc.term_end_column, tc.district_column, tc.filter_column, tc.filter_criteria, tc.dynamic_parse, tc.read_right_to_left,
                       tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                       tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                      tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, tc.notes AS tc_notes, tc.created_at
+                      tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, tc.notes AS tc_notes, tc.created_at, tc.last_html_hash
                FROM source_pages p
                JOIN office_details od ON od.source_page_id = p.id AND od.enabled = 1
                JOIN office_table_config tc ON tc.office_details_id = od.id AND tc.enabled = 1
@@ -430,15 +430,32 @@ def list_runnable_units(conn: sqlite3.Connection | None = None) -> list[dict[str
             )
             p = {"url": rd.get("url"), "country_id": rd.get("country_id"), "state_id": rd.get("state_id"), "city_id": rd.get("city_id"), "level_id": rd.get("level_id"), "branch_id": rd.get("branch_id"), "notes": rd.get("page_notes"), "enabled": rd.get("page_enabled"), "disable_auto_table_update": rd.get("disable_auto_table_update")}
             od = {"id": od_id, "name": rd.get("name"), "department": rd.get("department"), "notes": rd.get("notes"), "alt_link_include_main": rd.get("alt_link_include_main"), "enabled": rd.get("od_enabled")}
-            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "filter_column": rd.get("filter_column"), "filter_criteria": rd.get("filter_criteria"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "ignore_non_links": rd.get("ignore_non_links"), "remove_duplicates": rd.get("remove_duplicates"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "infobox_role_key_filter_id": rd.get("infobox_role_key_filter_id"), "infobox_role_key": rd.get("infobox_role_key"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at")}
+            tc = {"table_no": rd.get("table_no"), "table_rows": rd.get("table_rows"), "link_column": rd.get("link_column"), "party_column": rd.get("party_column"), "term_start_column": rd.get("term_start_column"), "term_end_column": rd.get("term_end_column"), "district_column": rd.get("district_column"), "filter_column": rd.get("filter_column"), "filter_criteria": rd.get("filter_criteria"), "dynamic_parse": rd.get("dynamic_parse"), "read_right_to_left": rd.get("read_right_to_left"), "find_date_in_infobox": rd.get("find_date_in_infobox"), "parse_rowspan": rd.get("parse_rowspan"), "rep_link": rd.get("rep_link"), "party_link": rd.get("party_link"), "enabled": rd.get("tc_enabled"), "use_full_page_for_table": rd.get("use_full_page_for_table"), "years_only": rd.get("years_only"), "term_dates_merged": rd.get("term_dates_merged"), "party_ignore": rd.get("party_ignore"), "district_ignore": rd.get("district_ignore"), "district_at_large": rd.get("district_at_large"), "ignore_non_links": rd.get("ignore_non_links"), "remove_duplicates": rd.get("remove_duplicates"), "consolidate_rowspan_terms": rd.get("consolidate_rowspan_terms"), "infobox_role_key_filter_id": rd.get("infobox_role_key_filter_id"), "infobox_role_key": rd.get("infobox_role_key"), "notes": rd.get("tc_notes"), "created_at": rd.get("created_at"), "last_html_hash": rd.get("last_html_hash")}
             flat = _flatten_hierarchy_row(p, od, tc, c, s, lv, b, alt_links)
             flat["id"] = rd["office_table_config_id"]
             flat["office_details_id"] = od_id
             flat["office_table_config_id"] = rd["office_table_config_id"]
             flat["country_id"] = rd.get("country_id")
             flat["disable_auto_table_update"] = bool(rd.get("disable_auto_table_update"))
+            flat["last_html_hash"] = rd.get("last_html_hash")
             out.append(flat)
         return out
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def update_html_hash(tc_id: int, html_hash: str, conn: sqlite3.Connection | None = None) -> None:
+    """Store the SHA-256 hash of the last-parsed HTML for an office_table_config row."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE office_table_config SET last_html_hash = ? WHERE id = ?",
+            (html_hash, tc_id),
+        )
+        conn.commit()
     finally:
         if own_conn:
             conn.close()

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -6,6 +6,7 @@ Supports: dry_run / test_run (no DB write), row limits, Full / Delta / Live pers
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 import sys
 import time
@@ -715,6 +716,8 @@ def run_with_db(
     revalidate_missing_holders_list: list[list[str]] = []  # full list per office when failure is "missing holders"
     office_errors: list[dict[str, Any]] = []  # offices that raised; run continues for others
     cancelled_early = False
+    offices_unchanged = 0
+    html_hashes_to_update: dict[int, str] = {}
     bio_success_count = 0
     bio_error_count = 0
     bio_errors: list[dict[str, str]] = []
@@ -825,6 +828,23 @@ def run_with_db(
             logger.log(f"Cached table: {cache_result['cache_file']}", True)
         html_content = cache_result.get("html") or ""
         cached_table_html = html_content if html_content else None
+
+        # Hash-based skip: if HTML unchanged since last run and office has terms, skip re-parse
+        html_hash = hashlib.sha256(html_content.encode("utf-8")).hexdigest() if html_content else None
+        stored_hash = office_row.get("last_html_hash")
+        if (
+            run_mode == "delta"
+            and not refresh_table_cache
+            and not dry_run
+            and not test_run
+            and html_hash
+            and html_hash == stored_hash
+            and has_existing
+        ):
+            offices_unchanged += 1
+            continue
+        if html_hash:
+            html_hashes_to_update[office_id] = html_hash
 
         # When office has existing terms and find_date_in_infobox is on: validate from table-only parse first
         # so we don't fetch infoboxes only to fail validation later.
@@ -1087,6 +1107,8 @@ def run_with_db(
                     )
                 if individual_id:
                     db_individuals._recompute_is_living_for_individual(individual_id, conn)
+            for tc_id, h in html_hashes_to_update.items():
+                db_offices.update_html_hash(tc_id, h, conn=conn)
         finally:
             conn.close()
 
@@ -1334,6 +1356,7 @@ def run_with_db(
 
     return {
         "office_count": len(offices),
+        "offices_unchanged": offices_unchanged,
         "terms_parsed": total_terms,
         "unique_wiki_urls": len(unique_wiki_urls),
         "bio_success_count": bio_success_count,

--- a/src/scraper/test_html_hash_skip.py
+++ b/src/scraper/test_html_hash_skip.py
@@ -1,0 +1,235 @@
+"""Tests for HTML hash-based delta skip in runner.py."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Helpers (same as tests/test_scenarios.py)
+# ---------------------------------------------------------------------------
+
+def _cache_key(url: str, table_no: int, use_full_page: bool = False) -> str:
+    normalized = (
+        url.strip() + "|" + str(table_no) + "|" + ("1" if use_full_page else "0")
+    ).encode("utf-8")
+    return hashlib.sha256(normalized).hexdigest()[:32]
+
+
+def _extract_table(html: str, table_no: int) -> tuple[str, int]:
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup(html, "html.parser")
+    tables = soup.find_all("table")
+    num_tables = len(tables)
+    if not (1 <= table_no <= num_tables):
+        raise ValueError(f"Table {table_no} not found (page has {num_tables} tables)")
+    return str(tables[table_no - 1]), num_tables
+
+
+def _write_cache(
+    cache_dir: Path,
+    url: str,
+    table_no: int,
+    table_html: str,
+    use_full_page: bool = False,
+    num_tables: int = 1,
+) -> None:
+    key = _cache_key(url, table_no, use_full_page)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / f"{key}.json.gz"
+    with gzip.open(cache_path, "wt", encoding="utf-8") as f:
+        json.dump(
+            {"table_no": table_no, "num_tables": num_tables, "html": table_html},
+            f,
+            ensure_ascii=False,
+        )
+
+
+def _setup_db_and_office(tmp_path, monkeypatch):
+    """Init DB, seed one office from first manifest entry. Returns (db_path, cache_dir, tc_id, source_url, table_no, table_html, config)."""
+    db_path = tmp_path / "test_run.db"
+    cache_dir = tmp_path / "wiki_cache"
+    monkeypatch.setenv("OFFICE_HOLDER_DB_PATH", str(db_path))
+
+    from src.db.connection import DB_PATH, init_db, get_connection
+    from src.db import offices as db_offices
+    import src.scraper.table_cache as table_cache_mod
+
+    assert str(db_path) != str(DB_PATH), "test DB must not point at production DB"
+    monkeypatch.setattr(table_cache_mod, "_cache_dir", lambda: cache_dir)
+
+    init_db(path=db_path)
+    conn = get_connection(db_path)
+    try:
+        row = conn.execute(
+            "SELECT id FROM countries WHERE name = ? LIMIT 1",
+            ("United States of America",),
+        ).fetchone()
+        assert row, "Seed data missing: no United States country"
+        country_id = row[0]
+
+        manifest_path = PROJECT_ROOT / "test_scripts" / "manifest" / "parser_tests.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        entry = manifest[0]
+        source_url = (entry.get("source_url") or "").strip()
+        html_file = entry.get("html_file") or ""
+        config = dict(entry.get("config_json") or {})
+        assert source_url and html_file
+
+        html_path = PROJECT_ROOT / html_file.replace("/", os.sep)
+        full_html = html_path.read_text(encoding="utf-8")
+        table_no = int(config.get("table_no", 1))
+        table_html, num_tables = _extract_table(full_html, table_no)
+
+        office_data = {
+            "country_id": country_id,
+            "url": source_url,
+            "name": "Test Office (hash skip)",
+            "enabled": 1,
+            **config,
+        }
+        office_details_id = db_offices.create_office(office_data, conn=conn)
+        conn.commit()
+
+        tc_row = conn.execute(
+            "SELECT id FROM office_table_config WHERE office_details_id = ? ORDER BY id LIMIT 1",
+            (office_details_id,),
+        ).fetchone()
+        assert tc_row, "No office_table_config row created"
+        tc_id = tc_row[0]
+    finally:
+        conn.close()
+
+    _write_cache(
+        cache_dir,
+        source_url,
+        table_no,
+        table_html,
+        use_full_page=bool(config.get("use_full_page_for_table", False)),
+        num_tables=num_tables,
+    )
+
+    return db_path, cache_dir, tc_id, source_url, table_no, table_html, config
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_hash_skip_activates_on_second_run(tmp_path, monkeypatch):
+    """Second delta run with unchanged HTML reports offices_unchanged == 1, term count stable."""
+    db_path, cache_dir, tc_id, source_url, table_no, table_html, config = _setup_db_and_office(
+        tmp_path, monkeypatch
+    )
+
+    from src.scraper.runner import run_with_db
+
+    # First run: hash is null → always parses, stores hash, writes terms
+    result1 = run_with_db(
+        run_mode="delta",
+        dry_run=False,
+        test_run=False,
+        run_office_bio=False,
+        office_ids=[tc_id],
+    )
+    assert result1["terms_parsed"] > 0, "Expected terms from first run"
+    assert result1.get("offices_unchanged", 0) == 0, "First run should not skip any offices"
+
+    # Second run: hash matches → skip
+    result2 = run_with_db(
+        run_mode="delta",
+        dry_run=False,
+        test_run=False,
+        run_office_bio=False,
+        office_ids=[tc_id],
+    )
+    assert result2.get("offices_unchanged", 0) == 1, "Second run should skip unchanged office"
+    assert result2["terms_parsed"] == 0, "No new terms should be parsed on skip"
+
+    # Verify DB term count is unchanged
+    from src.db.connection import get_connection
+    conn = get_connection(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM office_terms").fetchone()[0]
+    finally:
+        conn.close()
+    assert count > 0, "Terms should exist after first run"
+
+
+@pytest.mark.integration
+def test_hash_skip_bypassed_when_html_changes(tmp_path, monkeypatch):
+    """When cache HTML is updated between runs, second run re-parses (offices_unchanged == 0)."""
+    db_path, cache_dir, tc_id, source_url, table_no, table_html, config = _setup_db_and_office(
+        tmp_path, monkeypatch
+    )
+
+    from src.scraper.runner import run_with_db
+
+    # First run: populates hash
+    result1 = run_with_db(
+        run_mode="delta",
+        dry_run=False,
+        test_run=False,
+        run_office_bio=False,
+        office_ids=[tc_id],
+    )
+    assert result1["terms_parsed"] > 0
+
+    # Overwrite cache with slightly different HTML
+    modified_html = table_html + "<!-- modified -->"
+    _write_cache(
+        cache_dir,
+        source_url,
+        table_no,
+        modified_html,
+        use_full_page=bool(config.get("use_full_page_for_table", False)),
+    )
+
+    # Second run: hash differs → re-parses
+    result2 = run_with_db(
+        run_mode="delta",
+        dry_run=False,
+        test_run=False,
+        run_office_bio=False,
+        office_ids=[tc_id],
+    )
+    assert result2.get("offices_unchanged", 0) == 0, "Changed HTML should not be skipped"
+
+
+@pytest.mark.integration
+def test_hash_skip_bypassed_with_refresh_table_cache(tmp_path, monkeypatch):
+    """refresh_table_cache=True always re-parses regardless of hash."""
+    db_path, cache_dir, tc_id, source_url, table_no, table_html, config = _setup_db_and_office(
+        tmp_path, monkeypatch
+    )
+
+    from src.scraper.runner import run_with_db
+
+    # First run: store hash
+    run_with_db(
+        run_mode="delta",
+        dry_run=False,
+        test_run=False,
+        run_office_bio=False,
+        office_ids=[tc_id],
+    )
+
+    # Second run with refresh=True: should re-parse even though HTML is unchanged
+    result2 = run_with_db(
+        run_mode="delta",
+        dry_run=False,
+        test_run=False,
+        run_office_bio=False,
+        office_ids=[tc_id],
+        refresh_table_cache=True,
+    )
+    assert result2.get("offices_unchanged", 0) == 0, "refresh_table_cache=True should bypass skip"


### PR DESCRIPTION
Store SHA-256 of last-parsed HTML on office_table_config.last_html_hash. On delta runs, skip re-parsing offices whose HTML hasn't changed since the last run and already have existing terms — reducing redundant work.

- src/db/migrate.py: add _migrate_office_table_config_html_hash migration
- src/db/offices.py: add update_html_hash(), expose last_html_hash in list_runnable_units()
- src/scraper/runner.py: hash check + hash update logic, offices_unchanged in return dict
- src/scraper/test_html_hash_skip.py: 3 integration tests (skip activates, bypassed on change, bypassed on refresh)