### PR TITLE
test: add 64 tests — connection layer, DB units, refs CRUD, security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
   test-python:
     uses: wcmchenry3-stack/.github/.github/workflows/called-test-python.yml@main
     with:
-      # Baseline coverage for existing codebase — increase as tests are added
-      coverage-threshold: 50
+      # Raised from 50 → 58 after adding connection, individuals, reports, refs CRUD, and security tests
+      coverage-threshold: 58
     secrets: inherit
 
   cve-python:

--- a/src/db/test_connection.py
+++ b/src/db/test_connection.py
@@ -1,0 +1,196 @@
+"""Unit tests for the dual-backend connection layer.
+
+Tests _SQLiteConnWrapper._adapt(), _PrefetchedCursor, RETURNING detection,
+and get_connection() routing logic. All tests use in-memory SQLite — no
+PostgreSQL connection required.
+
+Run: pytest src/db/test_connection.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+from src.db.connection import (
+    _PrefetchedCursor,
+    _SQLiteConnWrapper,
+    get_connection,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _memory_conn() -> _SQLiteConnWrapper:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    return _SQLiteConnWrapper(conn)
+
+
+# ---------------------------------------------------------------------------
+# _SQLiteConnWrapper._adapt() — SQL translation
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_replaces_percent_s_placeholder():
+    assert _SQLiteConnWrapper._adapt("SELECT * FROM t WHERE id = %s") == (
+        "SELECT * FROM t WHERE id = ?"
+    )
+
+
+def test_adapt_replaces_multiple_percent_s():
+    result = _SQLiteConnWrapper._adapt("INSERT INTO t (a, b) VALUES (%s, %s)")
+    assert result == "INSERT INTO t (a, b) VALUES (?, ?)"
+
+
+def test_adapt_replaces_double_percent_with_single():
+    """%%  (psycopg2 escaped literal %) → % (SQLite modulo operator)."""
+    result = _SQLiteConnWrapper._adapt("UPDATE t SET batch = id %% 7")
+    assert result == "UPDATE t SET batch = id % 7"
+
+
+def test_adapt_replaces_now_with_current_timestamp():
+    result = _SQLiteConnWrapper._adapt("INSERT INTO t (ts) VALUES (NOW())")
+    assert result == "INSERT INTO t (ts) VALUES (CURRENT_TIMESTAMP)"
+
+
+def test_adapt_strips_double_colon_text_cast():
+    assert _SQLiteConnWrapper._adapt("SELECT col::TEXT FROM t") == "SELECT col FROM t"
+    assert _SQLiteConnWrapper._adapt("SELECT col::text FROM t") == "SELECT col FROM t"
+
+
+def test_adapt_strips_double_colon_integer_cast():
+    assert _SQLiteConnWrapper._adapt("SELECT val::integer FROM t") == "SELECT val FROM t"
+    assert _SQLiteConnWrapper._adapt("SELECT val::INTEGER FROM t") == "SELECT val FROM t"
+
+
+def test_adapt_strips_double_colon_date_cast():
+    assert _SQLiteConnWrapper._adapt("SELECT d::date FROM t") == "SELECT d FROM t"
+
+
+def test_adapt_combined_translations():
+    sql = "UPDATE t SET ts = NOW(), batch = id %% 7 WHERE id = %s"
+    result = _SQLiteConnWrapper._adapt(sql)
+    assert result == "UPDATE t SET ts = CURRENT_TIMESTAMP, batch = id % 7 WHERE id = ?"
+
+
+def test_adapt_passthrough_when_no_substitutions():
+    sql = "SELECT id, name FROM countries ORDER BY name"
+    assert _SQLiteConnWrapper._adapt(sql) == sql
+
+
+# ---------------------------------------------------------------------------
+# _PrefetchedCursor
+# ---------------------------------------------------------------------------
+
+
+def _make_prefetched(rows: list) -> _PrefetchedCursor:
+    return _PrefetchedCursor(rows, rowcount=len(rows), description=None)
+
+
+def test_prefetched_cursor_fetchone_returns_rows_in_order():
+    cur = _make_prefetched([{"id": 1}, {"id": 2}])
+    assert cur.fetchone()["id"] == 1
+    assert cur.fetchone()["id"] == 2
+
+
+def test_prefetched_cursor_fetchone_returns_none_after_exhaustion():
+    cur = _make_prefetched([{"id": 1}])
+    cur.fetchone()
+    assert cur.fetchone() is None
+
+
+def test_prefetched_cursor_fetchall_returns_all_rows():
+    cur = _make_prefetched([{"id": 1}, {"id": 2}, {"id": 3}])
+    rows = cur.fetchall()
+    assert len(rows) == 3
+    assert rows[0]["id"] == 1
+
+
+def test_prefetched_cursor_fetchall_after_fetchone_returns_remaining():
+    cur = _make_prefetched([{"id": 1}, {"id": 2}, {"id": 3}])
+    cur.fetchone()  # consume first
+    remaining = cur.fetchall()
+    assert len(remaining) == 2
+    assert remaining[0]["id"] == 2
+
+
+def test_prefetched_cursor_rowcount_preserved():
+    cur = _make_prefetched([{"id": 1}, {"id": 2}])
+    assert cur.rowcount == 2
+
+
+def test_prefetched_cursor_description_preserved():
+    cur = _PrefetchedCursor([], rowcount=0, description="mock-description")
+    assert cur.description == "mock-description"
+
+
+# ---------------------------------------------------------------------------
+# _SQLiteConnWrapper.execute() — RETURNING detection
+# ---------------------------------------------------------------------------
+
+
+def test_execute_with_returning_returns_prefetched_cursor():
+    conn = _memory_conn()
+    conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+    result = conn.execute("INSERT INTO items (name) VALUES (%s) RETURNING id", ("test",))
+    assert isinstance(result, _PrefetchedCursor)
+
+
+def test_execute_without_returning_returns_raw_cursor():
+    conn = _memory_conn()
+    conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+    result = conn.execute("INSERT INTO items (name) VALUES (%s)", ("test",))
+    # Should NOT be a _PrefetchedCursor
+    assert not isinstance(result, _PrefetchedCursor)
+
+
+def test_execute_returning_detection_is_case_insensitive():
+    conn = _memory_conn()
+    conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+    # lowercase 'returning'
+    result = conn.execute("INSERT INTO items (name) VALUES (%s) returning id", ("test",))
+    assert isinstance(result, _PrefetchedCursor)
+
+
+def test_execute_returning_fetchone_works_after_commit():
+    """Core guarantee: RETURNING result survives commit() because it's pre-fetched."""
+    conn = _memory_conn()
+    conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+    cur = conn.execute("INSERT INTO items (name) VALUES (%s) RETURNING id", ("alpha",))
+    conn.commit()  # must not lose the pre-fetched row
+    row = cur.fetchone()
+    assert row is not None
+    assert row["id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_connection() routing
+# ---------------------------------------------------------------------------
+
+
+def test_get_connection_returns_sqlite_wrapper_without_database_url(tmp_path, monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("OFFICE_HOLDER_DB_PATH", str(tmp_path / "test.db"))
+    conn = get_connection()
+    try:
+        assert isinstance(conn, _SQLiteConnWrapper)
+    finally:
+        conn.close()
+
+
+def test_get_connection_with_explicit_path_returns_sqlite_wrapper_even_if_database_url_set(
+    tmp_path, monkeypatch
+):
+    """Explicit path arg always returns SQLite, even when DATABASE_URL is set."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fake/db")
+    db_path = tmp_path / "explicit.db"
+    conn = get_connection(path=db_path)
+    try:
+        assert isinstance(conn, _SQLiteConnWrapper)
+    finally:
+        conn.close()

--- a/src/db/test_individuals.py
+++ b/src/db/test_individuals.py
@@ -1,0 +1,247 @@
+"""Unit tests for src/db/individuals.py.
+
+All tests use the `tmp_db` fixture (fully initialised, seeded SQLite DB).
+No network access, no HTTP.
+
+Run: pytest src/db/test_individuals.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.db import individuals as db_individuals
+from src.db import offices as db_offices
+from src.db import refs as db_refs
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_office(conn) -> int:
+    """Create a minimal office and return its office_details_id."""
+    return db_offices.create_office(
+        {
+            "country_id": 1,  # United States of America (seeded)
+            "state_id": None,
+            "city_id": None,
+            "level_id": None,
+            "branch_id": None,
+            "department": "",
+            "name": "Test Office",
+            "enabled": True,
+            "notes": "",
+            "url": "https://en.wikipedia.org/wiki/Test_Office_Ind",
+            "table_configs": [
+                {
+                    "name": "",
+                    "table_no": 1,
+                    "table_rows": 1,
+                    "link_column": 1,
+                    "party_column": 0,
+                    "term_start_column": 2,
+                    "term_end_column": 3,
+                    "district_column": 0,
+                    "enabled": 1,
+                }
+            ],
+        },
+        conn=conn,
+    )
+
+
+def _insert_term(conn, individual_id: int, office_details_id: int, term_start_year: int) -> None:
+    """Insert a minimal office_term with a given term_start_year."""
+    conn.execute(
+        """INSERT INTO office_terms
+           (office_id, individual_id, wiki_url, term_start_year)
+           VALUES (%s, %s, %s, %s)""",
+        (
+            office_details_id,
+            individual_id,
+            f"https://en.wikipedia.org/wiki/Person_{individual_id}",
+            term_start_year,
+        ),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# upsert_individual — insert
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_individual_insert_returns_id(tmp_db):
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/Jane_Smith", "full_name": "Jane Smith"},
+        conn=tmp_db,
+    )
+    assert isinstance(ind_id, int)
+    assert ind_id > 0
+
+
+def test_upsert_individual_insert_stores_correct_fields(tmp_db):
+    db_individuals.upsert_individual(
+        {
+            "wiki_url": "/wiki/John_Doe",
+            "full_name": "John Doe",
+            "birth_date": "1950-01-01",
+            "page_path": "John_Doe",
+        },
+        conn=tmp_db,
+    )
+    row = db_individuals.get_individual_by_wiki_url("/wiki/John_Doe", conn=tmp_db)
+    assert row is not None
+    assert row["full_name"] == "John Doe"
+    assert row["birth_date"] == "1950-01-01"
+    assert row["page_path"] == "John_Doe"
+
+
+def test_upsert_individual_update_keeps_same_id(tmp_db):
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/UpdateMe", "full_name": "Original Name"},
+        conn=tmp_db,
+    )
+    updated_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/UpdateMe", "full_name": "Updated Name"},
+        conn=tmp_db,
+    )
+    assert updated_id == ind_id
+
+
+def test_upsert_individual_update_changes_fields(tmp_db):
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/FieldUpdate", "full_name": "Before"},
+        conn=tmp_db,
+    )
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/FieldUpdate", "full_name": "After", "birth_place": "Springfield"},
+        conn=tmp_db,
+    )
+    row = db_individuals.get_individual_by_wiki_url("/wiki/FieldUpdate", conn=tmp_db)
+    assert row["full_name"] == "After"
+    assert row["birth_place"] == "Springfield"
+
+
+# ---------------------------------------------------------------------------
+# bio_batch
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_individual_bio_batch_is_id_mod_7(tmp_db):
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/BatchTest"},
+        conn=tmp_db,
+    )
+    row = db_individuals.get_individual(ind_id, conn=tmp_db)
+    assert row["bio_batch"] == ind_id % 7
+
+
+# ---------------------------------------------------------------------------
+# is_living inference
+# ---------------------------------------------------------------------------
+
+
+def test_is_living_stays_1_with_no_death_date_and_recent_terms(tmp_db):
+    od_id = _make_office(tmp_db)
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/LivingPerson"},
+        conn=tmp_db,
+    )
+    _insert_term(tmp_db, ind_id, od_id, date.today().year - 5)
+    row = db_individuals.get_individual(ind_id, conn=tmp_db)
+    assert row["is_living"] == 1
+
+
+def test_is_living_flips_to_0_when_death_date_set(tmp_db):
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/DeadPerson", "death_date": "2020-01-01"},
+        conn=tmp_db,
+    )
+    row = db_individuals.get_individual(ind_id, conn=tmp_db)
+    assert row["is_living"] == 0
+
+
+def test_is_living_flips_to_0_when_earliest_term_over_80_years_ago(tmp_db):
+    od_id = _make_office(tmp_db)
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/OldPerson"},
+        conn=tmp_db,
+    )
+    _insert_term(tmp_db, ind_id, od_id, date.today().year - 90)
+    # Re-upsert to trigger recompute
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/OldPerson"},
+        conn=tmp_db,
+    )
+    row = db_individuals.get_individual(ind_id, conn=tmp_db)
+    assert row["is_living"] == 0
+
+
+def test_is_living_0_not_flipped_back_to_1_on_re_upsert(tmp_db):
+    """Once is_living = 0, a subsequent upsert without death_date must not restore it."""
+    ind_id = db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/OneWayGate", "death_date": "2010-06-15"},
+        conn=tmp_db,
+    )
+    # Re-upsert without death_date
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/OneWayGate"},
+        conn=tmp_db,
+    )
+    row = db_individuals.get_individual(ind_id, conn=tmp_db)
+    assert row["is_living"] == 0
+
+
+# ---------------------------------------------------------------------------
+# get_living_individual_wiki_urls
+# ---------------------------------------------------------------------------
+
+
+def test_get_living_excludes_dead_link_individuals(tmp_db):
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/DeadLink", "is_dead_link": True},
+        conn=tmp_db,
+    )
+    urls = db_individuals.get_living_individual_wiki_urls(conn=tmp_db)
+    assert "/wiki/DeadLink" not in urls
+
+
+def test_get_living_excludes_no_link_prefix(tmp_db):
+    db_individuals.upsert_individual(
+        {"wiki_url": "No link: Jane Doe"},
+        conn=tmp_db,
+    )
+    urls = db_individuals.get_living_individual_wiki_urls(conn=tmp_db)
+    assert "No link: Jane Doe" not in urls
+
+
+def test_get_living_includes_normal_living_individual(tmp_db):
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/AliveAndWell", "full_name": "Alive Person"},
+        conn=tmp_db,
+    )
+    urls = db_individuals.get_living_individual_wiki_urls(conn=tmp_db)
+    assert "/wiki/AliveAndWell" in urls
+
+
+# ---------------------------------------------------------------------------
+# mark_bio_refreshed
+# ---------------------------------------------------------------------------
+
+
+def test_mark_bio_refreshed_stamps_bio_refreshed_at(tmp_db):
+    db_individuals.upsert_individual(
+        {"wiki_url": "/wiki/RefreshMe"},
+        conn=tmp_db,
+    )
+    row_before = db_individuals.get_individual_by_wiki_url("/wiki/RefreshMe", conn=tmp_db)
+    assert row_before["bio_refreshed_at"] is None
+
+    db_individuals.mark_bio_refreshed("/wiki/RefreshMe", conn=tmp_db)
+
+    row_after = db_individuals.get_individual_by_wiki_url("/wiki/RefreshMe", conn=tmp_db)
+    assert row_after["bio_refreshed_at"] is not None

