### PR TITLE
fix: return JSON 401 for unauthenticated API requests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -131,6 +131,8 @@ async def require_login(request: Request, call_next):
     if request.url.path in _PUBLIC_PATHS or request.url.path.startswith("/static"):
         return await call_next(request)
     if not request.session.get("user_email"):
+        if request.url.path.startswith("/api/"):
+            return JSONResponse({"detail": "Not authenticated"}, status_code=401)
         return RedirectResponse("/login")
     return await call_next(request)
 

--- a/src/templates/run.html
+++ b/src/templates/run.html
@@ -283,6 +283,7 @@ function _onJobFinished(s) {
 async function _poll(jobId) {
   try {
     const r = await fetch('/api/run/status/' + jobId);
+    if (r.status === 401) throw new Error('Session expired — please reload and log in again');
     const s = await r.json();
     _progressMessage.textContent = s.message || s.phase || 'Running…';
 


### PR DESCRIPTION
## Summary
- Auth middleware was sending `RedirectResponse("/login")` (HTML) for **all** unauthenticated requests, including `/api/` routes
- If a session expired during a long full run, the browser's status-poll would follow the redirect, receive `<!DOCTYPE html>`, and throw *"Unexpected token '<'"* — appearing as a hard error even though the run had completed successfully
- `/api/` paths now receive a `401 {"detail": "Not authenticated"}` JSON response; the run page's `_poll` handler detects the 401 and surfaces *"Session expired — please reload and log in again"* instead

## Test plan
- [ ] Start a run locally (auth disabled — no change in behaviour)
- [ ] In production, verify `/api/run/status/<id>` returns 401 JSON when session is invalid, not a redirect to `/login`
- [ ] Confirm the run UI shows the session-expired message rather than the JSON parse error when a 401 is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)