### PR TITLE
fix: auto-expire stale jobs that block scheduled tasks

### DIFF
--- a/src/db/scraper_jobs.py
+++ b/src/db/scraper_jobs.py
@@ -191,6 +191,60 @@ def count_queued_jobs(conn=None) -> int:
             conn.close()
 
 
+def expire_stale_jobs(conn=None) -> list[dict]:
+    """Mark stale running/queued jobs as 'error' and return details of expired jobs.
+
+    Expiry rules:
+    - Queued jobs older than 12 hours → expired
+    - Running jobs older than 8 hours → expired (except type='full')
+    - Running 'full' jobs older than 24 hours → expired
+    """
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        from datetime import timedelta
+
+        now = datetime.now(timezone.utc)
+        # Fetch all running/queued jobs
+        rows = conn.execute(
+            "SELECT id, type, status, created_at FROM scraper_jobs WHERE status IN (%s, %s)",
+            ("running", "queued"),
+        ).fetchall()
+
+        expired = []
+        for row in rows:
+            job_id, job_type, status, created_at_str = row[0], row[1], row[2], row[3]
+            try:
+                created_at = datetime.strptime(created_at_str, "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=timezone.utc
+                )
+            except (ValueError, TypeError):
+                continue
+            age = now - created_at
+            reason = None
+            if status == "queued" and age > timedelta(hours=12):
+                reason = f"Queued job expired after {age}"
+            elif status == "running" and job_type == "full" and age > timedelta(hours=24):
+                reason = f"Full run expired after {age}"
+            elif status == "running" and job_type != "full" and age > timedelta(hours=8):
+                reason = f"Running job expired after {age}"
+
+            if reason:
+                conn.execute(
+                    "UPDATE scraper_jobs SET status = %s, updated_at = %s WHERE id = %s",
+                    ("error", now.strftime("%Y-%m-%dT%H:%M:%SZ"), job_id),
+                )
+                expired.append({"id": job_id, "type": job_type, "status": status, "reason": reason})
+
+        if expired and own_conn:
+            conn.commit()
+        return expired
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def count_active_jobs(conn=None) -> int:
     """Return the number of jobs with status 'running' or 'queued'."""
     own_conn = conn is None

--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -74,11 +74,60 @@ print(json.dumps(result))
     return parsed
 
 
+def _expire_stale_jobs_with_email() -> None:
+    """Expire stale jobs and send an email notification for each expired job."""
+    try:
+        from src.db.scraper_jobs import expire_stale_jobs
+
+        expired = expire_stale_jobs()
+        for job in expired:
+            print(f"[scheduler] Expired stale job: {job}")
+            _send_expiry_email(job)
+    except Exception as e:
+        print(f"[scheduler] Stale job expiry check failed (non-fatal): {e}")
+
+
+def _send_expiry_email(job: dict) -> None:
+    """Send an email notification when a job is expired."""
+    app_password = os.environ.get("EMAIL_APP_PASSWORD", "")
+    if not app_password:
+        return
+
+    email_from = os.environ.get("EMAIL_FROM", _DEFAULT_EMAIL)
+    email_to = os.environ.get("EMAIL_TO", _DEFAULT_EMAIL)
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    body = (
+        f"A scraper job was automatically expired.\n\n"
+        f"  Job ID   : {job.get('id', 'unknown')}\n"
+        f"  Type     : {job.get('type', 'unknown')}\n"
+        f"  Status   : {job.get('status', 'unknown')} → error\n"
+        f"  Reason   : {job.get('reason', 'unknown')}\n"
+        f"  Expired  : {date_str}\n"
+    )
+
+    subject = f"Office Holder — Job Expired — {job.get('type', 'unknown')} ({date_str})"
+    msg = MIMEText(body, "plain", "utf-8")
+    msg["Subject"] = subject
+    msg["From"] = email_from
+    msg["To"] = email_to
+
+    try:
+        with smtplib.SMTP_SSL("smtp.gmail.com", 465) as smtp:
+            smtp.login(email_from, app_password)
+            smtp.sendmail(email_from, [email_to], msg.as_string())
+        print(f"[scheduler] Expiry email sent for job {job.get('id')}")
+    except Exception as exc:
+        print(f"[scheduler] Failed to send expiry email: {exc}")
+
+
 def run_daily_delta() -> None:
     """Entry point called by APScheduler at 06:00 UTC each day."""
     if not is_daily_delta_enabled():
         print("[scheduler] Daily delta run skipped because DAILY_DELTA_ENABLED is disabled")
         return
+
+    _expire_stale_jobs_with_email()
 
     try:
         from src.db.scraper_jobs import count_active_jobs
@@ -167,6 +216,8 @@ print(json.dumps(result))
 
 def run_daily_insufficient_vitals() -> None:
     """Entry point called by APScheduler at 07:00 UTC each day."""
+    _expire_stale_jobs_with_email()
+
     try:
         from src.db.scraper_jobs import count_active_jobs
 
@@ -197,6 +248,8 @@ def run_daily_insufficient_vitals() -> None:
 
 def run_daily_gemini_research() -> None:
     """Entry point called by APScheduler at 08:00 UTC each day."""
+    _expire_stale_jobs_with_email()
+
     try:
         from src.db.scraper_jobs import count_active_jobs
 

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -6,6 +6,7 @@ Tests cover:
 - DB CRUD: enqueue_job, pop_next_queued_job, count_queued_jobs, count_active_jobs
 - Router: api_run queues when busy, rejects when queue full, starts immediately when idle
 - Worker: _maybe_start_next_queued_job drains queue on job completion
+- Expiry: expire_stale_jobs marks stale running/queued jobs as error
 - Scheduler: run_daily_delta skips when active jobs exist
 """
 
@@ -17,6 +18,7 @@ import tempfile
 import threading
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -333,6 +335,84 @@ class TestMaybeStartNextQueuedJob:
             # Should not raise
             _maybe_start_next_queued_job()
             mock_thread.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Expiry tests
+# ---------------------------------------------------------------------------
+
+
+class TestExpireStaleJobs:
+    def _insert_job(self, conn, job_id, job_type, status, created_at_str):
+        now = db_scraper_jobs._now_iso()
+        conn.execute(
+            "INSERT INTO scraper_jobs (id, type, status, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?)",
+            (job_id, job_type, status, created_at_str, now),
+        )
+        conn.commit()
+
+    def test_expires_queued_job_older_than_12h(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        old = "2000-01-01T00:00:00Z"
+        self._insert_job(conn, "q1", "delta", "queued", old)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 1
+        assert expired[0]["id"] == "q1"
+        assert "Queued" in expired[0]["reason"]
+        row = conn.execute("SELECT status FROM scraper_jobs WHERE id = ?", ("q1",)).fetchone()
+        assert row["status"] == "error"
+
+    def test_does_not_expire_recent_queued_job(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        recent = db_scraper_jobs._now_iso()
+        self._insert_job(conn, "q1", "delta", "queued", recent)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 0
+
+    def test_expires_running_job_older_than_8h(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        old = "2000-01-01T00:00:00Z"
+        self._insert_job(conn, "r1", "delta", "running", old)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 1
+        assert expired[0]["id"] == "r1"
+        assert "Running" in expired[0]["reason"]
+
+    def test_does_not_expire_recent_running_job(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        recent = db_scraper_jobs._now_iso()
+        self._insert_job(conn, "r1", "delta", "running", recent)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 0
+
+    def test_full_run_gets_24h_threshold(self, tmp_path):
+        """A 'full' run should only expire after 24 hours, not 8."""
+        conn = _make_conn(tmp_path)
+        from datetime import timedelta
+
+        # 10 hours ago — would expire a normal job but not a full run
+        ten_hours_ago = (
+            datetime.now(timezone.utc) - timedelta(hours=10)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._insert_job(conn, "f1", "full", "running", ten_hours_ago)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 0
+
+    def test_full_run_expires_after_24h(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        old = "2000-01-01T00:00:00Z"
+        self._insert_job(conn, "f1", "full", "running", old)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 1
+        assert "Full run" in expired[0]["reason"]
+
+    def test_does_not_expire_completed_jobs(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        old = "2000-01-01T00:00:00Z"
+        self._insert_job(conn, "c1", "delta", "complete", old)
+        expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
+        assert len(expired) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Queued jobs expire after 12h, running jobs after 8h (full runs after
24h). Each scheduled task now calls expire_stale_jobs() before checking
count_active_jobs(), so a stuck job from a previous run no longer blocks
all future scheduled tasks. An email notification is sent for every
expired job.

https://claude.ai/code/session_01JzqSrMJszkJZNj41s8Dvka