### PR TITLE
fix: drop stale office_terms_office_id_fkey FK on PostgreSQL

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -280,9 +280,40 @@ def _init_postgres() -> None:
 
         db_test_scripts.seed_db_from_manifest_if_empty(conn=conn)
         conn.commit()
+
+        _run_pg_migrations(conn)
+
         # migrate_to_fk() is deliberately NOT called — PostgreSQL starts with the final schema
     finally:
         conn.close()
+
+
+def _run_pg_migrations(conn) -> None:
+    """Apply idempotent PostgreSQL-only schema corrections that cannot be expressed as
+    CREATE TABLE IF NOT EXISTS (e.g. dropping stale FK constraints)."""
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS schema_migrations "
+        "(id TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW())"
+    )
+    conn.commit()
+
+    cur = conn.execute("SELECT id FROM schema_migrations")
+    applied = {row[0] for row in cur.fetchall()}
+
+    def _apply(name: str, sql: str) -> None:
+        if name in applied:
+            return
+        conn.execute(sql)
+        conn.execute("INSERT INTO schema_migrations (id) VALUES (%s)", (name,))
+        conn.commit()
+
+    # office_terms.office_id previously had REFERENCES offices(id), but in hierarchy
+    # mode it stores office_table_config_id values — violating the FK. Drop it; the
+    # office_table_config_id column already carries the proper referential integrity.
+    _apply(
+        "pg_drop_office_terms_office_id_fkey",
+        "ALTER TABLE office_terms DROP CONSTRAINT IF EXISTS office_terms_office_id_fkey",
+    )
 
 
 def _init_sqlite(path: Path | None = None) -> None:

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -530,7 +530,7 @@ CREATE TABLE IF NOT EXISTS parties (
 -- Office terms
 CREATE TABLE IF NOT EXISTS office_terms (
     id SERIAL PRIMARY KEY,
-    office_id INTEGER NOT NULL REFERENCES offices(id),
+    office_id INTEGER NOT NULL,
     office_details_id INTEGER REFERENCES office_details(id),
     office_table_config_id INTEGER REFERENCES office_table_config(id),
     individual_id INTEGER REFERENCES individuals(id),


### PR DESCRIPTION
In hierarchy mode, insert_office_term stores office_table_config_id in office_terms.office_id. The PostgreSQL schema had that column declared as REFERENCES offices(id), causing a FK violation when the tc_id (e.g. 1284) doesn't exist in the legacy offices table.

- SCHEMA_PG_SQL: office_terms.office_id is now plain INTEGER NOT NULL (the office_table_config_id column already carries referential integrity)
- _init_postgres: calls new _run_pg_migrations() which drops office_terms_office_id_fkey on the live DB via a tracked, idempotent migration recorded in schema_migrations

## Summary
<!-- What does this PR do? Focus on the why, not the how. -->
-

## Type of change
- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done
<!-- What did you run? Any coverage delta? -->
- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist
- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist *(frontend PRs only)*
- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom
