### PR TITLE
fix: add -preview suffix to Gemini 3.1 Pro model name

### DIFF
--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -323,7 +323,7 @@ def run_daily_gemini_research() -> None:
         logger.error("Gemini research run crashed:\n%s", tb)
         # Detect model deprecation from subprocess traceback
         if "GeminiModelDeprecatedError" in tb:
-            _send_model_deprecated_email("gemini-3.1-pro", tb)
+            _send_model_deprecated_email("gemini-3.1-pro-preview", tb)
         _send_job_summary_email("Gemini Research", None, 0.0, run_start, error=tb)
         return
 

--- a/src/services/gemini_vitals_researcher.py
+++ b/src/services/gemini_vitals_researcher.py
@@ -140,7 +140,7 @@ class GeminiVitalsResearcher:
         from google import genai
 
         self._client = genai.Client(api_key=api_key)
-        self._model = "gemini-3.1-pro"
+        self._model = "gemini-3.1-pro-preview"
 
     def research_individual(
         self,


### PR DESCRIPTION
## Summary
- Gemini 3.1 Pro is still in Preview stage and the API requires the `-preview` suffix (`gemini-3.1-pro-preview`), otherwise requests return 404
- Updated model name in `gemini_vitals_researcher.py` and the deprecation email reference in `scheduled_tasks.py`

## Test plan
- [ ] Verify Gemini vitals research completes without 404 errors
- [ ] Confirm deprecation alert email references the correct model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)