### PR TITLE
fix: cast TEXT date columns to ::date in milestone report queries

### DIFF
--- a/src/db/reports.py
+++ b/src/db/reports.py
@@ -13,10 +13,15 @@ def get_recent_deaths(conn=None) -> list[dict[str, Any]]:
     if own_conn:
         conn = get_connection()
     try:
-        since = "CURRENT_DATE - INTERVAL '90 days'" if is_postgres() else "date('now', '-90 days')"
+        if is_postgres():
+            since = "CURRENT_DATE - INTERVAL '90 days'"
+            date_col = "death_date::date"
+        else:
+            since = "date('now', '-90 days')"
+            date_col = "death_date"
         cur = conn.execute(f"""SELECT full_name, birth_date, death_date
                FROM individuals
-               WHERE death_date BETWEEN {since} AND CURRENT_DATE
+               WHERE {date_col} BETWEEN {since} AND CURRENT_DATE
                ORDER BY death_date DESC""")
         return [_row_to_dict(r) for r in cur.fetchall()]
     finally:
@@ -30,7 +35,12 @@ def _term_report_query(
     order_column: str,
 ) -> list[dict[str, Any]]:
     """Shared logic: term report filtered by date_column (term_start or term_end), ordered by order_column."""
-    since = "CURRENT_DATE - INTERVAL '90 days'" if is_postgres() else "date('now', '-90 days')"
+    if is_postgres():
+        since = "CURRENT_DATE - INTERVAL '90 days'"
+        date_col = f"ot.{date_column}::date"
+    else:
+        since = "date('now', '-90 days')"
+        date_col = f"ot.{date_column}"
     if _has_hierarchy_terms(conn):
         cur = conn.execute(f"""
             SELECT
@@ -51,7 +61,7 @@ def _term_report_query(
             LEFT JOIN states s ON s.id = sp.state_id
             LEFT JOIN levels l ON l.id = sp.level_id
             LEFT JOIN branches b ON b.id = sp.branch_id
-            WHERE ot.{date_column} BETWEEN {since} AND CURRENT_DATE
+            WHERE {date_col} BETWEEN {since} AND CURRENT_DATE
             ORDER BY ot.{order_column} DESC
             """)
     else:
@@ -73,7 +83,7 @@ def _term_report_query(
             LEFT JOIN states s ON s.id = o.state_id
             LEFT JOIN levels l ON l.id = o.level_id
             LEFT JOIN branches b ON b.id = o.branch_id
-            WHERE ot.{date_column} BETWEEN {since} AND CURRENT_DATE
+            WHERE {date_col} BETWEEN {since} AND CURRENT_DATE
             ORDER BY ot.{order_column} DESC
             """)
     return [_row_to_dict(r) for r in cur.fetchall()]


### PR DESCRIPTION
## Summary
- `/report/milestones` was returning a 500 on Render (Postgres) because `death_date`, `term_start`, and `term_end` are stored as `TEXT` but were compared with `CURRENT_DATE` / `CURRENT_DATE - INTERVAL '90 days'` (both `DATE` type)
- Postgres raises `operator does not exist: text >= date` — SQLite silently handles this via dynamic typing
- Added `::date` casts in `reports.py` when `is_postgres()` is true; SQLite path unchanged

## Test plan
- [ ] All 12 existing milestone/data-routes tests pass locally
- [ ] Verify `/report/milestones` returns 200 on Render after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)