### PR TITLE
fix: correct PostgreSQL COALESCE empty-string literals

### DIFF
--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -480,7 +480,7 @@ def list_runnable_units(conn: Any | None = None) -> list[dict[str, Any]]:
                       tc.term_start_column, tc.term_end_column, tc.district_column, tc.filter_column, tc.filter_criteria, tc.dynamic_parse, tc.read_right_to_left,
                       tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                       tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                      tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, tc.notes AS tc_notes, tc.created_at, tc.last_html_hash
+                      tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, '') AS infobox_role_key, tc.notes AS tc_notes, tc.created_at, tc.last_html_hash
                FROM source_pages p
                JOIN office_details od ON od.source_page_id = p.id AND od.enabled = 1
                JOIN office_table_config tc ON tc.office_details_id = od.id AND tc.enabled = 1
@@ -604,7 +604,7 @@ def list_offices(conn: Any | None = None) -> list[dict[str, Any]]:
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.filter_column, tc.filter_criteria, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, '') AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
@@ -706,7 +706,7 @@ def list_offices(conn: Any | None = None) -> list[dict[str, Any]]:
                       o.parse_rowspan, o.consolidate_rowspan_terms, o.rep_link, o.party_link, o.alt_link_include_main,
                       o.use_full_page_for_table, o.years_only,
                       o.term_dates_merged, o.party_ignore, o.district_ignore, o.district_at_large,
-                      o.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, o.created_at
+                      o.infobox_role_key_filter_id, COALESCE(rkf.role_key, '') AS infobox_role_key, o.created_at
                FROM offices o
                LEFT JOIN countries c ON c.id = o.country_id
                LEFT JOIN states s ON s.id = o.state_id
@@ -847,7 +847,7 @@ def get_office(office_id: int, conn: Any | None = None) -> dict[str, Any] | None
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.filter_column, tc.filter_criteria, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, '') AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id
@@ -939,7 +939,7 @@ def get_office(office_id: int, conn: Any | None = None) -> dict[str, Any] | None
             return flat
         cur = conn.execute(
             """SELECT o.*, c.name AS country_name, s.name AS state_name, l.name AS level_name, b.name AS branch_name,
-                         o.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key
+                         o.infobox_role_key_filter_id, COALESCE(rkf.role_key, '') AS infobox_role_key
                FROM offices o
                LEFT JOIN countries c ON c.id = o.country_id
                LEFT JOIN states s ON s.id = o.state_id
@@ -1163,7 +1163,7 @@ def list_offices_for_page(source_page_id: int, conn: Any | None = None) -> list[
                           tc.term_start_column, tc.term_end_column, tc.district_column, tc.filter_column, tc.filter_criteria, tc.dynamic_parse, tc.read_right_to_left,
                           tc.find_date_in_infobox, tc.parse_rowspan, tc.rep_link, tc.party_link, tc.enabled AS tc_enabled,
                           tc.use_full_page_for_table, tc.years_only, tc.term_dates_merged, tc.party_ignore, tc.district_ignore, tc.district_at_large, tc.ignore_non_links, tc.remove_duplicates,
-                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, "") AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
+                          tc.consolidate_rowspan_terms, tc.infobox_role_key_filter_id, COALESCE(rkf.role_key, '') AS infobox_role_key, tc.notes AS tc_notes, tc.name AS tc_name, tc.created_at
                    FROM office_details od
                    JOIN source_pages p ON p.id = od.source_page_id
                    LEFT JOIN office_table_config tc ON tc.office_details_id = od.id

--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -22,6 +22,9 @@ import subprocess
 import sys
 import traceback
 from datetime import datetime, timezone
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 _DEFAULT_EMAIL = "wcmchenry3@gmail.com"
@@ -157,10 +160,9 @@ Run date : {date_str}
 Started  : {started_str}
 Status   : FAILED
 
-CRASH OUTPUT
-------------
-{error or 'Unknown error — result was None'}
+See attached log file for the full crash output.
 """
+        crash_log = (error or "Unknown error — result was None").encode("utf-8")
     else:
         office_count = result.get("office_count", 0)
         unchanged = result.get("offices_unchanged", 0)
@@ -211,10 +213,27 @@ ERRORS
 """
 
     subject = f"Office Holder Daily Run — {date_str} — {status}"
-    msg = MIMEText(body, "plain", "utf-8")
-    msg["Subject"] = subject
-    msg["From"] = email_from
-    msg["To"] = email_to
+
+    if error or result is None:
+        msg = MIMEMultipart()
+        msg["Subject"] = subject
+        msg["From"] = email_from
+        msg["To"] = email_to
+        msg.attach(MIMEText(body, "plain", "utf-8"))
+        attachment = MIMEBase("text", "plain", charset="utf-8")
+        attachment.set_payload(crash_log)
+        encoders.encode_base64(attachment)
+        attachment.add_header(
+            "Content-Disposition",
+            "attachment",
+            filename=f"crash_{date_str}.log",
+        )
+        msg.attach(attachment)
+    else:
+        msg = MIMEText(body, "plain", "utf-8")
+        msg["Subject"] = subject
+        msg["From"] = email_from
+        msg["To"] = email_to
 
     try:
         with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:

--- a/tests/test_nightly_smoke.py
+++ b/tests/test_nightly_smoke.py
@@ -1,0 +1,95 @@
+"""
+Smoke test for the nightly delta job pipeline.
+
+Picks the first 3 enabled manifest entries, seeds them into a fresh DB, pre-populates
+the disk cache with fixture HTML, then calls run_with_db(run_mode="delta") exactly as
+the nightly job does.  Zero network calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import src.scraper.wiki_fetch as _wiki_fetch_module
+from tests.conftest import PROJECT_ROOT, _extract_table, _write_fixture_to_cache
+from tests.test_e2e_runner import (
+    _build_member_html_map,
+    _get_country_id,
+    _load_html,
+    _load_manifest,
+    _make_requests_mock,
+    _seed_office,
+)
+
+SMOKE_ENTRY_COUNT = 3
+
+
+@pytest.mark.integration
+def test_nightly_delta_parses_offices_and_finds_individuals(db_with_cache, monkeypatch):
+    """
+    Simulate the nightly delta run against 3 manifest pages.
+
+    Asserts:
+    - All 3 offices are processed (office_count == 3).
+    - At least one individual term is found across the pages (terms_parsed > 0).
+    - No office-level errors occurred.
+    """
+    db_path, cache_dir = db_with_cache
+
+    from src.db.connection import get_connection
+    from src.scraper.runner import run_with_db
+
+    manifest = _load_manifest()
+    enabled = [e for e in manifest if e.get("enabled")]
+    assert len(enabled) >= SMOKE_ENTRY_COUNT, (
+        f"Need at least {SMOKE_ENTRY_COUNT} enabled manifest entries for smoke test, "
+        f"found {len(enabled)}"
+    )
+    entries = enabled[:SMOKE_ENTRY_COUNT]
+
+    member_html = _build_member_html_map(entries)
+    monkeypatch.setattr(_wiki_fetch_module, "_session", _make_requests_mock(member_html))
+
+    conn = get_connection(db_path)
+    try:
+        country_id = _get_country_id(conn)
+        tc_ids: list[int] = []
+
+        for entry in entries:
+            source_url = (entry.get("source_url") or "").strip()
+            config = dict(entry.get("config_json") or {})
+            table_no = int(config.get("table_no", 1))
+
+            full_html = _load_html(entry.get("html_file") or "")
+            table_html, num_tables = _extract_table(full_html, table_no)
+
+            _write_fixture_to_cache(
+                cache_dir,
+                source_url,
+                table_no,
+                table_html,
+                use_full_page=bool(config.get("use_full_page_for_table", False)),
+                num_tables=num_tables,
+            )
+
+            _, tc_id = _seed_office(conn, country_id, entry)
+            tc_ids.append(tc_id)
+    finally:
+        conn.close()
+
+    result = run_with_db(
+        run_mode="delta",
+        run_bio=False,
+        run_office_bio=False,
+        office_ids=tc_ids,
+    )
+
+    assert result["office_count"] == SMOKE_ENTRY_COUNT, (
+        f"Expected {SMOKE_ENTRY_COUNT} offices processed, got {result['office_count']}"
+    )
+    assert result["terms_parsed"] > 0, "No individual terms found — scraper may have failed silently"
+    assert result["office_errors"] == [], f"Office errors: {result['office_errors']}"


### PR DESCRIPTION
## Summary
- Fixes nightly job crash and `/run` page 500 error caused by `COALESCE(col, "")` in 6 SQL queries — PostgreSQL treats double-quotes as identifiers, not string literals; changed all to `''`
- Failure emails now attach the crash traceback as `crash_YYYY-MM-DD.log` instead of embedding it inline
- Adds `tests/test_nightly_smoke.py`: integration smoke test that seeds 3 manifest offices, runs `run_with_db(run_mode="delta")`, and asserts individuals are found (mirrors the nightly job path)

## Test plan
- [ ] `python -m pytest tests/test_nightly_smoke.py` passes
- [ ] Deploy to Render and confirm `/run` page loads without 500
- [ ] Confirm next nightly job completes and email arrives with clean body + log attachment on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)