### PR TITLE
fix: gate Wikipedia bio fetch concurrency behind WIKI_FETCH_WORKERS env var

### DIFF
--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -281,7 +282,7 @@ def _fetch_bio_batch(
     on_success,
     on_error,
     run_cache=None,
-    max_workers: int = 3,
+    max_workers: int | None = None,
 ) -> bool:
     """Fetch biographies for *urls* with up to *max_workers* concurrent HTTP calls.
 
@@ -294,6 +295,9 @@ def _fetch_bio_batch(
 
     Returns True if the run was cancelled, False if all URLs were processed.
     """
+
+    if max_workers is None:
+        max_workers = int(os.environ.get("WIKI_FETCH_WORKERS", "1"))
 
     def _worker(url: str) -> tuple[str, dict | None, str | None]:
         try:


### PR DESCRIPTION
## Summary
- `_fetch_bio_batch` previously hardcoded `max_workers=3`, spawning 3 concurrent Wikipedia HTTP threads — likely the cause of the OOM on Render's 512 MB plan
- `max_workers` now resolves from `WIKI_FETCH_WORKERS` env var at runtime, defaulting to `1` (sequential)
- No call sites changed; the parallel design (ThreadPoolExecutor + wiki_throttle rate limiter) is fully preserved for future use

## To scale up
Set `WIKI_FETCH_WORKERS=3` (or higher) in the Render environment dashboard.

## Test plan
- [x] All 764 existing tests pass (11 skipped)
- [ ] Confirm nightly job runs without OOM on Render at `WIKI_FETCH_WORKERS=1`
- [ ] Optionally bump to 2–3 workers once memory headroom is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)