### PR TITLE
fix: handle Postgres datetime objects in expire_stale_jobs

### DIFF
--- a/src/db/scraper_jobs.py
+++ b/src/db/scraper_jobs.py
@@ -214,13 +214,19 @@ def expire_stale_jobs(conn=None) -> list[dict]:
 
         expired = []
         for row in rows:
-            job_id, job_type, status, created_at_str = row[0], row[1], row[2], row[3]
-            try:
-                created_at = datetime.strptime(created_at_str, "%Y-%m-%dT%H:%M:%SZ").replace(
-                    tzinfo=timezone.utc
-                )
-            except (ValueError, TypeError):
-                continue
+            job_id, job_type, status, created_at_raw = row[0], row[1], row[2], row[3]
+            # PostgreSQL TIMESTAMPTZ returns datetime; SQLite TEXT returns str.
+            if isinstance(created_at_raw, datetime):
+                created_at = created_at_raw
+                if created_at.tzinfo is None:
+                    created_at = created_at.replace(tzinfo=timezone.utc)
+            else:
+                try:
+                    created_at = datetime.strptime(created_at_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
+                        tzinfo=timezone.utc
+                    )
+                except (ValueError, TypeError):
+                    continue
             age = now - created_at
             reason = None
             if status == "queued" and age > timedelta(hours=12):

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -414,6 +414,52 @@ class TestExpireStaleJobs:
         expired = db_scraper_jobs.expire_stale_jobs(conn=conn)
         assert len(expired) == 0
 
+    def test_handles_datetime_object_from_postgres(self, tmp_path):
+        """Postgres TIMESTAMPTZ columns return datetime objects, not strings."""
+
+        class _FakeConn:
+            """Simulates a psycopg-style connection returning datetime objects."""
+
+            def __init__(self, rows):
+                self._rows = rows
+                self.updates = []
+
+            def execute(self, sql, params):
+                if sql.strip().upper().startswith("SELECT"):
+                    return self
+
+                class _Result:
+                    pass
+
+                self.updates.append((sql, params))
+                return _Result()
+
+            def fetchall(self):
+                return self._rows
+
+            def commit(self):
+                pass
+
+            def close(self):
+                pass
+
+        from datetime import timedelta
+
+        # Aware datetime (like psycopg would return for TIMESTAMPTZ)
+        old_aware = datetime.now(timezone.utc) - timedelta(hours=10)
+        # Naive datetime (fallback case)
+        old_naive = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=10)
+        fake = _FakeConn(
+            [
+                ("r1", "delta", "running", old_aware),
+                ("r2", "delta", "running", old_naive),
+            ]
+        )
+        expired = db_scraper_jobs.expire_stale_jobs(conn=fake)
+        assert len(expired) == 2
+        assert {e["id"] for e in expired} == {"r1", "r2"}
+        assert len(fake.updates) == 2
+
 
 # ---------------------------------------------------------------------------
 # Scheduler tests


### PR DESCRIPTION
## Summary

The expiry fix (#190) was silently failing in production because Postgres `TIMESTAMPTZ` columns return Python `datetime` objects, not strings. The `strptime` call threw `TypeError` which was swallowed by the `except` clause, so every job was silently skipped and nothing ever expired.

**Evidence from production logs (2026-04-04):**
```
06:00:00 Daily delta run skipped: 1 job(s) already running or queued.
07:00:00 Insufficient vitals run skipped: 1 job(s) already active.
08:00:00 Gemini research run skipped: 1 job(s) already active.
```
No `Expired stale job` log appeared even though a stuck job was present.

## Changes

- Detect `datetime` objects returned by psycopg and use them directly
- Fall back to `strptime` for SQLite (TEXT column) test compatibility
- Handle both timezone-aware and naive datetimes
- New test using a fake connection that returns datetime rows

## Test plan

- [x] All 28 `test_job_queue.py` tests pass
- [ ] Verify scheduled jobs run tomorrow morning and stale job is expired with email notification

https://claude.ai/code/session_01JzqSrMJszkJZNj41s8Dvka