### PR TITLE
Add 30 new tests: API endpoints, DB layer, scheduled tasks, scraper utils

### DIFF
--- a/src/db/test_db_layer.py
+++ b/src/db/test_db_layer.py
@@ -1,0 +1,140 @@
+"""DB layer unit tests — refs, parties, office terms, bulk import.
+
+All tests use the `tmp_db` fixture from conftest.py (fully initialised,
+seeded SQLite DB). No network access, no HTTP.
+
+Run: pytest src/db/test_db_layer.py -v
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.db import refs as db_refs
+from src.db import parties as db_parties
+from src.db import offices as db_offices
+from src.db import office_terms as db_terms
+from src.db.bulk_import import bulk_import_offices_from_csv
+
+
+# ---------------------------------------------------------------------------
+# Country ref tests
+# ---------------------------------------------------------------------------
+
+def test_create_country_raises_on_duplicate_name(tmp_db):
+    """Creating a country with a duplicate name raises ValueError."""
+    db_refs.create_country("Testland", conn=tmp_db)
+    with pytest.raises(ValueError, match="already exists"):
+        db_refs.create_country("Testland", conn=tmp_db)
+
+
+def test_delete_country_raises_when_in_use_by_party(tmp_db):
+    """delete_country raises ValueError when a party references the country."""
+    country_id = db_refs.create_country("Partyville", conn=tmp_db)
+    db_parties.create_party(
+        {"country_id": country_id, "party_name": "TestParty", "party_link": "/wiki/TestParty"},
+        conn=tmp_db,
+    )
+    with pytest.raises(ValueError, match="parties"):
+        db_refs.delete_country(country_id, conn=tmp_db)
+
+
+# ---------------------------------------------------------------------------
+# Party resolution tests
+# ---------------------------------------------------------------------------
+
+def test_resolve_party_id_by_country_matches_name_and_link(tmp_db):
+    """resolve_party_id_by_country matches by name and by link."""
+    country_id = db_refs.create_country("Resolveland", conn=tmp_db)
+    party_id = db_parties.create_party(
+        {"country_id": country_id, "party_name": "Republican", "party_link": "/wiki/Republican_Party"},
+        conn=tmp_db,
+    )
+
+    assert db_parties.resolve_party_id_by_country(country_id, "Republican", conn=tmp_db) == party_id
+    assert db_parties.resolve_party_id_by_country(country_id, "/wiki/Republican_Party", conn=tmp_db) == party_id
+    assert db_parties.resolve_party_id_by_country(country_id, "Unknown Party", conn=tmp_db) is None
+
+
+def test_resolve_party_id_by_country_returns_none_for_empty_input(tmp_db):
+    """resolve_party_id_by_country returns None for empty or None input."""
+    # Use seeded country_id=1 (United States of America)
+    assert db_parties.resolve_party_id_by_country(1, "", conn=tmp_db) is None
+    assert db_parties.resolve_party_id_by_country(1, None, conn=tmp_db) is None
+
+
+# ---------------------------------------------------------------------------
+# Office terms insert / count / delete
+# ---------------------------------------------------------------------------
+
+def _make_office(conn) -> tuple[int, int]:
+    """Create a minimal office, return (office_details_id, office_table_config_id)."""
+    data = {
+        "country_id": 1,  # United States of America (seeded)
+        "state_id": None,
+        "city_id": None,
+        "level_id": None,
+        "branch_id": None,
+        "department": "",
+        "name": "Test Senate",
+        "enabled": True,
+        "notes": "",
+        "url": "https://en.wikipedia.org/wiki/Test_Senate",
+        "table_configs": [
+            {
+                "name": "",
+                "table_no": 1,
+                "table_rows": 1,
+                "link_column": 1,
+                "party_column": 0,
+                "term_start_column": 2,
+                "term_end_column": 3,
+                "district_column": 0,
+                "enabled": 1,
+            }
+        ],
+    }
+    od_id = db_offices.create_office(data, conn=conn)
+    cur = conn.execute("SELECT id FROM office_table_config WHERE office_details_id = ? LIMIT 1", (od_id,))
+    tc_id = cur.fetchone()["id"]
+    return od_id, tc_id
+
+
+def test_insert_office_term_and_count_and_delete(tmp_db):
+    """Insert a term, count it, then delete it."""
+    od_id, tc_id = _make_office(tmp_db)
+
+    db_terms.insert_office_term(
+        office_details_id=od_id,
+        office_table_config_id=tc_id,
+        wiki_url="https://en.wikipedia.org/wiki/Jane_Smith",
+        conn=tmp_db,
+    )
+
+    assert db_terms.count_terms_for_office(od_id, conn=tmp_db) == 1
+
+    deleted = db_terms.delete_office_terms_for_office(tc_id, conn=tmp_db)
+    assert deleted == 1
+    assert db_terms.count_terms_for_office(od_id, conn=tmp_db) == 0
+
+
+# ---------------------------------------------------------------------------
+# Bulk import CSV
+# ---------------------------------------------------------------------------
+
+def test_bulk_import_offices_from_csv_valid_and_invalid_rows(tmp_db, tmp_path):
+    """CSV bulk import: 1 valid row + 2 invalid rows → (imported=1, errors=2)."""
+    header = "Country,Level,Branch,Department,Name,State,URL,Table No,Table Rows,Link Column,Party Column,Term Start Column,Term End Column,District,Dynamic Parse,Read columns right to left,Find Date,Parse Rowspan,Consolidate Rowspan Terms,Rep Link,Party Link,Notes,Alt Link\n"
+    row_valid = "United States of America,Federal,Executive,,Valid Office,,https://en.wikipedia.org/wiki/Valid,1,4,1,0,4,5,0,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,\n"
+    row_no_url = "United States of America,,,, No URL Office,,,1,4,1,0,4,5,0,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,\n"
+    row_bad_country = "Nonexistent Country,,,, Bad Country,,https://en.wikipedia.org/wiki/Bad,1,4,1,0,4,5,0,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE,,\n"
+
+    csv_file = tmp_path / "import.csv"
+    csv_file.write_text(header + row_valid + row_no_url + row_bad_country, encoding="utf-8")
+
+    imported, errors = bulk_import_offices_from_csv(csv_file, conn=tmp_db)
+    assert imported == 1
+    assert errors == 2

--- a/src/scraper/test_table_parser_edge_cases.py
+++ b/src/scraper/test_table_parser_edge_cases.py
@@ -1,0 +1,77 @@
+"""Pure unit tests for scraper utility functions.
+
+No DB, no network, no fixtures required.
+
+Run: pytest src/scraper/test_table_parser_edge_cases.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.scraper.table_parser import parse_infobox_role_key_query
+from src.db.bulk_import import _bool_from_cell, _int_from_cell
+from src.scheduled_tasks import _format_duration
+
+
+# ---------------------------------------------------------------------------
+# parse_infobox_role_key_query
+# ---------------------------------------------------------------------------
+
+def test_parse_infobox_role_key_query_empty_string():
+    """Empty input returns empty includes and excludes."""
+    includes, excludes = parse_infobox_role_key_query("")
+    assert includes == []
+    assert excludes == []
+
+
+def test_parse_infobox_role_key_query_includes_and_excludes():
+    """Quoted includes and excludes are parsed correctly."""
+    includes, excludes = parse_infobox_role_key_query('"judge" "associate justice" -"chief judge"')
+    assert "judge" in includes
+    assert "associate justice" in includes
+    assert "chief judge" in excludes
+
+
+# ---------------------------------------------------------------------------
+# _bool_from_cell
+# ---------------------------------------------------------------------------
+
+def test_bool_from_cell_variants():
+    """_bool_from_cell converts CSV TRUE/FALSE/yes/1 values correctly."""
+    assert _bool_from_cell("TRUE") == 1
+    assert _bool_from_cell("true") == 1
+    assert _bool_from_cell("yes") == 1
+    assert _bool_from_cell("YES") == 1
+    assert _bool_from_cell("1") == 1
+    assert _bool_from_cell("FALSE") == 0
+    assert _bool_from_cell("false") == 0
+    assert _bool_from_cell("") == 0
+    assert _bool_from_cell(None) == 0
+    assert _bool_from_cell("no") == 0
+
+
+# ---------------------------------------------------------------------------
+# _int_from_cell
+# ---------------------------------------------------------------------------
+
+def test_int_from_cell_with_bad_values():
+    """_int_from_cell returns default on non-integer input."""
+    assert _int_from_cell("abc", default=99) == 99
+    assert _int_from_cell(None, default=3) == 3
+    assert _int_from_cell("", default=7) == 7
+    assert _int_from_cell("5") == 5
+    assert _int_from_cell("0") == 0
+
+
+# ---------------------------------------------------------------------------
+# _format_duration
+# ---------------------------------------------------------------------------
+
+def test_format_duration_minutes_and_seconds():
+    """_format_duration formats seconds into human-readable duration."""
+    assert _format_duration(90) == "1m 30s"
+    assert _format_duration(45) == "45s"
+    assert _format_duration(0) == "0s"
+    assert _format_duration(60) == "1m 0s"
+    assert _format_duration(3661) == "61m 1s"

--- a/src/test_api_endpoints.py
+++ b/src/test_api_endpoints.py
@@ -1,0 +1,127 @@
+"""Tests for the scraper run and table-cache-refresh API endpoints.
+
+Uses FastAPI TestClient (no live server). The DB is initialised into a
+temp directory; Datasette startup is suppressed so no subprocess is spawned.
+
+Run: pytest src/test_api_endpoints.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import importlib
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    """TestClient with a temp DB and Datasette suppressed."""
+    tmp = tmp_path_factory.mktemp("api_ep_db")
+    db_path = tmp / "api_ep_test.db"
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    import src.main as main_mod
+    original_start = main_mod._start_datasette
+    original_stop = main_mod._stop_datasette
+    main_mod._start_datasette = lambda: None
+    main_mod._stop_datasette = lambda: None
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as c:
+        yield c
+
+    main_mod._start_datasette = original_start
+    main_mod._stop_datasette = original_stop
+    os.environ.pop("OFFICE_HOLDER_DB_PATH", None)
+
+
+# ---------------------------------------------------------------------------
+# /api/run
+# ---------------------------------------------------------------------------
+
+def test_api_run_returns_202_and_job_id(client):
+    """POST /api/run returns 202 with a job_id key."""
+    resp = client.post("/api/run", data={"run_mode": "delta"})
+    assert resp.status_code == 202
+    body = resp.json()
+    assert "job_id" in body
+    assert body["job_id"]
+
+
+def test_api_run_status_returns_valid_shape_for_new_job(client):
+    """Immediately after starting a run, status endpoint returns a valid shape."""
+    resp = client.post("/api/run", data={"run_mode": "delta"})
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    status_resp = client.get(f"/api/run/status/{job_id}")
+    assert status_resp.status_code == 200
+    body = status_resp.json()
+    assert body["status"] in ("running", "complete", "error")
+    assert "progress" in body
+    assert "office" in body["progress"]
+
+
+def test_api_run_status_404_for_unknown_job_id(client):
+    """Status endpoint returns 404 for a job ID that does not exist."""
+    resp = client.get("/api/run/status/nonexistent-uuid-abc")
+    assert resp.status_code == 404
+
+
+def test_api_run_cancel_404_for_unknown_job_id(client):
+    """Cancel endpoint returns 404 for a job ID that does not exist."""
+    resp = client.post("/api/run/cancel/nonexistent-uuid-abc")
+    assert resp.status_code == 404
+
+
+def test_api_run_cancel_409_when_job_already_complete(client):
+    """Cancel endpoint returns 409 when the job is not running."""
+    import uuid
+    from src.routers.run_scraper import _run_job_store, _run_job_lock
+
+    fake_job_id = str(uuid.uuid4())
+    with _run_job_lock:
+        _run_job_store[fake_job_id] = {
+            "status": "complete",
+            "progress": {},
+            "cancelled": False,
+        }
+
+    try:
+        resp = client.post(f"/api/run/cancel/{fake_job_id}")
+        assert resp.status_code == 409
+        assert resp.json()["ok"] is False
+    finally:
+        with _run_job_lock:
+            _run_job_store.pop(fake_job_id, None)
+
+
+# ---------------------------------------------------------------------------
+# /api/refresh-table-cache
+# ---------------------------------------------------------------------------
+
+def test_api_refresh_table_cache_400_for_missing_url(client):
+    """refresh-table-cache returns 400 when url is empty."""
+    resp = client.post(
+        "/api/refresh-table-cache",
+        json={"url": "", "table_no": 1},
+    )
+    assert resp.status_code == 400
+
+
+def test_api_refresh_table_cache_400_for_invalid_json(client):
+    """refresh-table-cache returns 400 when body is not valid JSON."""
+    resp = client.post(
+        "/api/refresh-table-cache",
+        content=b"not json at all",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400

--- a/src/test_data_routes.py
+++ b/src/test_data_routes.py
@@ -1,0 +1,68 @@
+"""Tests for data-view routes: /data/individuals, /data/office-terms, /report/milestones.
+
+Validates that each page renders 200 on an empty DB and that pagination
+query params are accepted without error.
+
+Run: pytest src/test_data_routes.py -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    """TestClient with a temp DB and Datasette suppressed."""
+    tmp = tmp_path_factory.mktemp("data_routes_db")
+    db_path = tmp / "data_routes_test.db"
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    import src.main as main_mod
+    original_start = main_mod._start_datasette
+    original_stop = main_mod._stop_datasette
+    main_mod._start_datasette = lambda: None
+    main_mod._stop_datasette = lambda: None
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as c:
+        yield c
+
+    main_mod._start_datasette = original_start
+    main_mod._stop_datasette = original_stop
+    os.environ.pop("OFFICE_HOLDER_DB_PATH", None)
+
+
+# ---------------------------------------------------------------------------
+# Data view tests
+# ---------------------------------------------------------------------------
+
+def test_data_individuals_renders_200(client):
+    """GET /data/individuals returns 200 on an empty DB."""
+    resp = client.get("/data/individuals")
+    assert resp.status_code == 200
+
+
+def test_data_office_terms_renders_200(client):
+    """GET /data/office-terms returns 200 on an empty DB."""
+    resp = client.get("/data/office-terms")
+    assert resp.status_code == 200
+
+
+def test_data_office_terms_pagination_params_accepted(client):
+    """GET /data/office-terms with limit/offset params returns 200."""
+    resp = client.get("/data/office-terms?limit=10&offset=5")
+    assert resp.status_code == 200
+
+
+def test_report_milestones_renders_200(client):
+    """GET /report/milestones returns 200 — validates date-window SQL on empty DB."""
+    resp = client.get("/report/milestones")
+    assert resp.status_code == 200

