### PR TITLE
feat: add Gemini Research link to navigation menu

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -45,6 +45,7 @@
       <li><a href="/data/office-terms">Office terms</a></li>
       <li><a href="/db/" target="_blank" rel="noopener">DB Explorer</a></li>
       <li><a href="/report/milestones">Milestone report</a></li>
+      <li><a href="/gemini-research">Gemini Research</a></li>
     </ul>
   </nav>
   {% set git_sync = git_sync_status() %}


### PR DESCRIPTION
## Summary
- Added a navigation link for the Gemini Research page in `base.html`
- The feature was fully implemented (route, template, API endpoints) but had no nav entry, making it undiscoverable in the UI

## Test plan
- [ ] Verify the "Gemini Research" link appears in the nav bar
- [ ] Verify clicking it navigates to `/gemini-research`

🤖 Generated with [Claude Code](https://claude.com/claude-code)