### PR TITLE
Fix deploy: deduplicate source_pages before unique constraint

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -308,6 +308,24 @@ def _run_pg_migrations(conn) -> None:
     )
 
     # source_pages.url must be unique — prevent duplicate pages from AI-driven inserts.
+    # First reassign child rows and remove duplicates, keeping the row with the lowest id.
+    _apply(
+        "pg_source_pages_dedup",
+        """WITH keeper AS (
+               SELECT url, MIN(id) AS keep_id FROM source_pages GROUP BY url HAVING COUNT(*) > 1
+           )
+           UPDATE office_details SET source_page_id = k.keep_id
+           FROM keeper k
+           JOIN source_pages sp ON sp.url = k.url AND sp.id != k.keep_id
+           WHERE office_details.source_page_id = sp.id""",
+    )
+    _apply(
+        "pg_source_pages_dedup_delete",
+        """DELETE FROM source_pages
+           WHERE id NOT IN (
+               SELECT MIN(id) FROM source_pages GROUP BY url
+           )""",
+    )
     _apply(
         "pg_source_pages_url_unique",
         "ALTER TABLE source_pages ADD CONSTRAINT source_pages_url_key UNIQUE (url)",


### PR DESCRIPTION
## Summary
- Render deploy failed because `source_pages` had duplicate URLs, preventing the `source_pages_url_key` unique constraint from being created
- Adds two new migrations before the unique constraint: one to reassign `office_details` children to the keeper row (lowest id), and one to delete the duplicate rows
- All 880 tests pass

## Test plan
- [ ] Verify Render deploy succeeds
- [ ] Confirm `source_pages_url_key` unique constraint exists in production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)