### PR TITLE
feat: add OpenAI and Wikipedia policy workflow calls to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,13 @@ jobs:
 
       - name: Run tests
         run: pytest --tb=short
+
+  openai-policy:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
+    secrets: inherit
+
+  wikipedia-policy:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-wikipedia-policy.yml@main
+    with:
+      allowed-repo: wcmchenry3-stack/office_holder_cursor
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `openai-policy` job — enforces OpenAI API key hygiene, rate-limit handling, model pinning (warning), and token limits on any changed files referencing OpenAI
- Adds `wikipedia-policy` job — enforces User-Agent header, rate limiting, CC BY-SA attribution (warning), and no HTML scraping on any changed files referencing Wikipedia
- Both checks skip cleanly when no relevant files are changed

## Test plan
- [ ] Open a PR touching `wiki_fetch.py` — confirm Wikipedia policy checks run
- [ ] Open a PR not touching OpenAI/Wikipedia files — confirm both policy checks skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)