### PR TITLE
fix: remove insufficient_vitals index from SCHEMA_PG_SQL to fix prod deploy

### DIFF
--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -614,7 +614,8 @@ CREATE TABLE IF NOT EXISTS office_terms (
 CREATE INDEX IF NOT EXISTS idx_office_terms_office_id ON office_terms(office_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_individual_id ON office_terms(individual_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_wiki_url ON office_terms(wiki_url);
-CREATE INDEX IF NOT EXISTS idx_individuals_insuf_vitals_checked_at ON individuals(insufficient_vitals_checked_at);
+-- idx_individuals_insuf_vitals_checked_at is created via _run_pg_migrations (pg migration)
+-- so that ALTER TABLE ADD COLUMN runs first on pre-existing databases.
 
 -- Parser test scripts
 CREATE TABLE IF NOT EXISTS parser_test_scripts (


### PR DESCRIPTION
## Root Cause

On existing PostgreSQL databases, `_init_postgres()` runs `SCHEMA_PG_SQL` first, then `_run_pg_migrations()`. For pre-existing databases:

1. `CREATE TABLE IF NOT EXISTS individuals (...)` is **skipped** — table already exists without the new column
2. `CREATE INDEX IF NOT EXISTS idx_individuals_insuf_vitals_checked_at ON individuals(insufficient_vitals_checked_at)` **fails** — column doesn't exist yet
3. `_run_pg_migrations()` never runs — the `ALTER TABLE ADD COLUMN` migration that would have added the column is never reached

Result: `RuntimeError: Database startup failed: column "insufficient_vitals_checked_at" does not exist`

## Fix

Remove the `CREATE INDEX` for `idx_individuals_insuf_vitals_checked_at` from `SCHEMA_PG_SQL`. The index already exists as a dedicated migration entry in `_run_pg_migrations()` (`pg_individuals_insuf_vitals_checked_at_idx`), which runs **after** the `ALTER TABLE ADD COLUMN` migration.

- **Existing installs**: `ALTER TABLE ADD COLUMN` adds the column → index migration creates the index ✓
- **Fresh installs**: `CREATE TABLE` includes the column → `ADD COLUMN` is a no-op → index migration creates the index ✓

## Test plan
- [x] All 116 tests pass locally
- [x] No schema changes to SQLite path (SQLite index remains in `SCHEMA_SQL`; `_sqlite_add_columns_if_missing()` handles pre-existing local DBs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)