### PR TITLE
ci: verbose test output in validate-fixtures job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: python scripts/validate_parser_fixtures.py
 
       - name: Run tests
-        run: pytest --tb=short
+        run: pytest --tb=short -v
 
   openai-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main


### PR DESCRIPTION
## Summary
- Adds `-v` flag to `pytest --tb=short` in the `validate-fixtures` CI job so each test name and pass/fail status is visible in the job log

## Test plan
- [ ] CI passes on this PR
- [ ] Verify the `validate-fixtures` job log now shows individual test names

🤖 Generated with [Claude Code](https://claude.com/claude-code)