### PR TITLE
fix: nightly jobs silently skipped after deploy

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -110,16 +110,36 @@ async def lifespan(app: FastAPI):
         sentry_sdk.capture_exception(e)
         traceback.print_exc()
         raise RuntimeError(f"Database startup failed: {e}") from e
+    # Allow up to 15 minutes of misfire grace so deploys near trigger time
+    # don't silently skip the job (APScheduler default is only 1 second).
+    _MISFIRE_GRACE = 15 * 60  # seconds
     scheduler = AsyncIOScheduler(timezone="UTC")
     if is_daily_delta_enabled():
-        scheduler.add_job(run_daily_delta, "cron", hour=6, minute=0, id="daily_delta")
+        scheduler.add_job(
+            run_daily_delta,
+            "cron",
+            hour=6,
+            minute=0,
+            id="daily_delta",
+            misfire_grace_time=_MISFIRE_GRACE,
+        )
         print("[scheduler] Daily delta run scheduled at 06:00 UTC")
         scheduler.add_job(
-            run_daily_insufficient_vitals, "cron", hour=7, minute=0, id="daily_insufficient_vitals"
+            run_daily_insufficient_vitals,
+            "cron",
+            hour=7,
+            minute=0,
+            id="daily_insufficient_vitals",
+            misfire_grace_time=_MISFIRE_GRACE,
         )
         print("[scheduler] Insufficient vitals recheck scheduled at 07:00 UTC")
         scheduler.add_job(
-            run_daily_gemini_research, "cron", hour=8, minute=0, id="daily_gemini_research"
+            run_daily_gemini_research,
+            "cron",
+            hour=8,
+            minute=0,
+            id="daily_gemini_research",
+            misfire_grace_time=_MISFIRE_GRACE,
         )
         print("[scheduler] Gemini deep research scheduled at 08:00 UTC")
     else:

--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -176,7 +176,11 @@ def run_daily_delta() -> None:
 
         active = count_active_jobs()
         if active > 0:
-            logger.info("Daily delta run skipped: %d job(s) already running or queued.", active)
+            logger.warning("Daily delta run skipped: %d job(s) already running or queued.", active)
+            sentry_sdk.capture_message(
+                f"Daily delta skipped: {active} active job(s)",
+                level="warning",
+            )
             return
     except Exception as e:
         logger.warning("Could not check active jobs (non-fatal): %s", e)
@@ -265,8 +269,13 @@ def run_daily_insufficient_vitals() -> None:
     try:
         from src.db.scraper_jobs import count_active_jobs
 
-        if count_active_jobs() > 0:
-            logger.info("Insufficient vitals run skipped: jobs already active.")
+        active = count_active_jobs()
+        if active > 0:
+            logger.warning("Insufficient vitals run skipped: %d job(s) already active.", active)
+            sentry_sdk.capture_message(
+                f"Insufficient vitals skipped: {active} active job(s)",
+                level="warning",
+            )
             return
     except Exception as e:
         logger.warning("Could not check active jobs (non-fatal): %s", e)
@@ -301,8 +310,13 @@ def run_daily_gemini_research() -> None:
     try:
         from src.db.scraper_jobs import count_active_jobs
 
-        if count_active_jobs() > 0:
-            logger.info("Gemini research run skipped: jobs already active.")
+        active = count_active_jobs()
+        if active > 0:
+            logger.warning("Gemini research run skipped: %d job(s) already active.", active)
+            sentry_sdk.capture_message(
+                f"Gemini research skipped: {active} active job(s)",
+                level="warning",
+            )
             return
     except Exception as e:
         logger.warning("Could not check active jobs (non-fatal): %s", e)


### PR DESCRIPTION
## Summary
- **Root cause**: PR #202 merged at 05:44 UTC, triggering a Render deploy just before the 06:00 UTC nightly job. APScheduler's default `misfire_grace_time` is 1 second, so all three cron jobs (06:00, 07:00, 08:00) were silently dropped when the scheduler restarted after the trigger time.
- **Fix**: Added `misfire_grace_time=900` (15 min) to all three scheduled jobs so deploys near trigger time don't silently skip them.
- **Observability**: Upgraded "skipped due to active jobs" logging from INFO to WARNING with `sentry_sdk.capture_message()` so future skips show up in Sentry.

## Test plan
- [x] All 32 scheduler and job queue tests pass
- [ ] Verify next nightly run fires successfully after deploy
- [ ] Confirm Sentry receives warning events if a job is skipped due to active jobs

https://claude.ai/code/session_01ULHkkQ3JtzAzu3X3Rr2pQ7