--- a/src/test_router_refs_api.py
+++ b/src/test_router_refs_api.py
@@ -1,0 +1,109 @@
+"""Tests for the reference-data dropdown API endpoints.
+
+Uses FastAPI TestClient (no live server). The seeded DB always contains
+"United States of America" + states, Federal/State/Local levels, and
+Executive/Legislative/Judicial branches.
+
+Run: pytest src/test_router_refs_api.py -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    """TestClient with a seeded temp DB and Datasette suppressed."""
+    tmp = tmp_path_factory.mktemp("refs_api_db")
+    db_path = tmp / "refs_api_test.db"
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    import src.main as main_mod
+    original_start = main_mod._start_datasette
+    original_stop = main_mod._stop_datasette
+    main_mod._start_datasette = lambda: None
+    main_mod._stop_datasette = lambda: None
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as c:
+        yield c
+
+    main_mod._start_datasette = original_start
+    main_mod._stop_datasette = original_stop
+    os.environ.pop("OFFICE_HOLDER_DB_PATH", None)
+
+
+# ---------------------------------------------------------------------------
+# /api/countries
+# ---------------------------------------------------------------------------
+
+def test_api_countries_returns_list(client):
+    """GET /api/countries returns a JSON list with id and name keys."""
+    resp = client.get("/api/countries")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) > 0
+    assert "id" in body[0]
+    assert "name" in body[0]
+    names = [r["name"] for r in body]
+    assert "United States of America" in names
+
+
+# ---------------------------------------------------------------------------
+# /api/states
+# ---------------------------------------------------------------------------
+
+def test_api_states_with_valid_country_id_returns_list(client):
+    """GET /api/states?country_id=<us_id> returns US states."""
+    countries = client.get("/api/countries").json()
+    us = next(r for r in countries if r["name"] == "United States of America")
+
+    resp = client.get(f"/api/states?country_id={us['id']}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) > 0
+    state_names = [r["name"] for r in body]
+    assert "California" in state_names
+
+
+def test_api_states_with_zero_country_id_returns_empty(client):
+    """GET /api/states?country_id=0 returns an empty list."""
+    resp = client.get("/api/states?country_id=0")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# /api/levels and /api/branches
+# ---------------------------------------------------------------------------
+
+def test_api_levels_returns_list(client):
+    """GET /api/levels returns seeded levels."""
+    resp = client.get("/api/levels")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) > 0
+    names = [r["name"] for r in body]
+    assert "Federal" in names
+
+
+def test_api_branches_returns_list(client):
+    """GET /api/branches returns seeded branches."""
+    resp = client.get("/api/branches")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) > 0
+    names = [r["name"] for r in body]
+    assert "Executive" in names

--- a/src/test_scheduled_tasks.py
+++ b/src/test_scheduled_tasks.py
@@ -1,0 +1,117 @@
+"""Tests for scheduled_tasks.py — daily delta run and email summary.
+
+All SMTP calls are replaced with a FakeSMTP spy. No network access.
+
+Run: pytest src/test_scheduled_tasks.py -v
+"""
+
+from __future__ import annotations
+
+import smtplib
+from datetime import datetime, timezone
+
+
+# ---------------------------------------------------------------------------
+# SMTP spy
+# ---------------------------------------------------------------------------
+
+class _FakeSMTP:
+    """Context-manager SMTP stub that records sendmail calls."""
+    instances: list["_FakeSMTP"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.sent: list[tuple] = []
+        _FakeSMTP.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def login(self, user, password):
+        pass
+
+    def sendmail(self, from_addr, to_addrs, msg):
+        self.sent.append((from_addr, to_addrs, msg))
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_send_summary_email_skips_when_no_password(monkeypatch):
+    """_send_summary_email does nothing when EMAIL_APP_PASSWORD is not set."""
+    monkeypatch.delenv("EMAIL_APP_PASSWORD", raising=False)
+
+    _FakeSMTP.instances.clear()
+    monkeypatch.setattr(smtplib, "SMTP_SSL", _FakeSMTP)
+
+    from src.scheduled_tasks import _send_summary_email
+    _send_summary_email({}, 10.0, _now())
+
+    assert _FakeSMTP.instances == [], "SMTP_SSL should not be instantiated when no password"
+
+
+def test_send_summary_email_sends_when_password_set(monkeypatch):
+    """_send_summary_email sends one email containing summary fields."""
+    monkeypatch.setenv("EMAIL_APP_PASSWORD", "fake-password")
+    monkeypatch.setenv("EMAIL_FROM", "from@test.com")
+    monkeypatch.setenv("EMAIL_TO", "to@test.com")
+
+    _FakeSMTP.instances.clear()
+    monkeypatch.setattr(smtplib, "SMTP_SSL", _FakeSMTP)
+
+    from src.scheduled_tasks import _send_summary_email
+    result = {
+        "office_count": 10,
+        "offices_unchanged": 3,
+        "terms_parsed": 42,
+        "bio_success_count": 5,
+        "bio_error_count": 1,
+    }
+    _send_summary_email(result, 90.0, _now())
+
+    assert len(_FakeSMTP.instances) == 1
+    smtp = _FakeSMTP.instances[0]
+    assert len(smtp.sent) == 1
+    _, _, raw_msg = smtp.sent[0]
+
+    # Body may be base64-encoded; parse with email stdlib to get plain text.
+    import email as _email
+    parsed = _email.message_from_string(raw_msg)
+    body = parsed.get_payload(decode=True)
+    if body is not None:
+        body_text = body.decode("utf-8")
+    else:
+        body_text = parsed.get_payload()
+    assert "Terms parsed" in body_text
+    assert "42" in body_text
+
+
+def test_run_daily_delta_sends_crash_email_on_exception(monkeypatch):
+    """run_daily_delta catches scraper exceptions and emails the crash output."""
+    monkeypatch.setenv("EMAIL_APP_PASSWORD", "fake-password")
+    monkeypatch.setenv("EMAIL_FROM", "from@test.com")
+    monkeypatch.setenv("EMAIL_TO", "to@test.com")
+
+    _FakeSMTP.instances.clear()
+    monkeypatch.setattr(smtplib, "SMTP_SSL", _FakeSMTP)
+
+    def _explode(**kwargs):
+        raise RuntimeError("scraper exploded")
+
+    monkeypatch.setattr("src.scraper.runner.run_with_db", _explode)
+
+    from src.scheduled_tasks import run_daily_delta
+    run_daily_delta()  # must not raise
+
+    assert len(_FakeSMTP.instances) == 1
+    smtp = _FakeSMTP.instances[0]
+    assert len(smtp.sent) == 1
+    _, _, raw_msg = smtp.sent[0]
+    assert "FAILED" in raw_msg


### PR DESCRIPTION
## Summary
- **`src/test_api_endpoints.py`** (7): Run job API contracts (202, status shape, 404/409 guards), refresh-table-cache 400 guards
- **`src/test_router_refs_api.py`** (5): Countries/states/levels/branches dropdown endpoints and seed data validation
- **`src/test_scheduled_tasks.py`** (3): Email skipped without password, email body content, crash-to-email path
- **`src/db/test_db_layer.py`** (6): Duplicate country guard, ref-integrity delete, party resolution, office term CRUD, CSV bulk import
- **`src/test_data_routes.py`** (4): Data views render on empty DB, pagination params accepted
- **`src/scraper/test_table_parser_edge_cases.py`** (5): `parse_infobox_role_key_query`, `_bool_from_cell`, `_int_from_cell`, `_format_duration`

## Test plan
- [x] All 30 new tests pass
- [x] Full suite: 160 passed, 11 skipped (Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)