### PR TITLE
Fix render.yaml for Render Blueprint adoption

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,10 +1,10 @@
 services:
   - type: web
-    name: office-holder
+    name: office_holder_cursor
     runtime: python
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn src.main:app --host 0.0.0.0 --port $PORT
-    plan: free
+    plan: starter
     disk:
       name: app-data
       mountPath: /data


### PR DESCRIPTION
Corrects service name (office-holder → office_holder_cursor) and plan (free → starter) so Render Blueprint can adopt the existing live service.