### PR TITLE
fix: remove semicolons from SQL comments in schema.py to fix Postgres…

### DIFF
--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS states (
 );
 CREATE INDEX IF NOT EXISTS idx_states_country_id ON states(country_id);
 
--- Reference: cities (per state; state implies country)
+-- Reference: cities (per state, state implies country)
 CREATE TABLE IF NOT EXISTS cities (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     state_id INTEGER NOT NULL REFERENCES states(id),
@@ -174,7 +174,7 @@ CREATE INDEX IF NOT EXISTS idx_office_table_config_office_details_id ON office_t
 CREATE INDEX IF NOT EXISTS idx_office_table_config_enabled ON office_table_config(enabled);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_office_table_config_office_table_no ON office_table_config(office_details_id, table_no);
 
--- Offices: office definitions (what we scrape); link by FK to countries, states, levels, branches (legacy; migrated to hierarchy)
+-- Offices: office definitions (what we scrape) — link by FK to countries, states, levels, branches (legacy, migrated to hierarchy)
 CREATE TABLE IF NOT EXISTS offices (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     country_id INTEGER NOT NULL REFERENCES countries(id),
@@ -304,7 +304,7 @@ CREATE TABLE IF NOT EXISTS states (
 );
 CREATE INDEX IF NOT EXISTS idx_states_country_id ON states(country_id);
 
--- Reference: cities (per state; state implies country)
+-- Reference: cities (per state, state implies country)
 CREATE TABLE IF NOT EXISTS cities (
     id SERIAL PRIMARY KEY,
     state_id INTEGER NOT NULL REFERENCES states(id),
@@ -466,7 +466,7 @@ CREATE INDEX IF NOT EXISTS idx_office_table_config_office_details_id ON office_t
 CREATE INDEX IF NOT EXISTS idx_office_table_config_enabled ON office_table_config(enabled);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_office_table_config_office_table_no ON office_table_config(office_details_id, table_no);
 
--- Offices (legacy; new data goes through source_pages → office_details → office_table_config)
+-- Offices (legacy — new data goes through source_pages → office_details → office_table_config)
 CREATE TABLE IF NOT EXISTS offices (
     id SERIAL PRIMARY KEY,
     country_id INTEGER NOT NULL REFERENCES countries(id),


### PR DESCRIPTION
… init

_split_sql() splits on all semicolons including those in comments. Comments like '-- cities (per state; state implies country)' were producing pure-comment fragments that psycopg2 raises as empty queries. Replaced semicolons in comments with commas/dashes.

## Summary
<!-- What does this PR do? Focus on the why, not the how. -->
-

## Type of change
- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done
<!-- What did you run? Any coverage delta? -->
- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist
- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist *(frontend PRs only)*
- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom
