### PR TITLE
fix: escape literal % in psycopg2 LIKE patterns to prevent nightly job crash

### DIFF
--- a/src/db/individuals.py
+++ b/src/db/individuals.py
@@ -225,7 +225,7 @@ def get_living_individual_wiki_urls(conn=None) -> set[str]:
         conn = get_connection()
     try:
         cur = conn.execute(
-            "SELECT wiki_url FROM individuals WHERE is_living = 1 AND is_dead_link = 0 AND wiki_url NOT LIKE 'No link:%'"
+            "SELECT wiki_url FROM individuals WHERE is_living = 1 AND is_dead_link = 0 AND wiki_url NOT LIKE 'No link:%%'"
         )
         return {row["wiki_url"] for row in cur.fetchall()}
     finally:
@@ -242,7 +242,7 @@ def get_living_individuals_for_batch(batch: int, conn=None) -> list[str]:
         cur = conn.execute(
             """SELECT wiki_url FROM individuals
                WHERE is_living = 1 AND is_dead_link = 0
-                 AND wiki_url NOT LIKE 'No link:%'
+                 AND wiki_url NOT LIKE 'No link:%%'
                  AND bio_batch = %s
                ORDER BY bio_refreshed_at ASC NULLS FIRST""",
             (batch,),


### PR DESCRIPTION
## Summary
- `'No link:%'` in parameterized SQL queries was being parsed by psycopg2 as a format specifier, consuming a slot in the params tuple
- With `bio_batch = %s` also present, psycopg2 expected 2 params but received 1, raising `IndexError: tuple index out of range`
- Fixed by escaping `%` as `%%` in both affected LIKE patterns in `src/db/individuals.py`

## Root cause
The connection wrapper (`connection.py:76`) always passes `params if params is not None else ()`, so psycopg2 always processes `%` characters — even in SQL string literals.

## Test plan
- [ ] Run `python -m pytest` locally — all non-Playwright tests pass
- [ ] Confirm nightly delta job succeeds on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)