### PR TITLE
fix: finish_migration.py — filter against Postgres IDs not SQLite IDs

### DIFF
--- a/scripts/finish_migration.py
+++ b/scripts/finish_migration.py
@@ -10,11 +10,15 @@ pg = psycopg2.connect(os.environ["DATABASE_URL"])
 cur = pg.cursor()
 
 
-def migrate(table, sql, info_table):
-    cols = [d[1] for d in sq.execute(f"PRAGMA table_info({table})").fetchall()]
-    rows = sq.execute(sql).fetchall()
-    ph = ",".join(["%s"] * len(cols))
-    col_list = ",".join(cols)
+def pg_ids(table):
+    """Return set of IDs currently in a Postgres table."""
+    cur.execute(f"SELECT id FROM {table}")
+    return {r[0] for r in cur.fetchall()}
+
+
+def migrate(table, rows, sq_cols):
+    ph = ",".join(["%s"] * len(sq_cols))
+    col_list = ",".join(sq_cols)
     cur.executemany(
         f"INSERT INTO {table} ({col_list}) VALUES ({ph}) ON CONFLICT DO NOTHING",
         rows,
@@ -27,29 +31,33 @@ def migrate(table, sql, info_table):
     print(f"{table}: {len(rows)} rows")
 
 
-migrate(
-    "office_details",
-    """SELECT od.* FROM office_details od
-       WHERE EXISTS (SELECT 1 FROM source_pages sp WHERE sp.id = od.source_page_id)""",
-    "office_details",
-)
-migrate(
-    "office_table_config",
-    """SELECT otc.* FROM office_table_config otc
-       WHERE EXISTS (SELECT 1 FROM office_details od WHERE od.id = otc.office_details_id)""",
-    "office_table_config",
-)
-migrate(
-    "alt_links",
-    """SELECT al.* FROM alt_links al
-       WHERE EXISTS (SELECT 1 FROM offices o WHERE o.id = al.office_id)""",
-    "alt_links",
-)
-migrate(
-    "parser_test_scripts",
-    "SELECT * FROM parser_test_scripts",
-    "parser_test_scripts",
-)
+# office_details — filter against Postgres source_pages IDs (already migrated)
+sp_ids = pg_ids("source_pages")
+od_cols = [d[1] for d in sq.execute("PRAGMA table_info(office_details)").fetchall()]
+sp_idx = od_cols.index("source_page_id")
+od_rows = [r for r in sq.execute("SELECT * FROM office_details").fetchall() if r[sp_idx] in sp_ids]
+migrate("office_details", od_rows, od_cols)
+
+# office_table_config — filter against Postgres office_details IDs (just migrated)
+od_ids = pg_ids("office_details")
+otc_cols = [d[1] for d in sq.execute("PRAGMA table_info(office_table_config)").fetchall()]
+od_idx = otc_cols.index("office_details_id")
+otc_rows = [
+    r for r in sq.execute("SELECT * FROM office_table_config").fetchall() if r[od_idx] in od_ids
+]
+migrate("office_table_config", otc_rows, otc_cols)
+
+# alt_links — filter against Postgres offices IDs
+o_ids = pg_ids("offices")
+al_cols = [d[1] for d in sq.execute("PRAGMA table_info(alt_links)").fetchall()]
+o_idx = al_cols.index("office_id")
+al_rows = [r for r in sq.execute("SELECT * FROM alt_links").fetchall() if r[o_idx] in o_ids]
+migrate("alt_links", al_rows, al_cols)
+
+# parser_test_scripts — no FK deps
+pts_cols = [d[1] for d in sq.execute("PRAGMA table_info(parser_test_scripts)").fetchall()]
+pts_rows = sq.execute("SELECT * FROM parser_test_scripts").fetchall()
+migrate("parser_test_scripts", pts_rows, pts_cols)
 
 sq.close()
 pg.close()


### PR DESCRIPTION
office_table_config was being filtered against SQLite office_details, but some office_details rows were excluded from Postgres due to orphaned source_page_id refs. Now fetches actual Postgres IDs at each step before filtering.