### PR TITLE
fix: restore is_postgres() guard in _ensure_table to prevent startup crash

### DIFF
--- a/src/db/test_scripts.py
+++ b/src/db/test_scripts.py
@@ -149,10 +149,14 @@ def seed_db_from_manifest_if_empty(manifest_path: Path = MANIFEST_PATH, conn=Non
 def _ensure_table(conn) -> None:
     """Create parser_test_scripts if it doesn't exist.
 
-    On initialised connections (via init_db) the table already exists and this
-    is a no-op. On bare in-memory connections used in unit tests this creates
-    the table so tests don't need a full init_db() call.
+    On PostgreSQL (production) the table is created by SCHEMA_PG_SQL — nothing
+    to do. On bare in-memory SQLite connections used in unit tests the table
+    doesn't exist yet, so create it here with SQLite syntax.
     """
+    from .connection import is_postgres
+
+    if is_postgres():
+        return
     conn.execute("""
         CREATE TABLE IF NOT EXISTS parser_test_scripts (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary

- Restores the `if is_postgres(): return` guard in `test_scripts._ensure_table()` that was inadvertently weakened during PR #139 (SQLite migration cleanup)

## Root cause

PR #139 simplified `_ensure_table()` to remove the `is_postgres()` check and always run `CREATE TABLE IF NOT EXISTS`. However, `_ensure_table()` is called at app startup via `seed_db_from_manifest_if_empty()` and sends SQLite-specific DDL (`AUTOINCREMENT`) to psycopg2 on PostgreSQL, crashing the app:

```
psycopg2.errors.SyntaxError: syntax error at or near "AUTOINCREMENT"
RuntimeError: Database startup failed
```

## Fix

On PostgreSQL, `parser_test_scripts` is already created by `SCHEMA_PG_SQL` in `_init_postgres()` — `_ensure_table()` returns immediately. On bare SQLite in-memory connections (unit tests without `init_db()`), the table is still created dynamically as before.

## Test plan

- [x] `python -m pytest src/db/test_test_scripts_manifest_sync.py src/db/test_test_scripts_serialization.py` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)