### PR TITLE
fix: remove stale allowed-repos input from openai-policy CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
 
   openai-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
-    with:
-      allowed-repos: wcmchenry3-stack/office_holder_cursor
     secrets: inherit
 
   wikipedia-policy:


### PR DESCRIPTION
## Summary
Removes the `with: allowed-repos:` block from the `openai-policy` job in CI. The `wikipedia-policy` job is unchanged.

`called-openai-policy.yml` no longer accepts `allowed-repos` as an input (removed when the workflow became universal in wcmchenry3-stack/.github#7). Passing an undefined input to a `workflow_call` causes GitHub Actions to throw `startup_failure` — no jobs run at all, blocking PR #126 (dev → main).

## Change
```diff
  openai-policy:
    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
-    with:
-      allowed-repos: wcmchenry3-stack/office_holder_cursor
    secrets: inherit
```

## Test plan
- [ ] CI on this PR runs all jobs (no startup_failure)
- [ ] openai-policy job: "No changed files reference OpenAI — policy checks skipped."
- [ ] After merging to dev, re-run PR #126 — all required checks start and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)