--- a/src/db/test_reports.py
+++ b/src/db/test_reports.py
@@ -1,0 +1,165 @@
+"""Unit tests for src/db/reports.py.
+
+Uses the `tmp_db` fixture (fully initialised, seeded SQLite DB).
+Inserts individuals and office_terms with dates relative to today so
+the 90-day window tests remain correct regardless of when they run.
+
+Run: pytest src/db/test_reports.py -v
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from src.db import individuals as db_individuals
+from src.db import offices as db_offices
+from src.db import reports as db_reports
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _today_minus(days: int) -> str:
+    return (date.today() - timedelta(days=days)).isoformat()
+
+
+def _make_office(conn) -> int:
+    return db_offices.create_office(
+        {
+            "country_id": 1,
+            "state_id": None,
+            "city_id": None,
+            "level_id": None,
+            "branch_id": None,
+            "department": "",
+            "name": "Report Test Office",
+            "enabled": True,
+            "notes": "",
+            "url": "https://en.wikipedia.org/wiki/Report_Test_Office",
+            "table_configs": [
+                {
+                    "name": "",
+                    "table_no": 1,
+                    "table_rows": 1,
+                    "link_column": 1,
+                    "party_column": 0,
+                    "term_start_column": 2,
+                    "term_end_column": 3,
+                    "district_column": 0,
+                    "enabled": 1,
+                }
+            ],
+        },
+        conn=conn,
+    )
+
+
+def _make_individual(conn, wiki_url: str, **kwargs) -> int:
+    return db_individuals.upsert_individual({"wiki_url": wiki_url, **kwargs}, conn=conn)
+
+
+def _insert_term(
+    conn, od_id: int, ind_id: int, term_start: str | None, term_end: str | None
+) -> None:
+    conn.execute(
+        """INSERT INTO office_terms
+           (office_id, individual_id, wiki_url, term_start, term_end)
+           VALUES (%s, %s, %s, %s, %s)""",
+        (od_id, ind_id, f"https://en.wikipedia.org/wiki/P{ind_id}", term_start, term_end),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# get_recent_deaths
+# ---------------------------------------------------------------------------
+
+
+def test_get_recent_deaths_returns_individual_within_90_days(tmp_db):
+    _make_individual(
+        tmp_db,
+        "/wiki/RecentDeath",
+        full_name="Recent Death",
+        death_date=_today_minus(30),
+    )
+    results = db_reports.get_recent_deaths(conn=tmp_db)
+    names = [r["full_name"] for r in results]
+    assert "Recent Death" in names
+
+
+def test_get_recent_deaths_excludes_individual_over_91_days_ago(tmp_db):
+    _make_individual(
+        tmp_db,
+        "/wiki/OldDeath",
+        full_name="Old Death",
+        death_date=_today_minus(91),
+    )
+    results = db_reports.get_recent_deaths(conn=tmp_db)
+    names = [r["full_name"] for r in results]
+    assert "Old Death" not in names
+
+
+def test_get_recent_deaths_returns_empty_when_no_deaths(tmp_db):
+    results = db_reports.get_recent_deaths(conn=tmp_db)
+    assert isinstance(results, list)
+    # No deaths inserted — may be empty or contain nothing from seed
+    for r in results:
+        assert r.get("death_date") is not None
+
+
+# ---------------------------------------------------------------------------
+# get_recent_term_ends
+# ---------------------------------------------------------------------------
+
+
+def test_get_recent_term_ends_returns_term_within_90_days(tmp_db):
+    od_id = _make_office(tmp_db)
+    ind_id = _make_individual(tmp_db, "/wiki/RecentTermEnd", full_name="Recent Term End")
+    _insert_term(tmp_db, od_id, ind_id, _today_minus(120), _today_minus(45))
+
+    results = db_reports.get_recent_term_ends(conn=tmp_db)
+    names = [r["Name"] for r in results]
+    assert "Recent Term End" in names
+
+
+def test_get_recent_term_ends_excludes_term_outside_window(tmp_db):
+    od_id = _make_office(tmp_db)
+    ind_id = _make_individual(tmp_db, "/wiki/OldTermEnd", full_name="Old Term End")
+    _insert_term(tmp_db, od_id, ind_id, _today_minus(200), _today_minus(120))
+
+    results = db_reports.get_recent_term_ends(conn=tmp_db)
+    names = [r["Name"] for r in results]
+    assert "Old Term End" not in names
+
+
+# ---------------------------------------------------------------------------
+# get_recent_term_starts
+# ---------------------------------------------------------------------------
+
+
+def test_get_recent_term_starts_returns_term_within_90_days(tmp_db):
+    od_id = _make_office(tmp_db)
+    ind_id = _make_individual(tmp_db, "/wiki/RecentTermStart", full_name="Recent Term Start")
+    _insert_term(tmp_db, od_id, ind_id, _today_minus(30), None)
+
+    results = db_reports.get_recent_term_starts(conn=tmp_db)
+    names = [r["Name"] for r in results]
+    assert "Recent Term Start" in names
+
+
+def test_get_recent_term_starts_excludes_term_outside_window(tmp_db):
+    od_id = _make_office(tmp_db)
+    ind_id = _make_individual(tmp_db, "/wiki/OldTermStart", full_name="Old Term Start")
+    _insert_term(tmp_db, od_id, ind_id, _today_minus(91), None)
+
+    results = db_reports.get_recent_term_starts(conn=tmp_db)
+    names = [r["Name"] for r in results]
+    assert "Old Term Start" not in names
+
+
+def test_get_recent_term_starts_returns_empty_list_with_no_terms(tmp_db):
+    results = db_reports.get_recent_term_starts(conn=tmp_db)
+    assert isinstance(results, list)

--- a/src/test_router_refs_api.py
+++ b/src/test_router_refs_api.py
@@ -104,3 +104,206 @@ def test_api_branches_returns_list(client):
     assert len(body) > 0
     names = [r["name"] for r in body]
     assert "Executive" in names
+
+
+# ---------------------------------------------------------------------------
+# /refs/countries — full CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def crud_client(tmp_path_factory):
+    """Separate client with its own DB for CRUD mutation tests."""
+    import importlib
+
+    tmp = tmp_path_factory.mktemp("refs_crud_db")
+    db_path = tmp / "refs_crud_test.db"
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    import src.main as main_mod
+
+    importlib.reload(main_mod)
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as c:
+        yield c
+
+    os.environ.pop("OFFICE_HOLDER_DB_PATH", None)
+
+
+def test_create_country_redirects_on_success(crud_client):
+    resp = crud_client.post(
+        "/refs/countries/new", data={"name": "Testlandia"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+    assert "countries" in resp.headers["location"]
+
+
+def test_create_country_duplicate_name_returns_form_with_error(crud_client):
+    crud_client.post("/refs/countries/new", data={"name": "Dupeland"})
+    resp = crud_client.post(
+        "/refs/countries/new", data={"name": "Dupeland"}, follow_redirects=False
+    )
+    assert resp.status_code == 200
+    assert "already exists" in resp.text.lower() or "error" in resp.text.lower()
+
+
+def test_get_country_edit_form_returns_200(crud_client):
+    crud_client.post("/refs/countries/new", data={"name": "EditableCountry"})
+    countries = crud_client.get("/api/countries").json()
+    target = next((c for c in countries if c["name"] == "EditableCountry"), None)
+    assert target is not None
+    resp = crud_client.get(f"/refs/countries/{target['id']}")
+    assert resp.status_code == 200
+    assert "EditableCountry" in resp.text
+
+
+def test_get_country_edit_form_404_for_unknown_id(crud_client):
+    resp = crud_client.get("/refs/countries/999999")
+    assert resp.status_code == 404
+
+
+def test_update_country_redirects_on_success(crud_client):
+    crud_client.post("/refs/countries/new", data={"name": "OldName"})
+    countries = crud_client.get("/api/countries").json()
+    target = next((c for c in countries if c["name"] == "OldName"), None)
+    assert target is not None
+    resp = crud_client.post(
+        f"/refs/countries/{target['id']}", data={"name": "NewName"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+
+
+def test_delete_country_redirects_on_success(crud_client):
+    crud_client.post("/refs/countries/new", data={"name": "ToDelete"})
+    countries = crud_client.get("/api/countries").json()
+    target = next((c for c in countries if c["name"] == "ToDelete"), None)
+    assert target is not None
+    resp = crud_client.post(f"/refs/countries/{target['id']}/delete", follow_redirects=False)
+    assert resp.status_code == 302
+    countries_after = crud_client.get("/api/countries").json()
+    assert not any(c["name"] == "ToDelete" for c in countries_after)
+
+
+# ---------------------------------------------------------------------------
+# /refs/levels — CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_level_redirects_on_success(crud_client):
+    resp = crud_client.post("/refs/levels/new", data={"name": "Municipal"}, follow_redirects=False)
+    assert resp.status_code == 302
+
+
+def test_create_level_duplicate_returns_error(crud_client):
+    crud_client.post("/refs/levels/new", data={"name": "DupLevel"})
+    resp = crud_client.post("/refs/levels/new", data={"name": "DupLevel"}, follow_redirects=False)
+    assert resp.status_code == 200
+    assert "error" in resp.text.lower() or "already" in resp.text.lower()
+
+
+def test_update_level_redirects_on_success(crud_client):
+    crud_client.post("/refs/levels/new", data={"name": "OldLevel"})
+    levels = crud_client.get("/api/levels").json()
+    target = next((lv for lv in levels if lv["name"] == "OldLevel"), None)
+    assert target is not None
+    resp = crud_client.post(
+        f"/refs/levels/{target['id']}", data={"name": "UpdatedLevel"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+
+
+def test_delete_level_redirects_on_success(crud_client):
+    crud_client.post("/refs/levels/new", data={"name": "LevelToDelete"})
+    levels = crud_client.get("/api/levels").json()
+    target = next((lv for lv in levels if lv["name"] == "LevelToDelete"), None)
+    assert target is not None
+    resp = crud_client.post(f"/refs/levels/{target['id']}/delete", follow_redirects=False)
+    assert resp.status_code == 302
+    levels_after = crud_client.get("/api/levels").json()
+    assert not any(lv["name"] == "LevelToDelete" for lv in levels_after)
+
+
+# ---------------------------------------------------------------------------
+# /refs/branches — CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_branch_redirects_on_success(crud_client):
+    resp = crud_client.post(
+        "/refs/branches/new", data={"name": "Electoral"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+
+
+def test_create_branch_duplicate_returns_error(crud_client):
+    crud_client.post("/refs/branches/new", data={"name": "DupBranch"})
+    resp = crud_client.post(
+        "/refs/branches/new", data={"name": "DupBranch"}, follow_redirects=False
+    )
+    assert resp.status_code == 200
+    assert "error" in resp.text.lower() or "already" in resp.text.lower()
+
+
+def test_update_branch_redirects_on_success(crud_client):
+    crud_client.post("/refs/branches/new", data={"name": "OldBranch"})
+    branches = crud_client.get("/api/branches").json()
+    target = next((b for b in branches if b["name"] == "OldBranch"), None)
+    assert target is not None
+    resp = crud_client.post(
+        f"/refs/branches/{target['id']}", data={"name": "UpdatedBranch"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+
+
+def test_delete_branch_redirects_on_success(crud_client):
+    crud_client.post("/refs/branches/new", data={"name": "BranchToDelete"})
+    branches = crud_client.get("/api/branches").json()
+    target = next((b for b in branches if b["name"] == "BranchToDelete"), None)
+    assert target is not None
+    resp = crud_client.post(f"/refs/branches/{target['id']}/delete", follow_redirects=False)
+    assert resp.status_code == 302
+    branches_after = crud_client.get("/api/branches").json()
+    assert not any(b["name"] == "BranchToDelete" for b in branches_after)
+
+
+# ---------------------------------------------------------------------------
+# /refs/states — CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_state_redirects_on_success(crud_client):
+    countries = crud_client.get("/api/countries").json()
+    us = next(c for c in countries if c["name"] == "United States of America")
+    resp = crud_client.post(
+        "/refs/states/new",
+        data={"name": "New Test State", "country_id": us["id"]},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+
+
+def test_update_state_redirects_on_success(crud_client):
+    countries = crud_client.get("/api/countries").json()
+    us = next(c for c in countries if c["name"] == "United States of America")
+    crud_client.post("/refs/states/new", data={"name": "StateToUpdate", "country_id": us["id"]})
+    states = crud_client.get(f"/api/states?country_id={us['id']}").json()
+    target = next((s for s in states if s["name"] == "StateToUpdate"), None)
+    assert target is not None
+    resp = crud_client.post(
+        f"/refs/states/{target['id']}",
+        data={"name": "StateUpdated", "country_id": us["id"]},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+
+
+def test_delete_state_redirects_on_success(crud_client):
+    countries = crud_client.get("/api/countries").json()
+    us = next(c for c in countries if c["name"] == "United States of America")
+    crud_client.post("/refs/states/new", data={"name": "StateToDelete", "country_id": us["id"]})
+    states = crud_client.get(f"/api/states?country_id={us['id']}").json()
+    target = next((s for s in states if s["name"] == "StateToDelete"), None)
+    assert target is not None
+    resp = crud_client.post(f"/refs/states/{target['id']}/delete", follow_redirects=False)
+    assert resp.status_code == 302

--- a/src/test_security.py
+++ b/src/test_security.py
@@ -244,3 +244,60 @@ def test_integer_path_param_type_safety(client):
         404,
         422,
     ), f"Expected 404 or 422 for non-integer office ID, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# H8 — XSS: stored values returned as literal text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_xss_payload_in_country_name_is_not_executed(client):
+    """An XSS payload stored via the refs form must appear escaped in the response,
+    not as executable HTML."""
+    payload = "<script>alert('xss')</script>"
+    client.post("/refs/countries/new", data={"name": payload})
+    resp = client.get("/refs/countries")
+    assert resp.status_code == 200
+    # The raw <script> tag must NOT appear unescaped in the page
+    assert "<script>alert" not in resp.text, "XSS payload was reflected unescaped"
+
+
+# ---------------------------------------------------------------------------
+# H9 — Open redirect prevention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_no_open_redirect_on_saved_param(client):
+    """The ?saved=1 param on refs list pages must not redirect to an external URL."""
+    resp = client.get("/refs/countries?saved=https://evil.example.com", follow_redirects=False)
+    # Must render the page (200), not redirect externally
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# H10 — Sensitive data not in error responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_404_response_does_not_leak_stack_trace(client):
+    """A 404 for an unknown route must not expose a Python stack trace."""
+    resp = client.get("/this/route/does/not/exist")
+    assert resp.status_code == 404
+    assert "Traceback" not in resp.text
+    assert 'File "' not in resp.text
+
+
+@pytest.mark.security
+def test_malformed_body_does_not_leak_internals(client):
+    """Sending garbage bytes to a form endpoint must not expose a Python stack trace."""
+    resp = client.post(
+        "/refs/countries/new",
+        content=b"\xff\xfe<invalid encoding>",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code != 500, f"Malformed body caused unhandled 500: {resp.text[:200]}"
+    assert "Traceback" not in resp.text
+    assert 'File "' not in resp.text


### PR DESCRIPTION
## Summary

- **+64 new tests** across 5 files, coverage 50% → 58%
- **Coverage threshold raised** from 50 to 58 in CI

## New test files

| File | Tests | What's covered |
|------|-------|----------------|
| `src/db/test_connection.py` | 21 | `_SQLiteConnWrapper._adapt()` SQL translations, `_PrefetchedCursor` behaviour, `RETURNING` detection (case-insensitive), `get_connection()` backend routing |
| `src/db/test_individuals.py` | 13 | `upsert_individual()` insert/update, `bio_batch = id % 7`, `is_living` inference (death_date, 80-year term rule, one-way gate), `get_living_individual_wiki_urls()`, `mark_bio_refreshed()` |
| `src/db/test_reports.py` | 8 | `get_recent_deaths`, `get_recent_term_ends`, `get_recent_term_starts` — within-window vs outside 90-day window, empty tables |

## Extended test files

| File | Tests added | What's covered |
|------|-------------|----------------|
| `src/test_router_refs_api.py` | +17 | Full CRUD for `/refs/countries`, `/refs/levels`, `/refs/branches`, `/refs/states` — create, duplicate rejection, edit form 200/404, update, delete |
| `src/test_security.py` | +4 | XSS payload escaping in stored values, open-redirect prevention on `?saved=` param, 404 stack-trace leakage, malformed form body handling |

## Test plan

- [x] 223 tests pass locally (11 skipped — Playwright)
- [x] black + ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)