### PR TITLE
Add env-based pause toggle for daily scheduled run

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -28,3 +28,5 @@ services:
         value: wcmchenry3@gmail.com
       - key: EMAIL_TO
         value: wcmchenry3@gmail.com
+      - key: DAILY_DELTA_ENABLED
+        value: "1"

--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ from src.routers import preview as preview_router
 from src.routers import offices as offices_router
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from src.routers._deps import templates
-from src.scheduled_tasks import run_daily_delta
+from src.scheduled_tasks import is_daily_delta_enabled, run_daily_delta
 
 
 @asynccontextmanager
@@ -88,9 +88,12 @@ async def lifespan(app: FastAPI):
         raise RuntimeError(f"Database startup failed: {e}") from e
     _start_datasette()
     scheduler = AsyncIOScheduler(timezone="UTC")
-    scheduler.add_job(run_daily_delta, "cron", hour=6, minute=0, id="daily_delta")
+    if is_daily_delta_enabled():
+        scheduler.add_job(run_daily_delta, "cron", hour=6, minute=0, id="daily_delta")
+        print("[scheduler] Daily delta run scheduled at 06:00 UTC")
+    else:
+        print("[scheduler] Daily delta job is paused (DAILY_DELTA_ENABLED is disabled)")
     scheduler.start()
-    print("[scheduler] Daily delta run scheduled at 06:00 UTC")
     yield
     scheduler.shutdown(wait=False)
     _stop_datasette()

--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -10,6 +10,7 @@ Required env var (for email):
 Optional env vars:
     EMAIL_FROM          — sender address (default: wcmchenry3@gmail.com)
     EMAIL_TO            — recipient address (default: wcmchenry3@gmail.com)
+    DAILY_DELTA_ENABLED — set to 0/false/no/off to pause daily job (default: enabled)
 """
 
 from __future__ import annotations
@@ -24,6 +25,12 @@ from datetime import datetime, timezone
 from email.mime.text import MIMEText
 
 _DEFAULT_EMAIL = "wcmchenry3@gmail.com"
+
+
+def is_daily_delta_enabled() -> bool:
+    """Return True unless DAILY_DELTA_ENABLED is set to a false-like value."""
+    raw = os.environ.get("DAILY_DELTA_ENABLED", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
 
 
 def _run_daily_delta_in_subprocess(today_batch: int) -> dict:
@@ -66,6 +73,10 @@ print(json.dumps(result))
 
 def run_daily_delta() -> None:
     """Entry point called by APScheduler at 06:00 UTC each day."""
+    if not is_daily_delta_enabled():
+        print("[scheduler] Daily delta run skipped because DAILY_DELTA_ENABLED is disabled")
+        return
+
     from src.scraper.runner import _cleanup_disk_cache
 
     run_start = datetime.now(timezone.utc)

--- a/src/test_scheduled_tasks.py
+++ b/src/test_scheduled_tasks.py
@@ -121,3 +121,29 @@ def test_run_daily_delta_sends_crash_email_on_exception(monkeypatch):
     assert len(smtp.sent) == 1
     _, _, raw_msg = smtp.sent[0]
     assert "FAILED" in raw_msg
+
+
+def test_is_daily_delta_enabled_parses_false_values(monkeypatch):
+    from src.scheduled_tasks import is_daily_delta_enabled
+
+    for raw in ("0", "false", "False", "NO", "off"):
+        monkeypatch.setenv("DAILY_DELTA_ENABLED", raw)
+        assert is_daily_delta_enabled() is False
+
+
+def test_run_daily_delta_skips_when_disabled(monkeypatch):
+    monkeypatch.setenv("DAILY_DELTA_ENABLED", "0")
+
+    called = {"subprocess": False}
+
+    def _should_not_run(**kwargs):
+        called["subprocess"] = True
+        return {}
+
+    monkeypatch.setattr("src.scheduled_tasks._run_daily_delta_in_subprocess", _should_not_run)
+
+    from src.scheduled_tasks import run_daily_delta
+
+    run_daily_delta()
+
+    assert called["subprocess"] is False


### PR DESCRIPTION
### Motivation
- Provide a simple operational way to pause the daily delta job without changing code or redeploying the scheduler.
- Make the pause signal explicit and easy to manage from deployment configuration.

### Description
- Added `DAILY_DELTA_ENABLED` env flag and helper `is_daily_delta_enabled()` in `src/scheduled_tasks.py`, which treats `0`, `false`, `no`, and `off` as disabled.
- `run_daily_delta()` now exits early and logs when the toggle is disabled to guard against accidental invocation.
- App startup (`src/main.py`) checks the same toggle and only registers the APScheduler cron job when enabled, emitting a clear log line when paused.
- Exposed `DAILY_DELTA_ENABLED` in `render.yaml` with default value `"1"` so deployments can toggle it without code edits.
- Added tests (`src/test_scheduled_tasks.py`) to verify false-value parsing and that the daily run is skipped when disabled.

### Testing
- Ran `pytest -q src/test_scheduled_tasks.py` which passed: `5 passed`.
- The new tests cover parsing of false-like values and that `run_daily_delta()` does not invoke the subprocess when the toggle is disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28eb0ff7883288a73aa5e8a20aba2)