### PR TITLE
fix: purge office_terms before individuals in full run (FK violation)

### DIFF
--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -1384,8 +1384,9 @@ def run_with_db(
     biography = parse_core.Biography(logger, data_cleanup)
     offices_parser = parse_core.Offices(logger, biography, data_cleanup)
 
-    # Full run: purge individuals only; office_terms are replaced per-office after validation
+    # Full run: purge office_terms first (FK constraint), then individuals; terms are re-populated per-office
     if run_mode == "full" and not dry_run and not test_run:
+        db_office_terms.purge_all_office_terms()
         db_individuals.purge_all_individuals()
         existing_individual_wiki_urls: set[str] = set()
     else:


### PR DESCRIPTION
## Summary
- Full run mode called `purge_all_individuals()` while the previous run's `office_terms` rows still referenced those individuals
- Postgres's default FK behavior (`RESTRICT`) blocks the delete, causing the error: `update or delete on table "individuals" violates foreign key constraint "office_terms_individual_id_fkey"`
- Fix: call `purge_all_office_terms()` first, then `purge_all_individuals()` — correct for a full run since all terms are re-scraped per-office anyway

## Test plan
- [ ] Trigger a full run in a staging/prod environment and confirm it completes without FK violation
- [ ] Confirm office_terms are re-populated correctly after the run
- [ ] Confirm existing tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)