### PR TITLE
fix: correct alt_links migration order — must follow office_details

### DIFF
--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -39,9 +39,9 @@ TABLE_ORDER = [
     "infobox_role_key_filter_branches",
     "source_pages",
     "offices",
-    "alt_links",
     "office_details",
     "office_table_config",
+    "alt_links",
     "parser_test_scripts",
     # individuals and office_terms are intentionally excluded — re-scraped fresh.
 ]


### PR DESCRIPTION
alt_links has a FK to office_details_id. Moving it after office_details and office_table_config in TABLE_ORDER prevents FK violation.