### PR TITLE
fix: restore is_postgres() guard in _ensure_table to prevent SQLite D…

### DIFF
--- a/src/db/test_scripts.py
+++ b/src/db/test_scripts.py
@@ -149,10 +149,14 @@ def seed_db_from_manifest_if_empty(manifest_path: Path = MANIFEST_PATH, conn=Non
 def _ensure_table(conn) -> None:
     """Create parser_test_scripts if it doesn't exist.
 
-    On initialised connections (via init_db) the table already exists and this
-    is a no-op. On bare in-memory connections used in unit tests this creates
-    the table so tests don't need a full init_db() call.
+    On PostgreSQL (production) the table is created by SCHEMA_PG_SQL — nothing
+    to do. On bare in-memory SQLite connections used in unit tests the table
+    doesn't exist yet, so create it here with SQLite syntax.
     """
+    from .connection import is_postgres
+
+    if is_postgres():
+        return
     conn.execute("""
         CREATE TABLE IF NOT EXISTS parser_test_scripts (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
…DL on PostgreSQL

_ensure_table() is called at startup via seed_db_from_manifest_if_empty() and sends SQLite-specific AUTOINCREMENT syntax to psycopg2, crashing the app. Restore the is_postgres() early-return so the CREATE TABLE only runs on bare SQLite connections (unit tests without init_db).

## Summary
<!-- What does this PR do? Focus on the why, not the how. -->
-

## Type of change
- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done
<!-- What did you run? Any coverage delta? -->
- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist
- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist *(frontend PRs only)*
- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom
