### PR TITLE
ci: add ZAP weekly security scan

### DIFF
--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -1,0 +1,15 @@
+name: ZAP Weekly Scan
+
+on:
+  schedule:
+    # Weekly Sunday at 06:00 UTC (midnight Mountain Time)
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+jobs:
+  zap-scan:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
+    with:
+      target-url: ${{ secrets.SITE_URL }}
+      artifact-name: 'zap-weekly-office-holder'
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds weekly OWASP ZAP baseline security scan (Sundays 06:00 UTC)
- Uses the shared reusable workflow from the org `.github` repo
- Matches the pattern used across other repos in the org

🤖 Generated with [Claude Code](https://claude.com/claude-code)