### PR TITLE
fix: replace unbounded _key_locks dict with WeakValueDictionary (#224)

### DIFF
--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import threading
+import weakref
 from pathlib import Path
 
 from bs4 import BeautifulSoup
@@ -20,8 +21,25 @@ logger = logging.getLogger(__name__)
 
 TIMEOUT = 30
 _LOCK = threading.Lock()
-_key_locks: dict[str, threading.Lock] = {}
+
+# WeakValueDictionary: entries are removed automatically once no thread holds
+# a reference to the _KeyLock, so the dict never grows unboundedly.
+_key_locks: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 _key_locks_lock = threading.Lock()
+
+
+class _KeyLock:
+    """Thin wrapper around threading.Lock that is weakly referenceable."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self._lock.release()
 
 
 def _cache_dir() -> Path:
@@ -36,11 +54,16 @@ def _cache_key(url: str, table_no: int, use_full_page: bool = False) -> str:
     return hashlib.sha256(normalized).hexdigest()[:32]
 
 
-def _key_lock(key: str) -> threading.Lock:
+def _key_lock(key: str) -> _KeyLock:
+    """Return a per-key lock, creating one if needed. Caller must hold a strong
+    reference for the duration of the critical section — the WeakValueDictionary
+    will GC the lock once the caller's local variable goes out of scope."""
     with _key_locks_lock:
-        if key not in _key_locks:
-            _key_locks[key] = threading.Lock()
-        return _key_locks[key]
+        lock = _key_locks.get(key)
+        if lock is None:
+            lock = _KeyLock()
+            _key_locks[key] = lock
+        return lock
 
 
 def _fetch_table_from_url(

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Tests for the _key_locks memory-leak fix in table_cache.py (Issue #224).
+
+The original implementation used a plain dict[str, threading.Lock] that
+grew forever. The fix uses weakref.WeakValueDictionary so entries are
+automatically removed once no thread holds a reference to the lock.
+
+Tests cover:
+- _key_lock returns a _KeyLock with working __enter__/__exit__
+- Same key returns the same object while a reference is held
+- Different keys return different objects
+- Dict shrinks after references are released (GC frees the lock)
+- Concurrent access from multiple threads does not corrupt the dict
+  and each thread gets a usable lock
+"""
+
+from __future__ import annotations
+
+import gc
+import threading
+import weakref
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# _KeyLock behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestKeyLock:
+    def test_context_manager_acquires_and_releases(self):
+        from src.scraper.table_cache import _KeyLock
+
+        kl = _KeyLock()
+        with kl:
+            # lock is held; trying to acquire again would block
+            acquired = kl._lock.acquire(blocking=False)
+            assert acquired is False  # already locked
+        # after context exits, lock is released
+        acquired = kl._lock.acquire(blocking=False)
+        assert acquired is True
+        kl._lock.release()
+
+    def test_is_weakly_referenceable(self):
+        from src.scraper.table_cache import _KeyLock
+
+        kl = _KeyLock()
+        ref = weakref.ref(kl)
+        assert ref() is kl
+        del kl
+        gc.collect()
+        assert ref() is None
+
+
+# ---------------------------------------------------------------------------
+# _key_lock function
+# ---------------------------------------------------------------------------
+
+
+class TestKeyLockFunction:
+    def test_returns_key_lock_instance(self):
+        from src.scraper.table_cache import _KeyLock, _key_lock
+
+        lock = _key_lock("abc123")
+        assert isinstance(lock, _KeyLock)
+
+    def test_same_key_same_object_while_held(self):
+        from src.scraper.table_cache import _key_lock
+
+        lock1 = _key_lock("same-key")
+        lock2 = _key_lock("same-key")
+        assert lock1 is lock2
+
+    def test_different_keys_different_objects(self):
+        from src.scraper.table_cache import _key_lock
+
+        lock_a = _key_lock("key-a-unique-1")
+        lock_b = _key_lock("key-b-unique-1")
+        assert lock_a is not lock_b
+
+    def test_dict_shrinks_after_reference_released(self):
+        from src.scraper.table_cache import _key_lock, _key_locks
+
+        unique_key = "gc-test-key-xyzzy"
+        lock = _key_lock(unique_key)
+        assert unique_key in _key_locks
+        del lock
+        gc.collect()
+        assert unique_key not in _key_locks
+
+    def test_lock_usable_as_context_manager(self):
+        from src.scraper.table_cache import _key_lock
+
+        key_lock = _key_lock("ctx-test-key")
+        with key_lock:
+            pass  # should not raise
+
+    def test_no_unbounded_growth(self):
+        """Creating and releasing 200 distinct locks leaves dict size bounded."""
+        from src.scraper.table_cache import _key_lock, _key_locks
+
+        initial_size = len(_key_locks)
+        refs = []
+        for i in range(200):
+            refs.append(_key_lock(f"growth-test-{i}"))
+        peak_size = len(_key_locks)
+        del refs
+        gc.collect()
+        final_size = len(_key_locks)
+        # After GC, all 200 should be gone
+        assert final_size <= initial_size
+        assert peak_size >= 200  # sanity — they were all created
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_same_key_returns_same_object(self):
+        """50 threads requesting the same key should all get the same object."""
+        from src.scraper.table_cache import _key_lock
+
+        results: list = []
+        barrier = threading.Barrier(50)
+
+        def worker():
+            barrier.wait()
+            results.append(_key_lock("shared-concurrent-key"))
+
+        threads = [threading.Thread(target=worker) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All results should be the same object (one lock per key while held)
+        assert all(r is results[0] for r in results)
+
+    def test_concurrent_distinct_keys_no_corruption(self):
+        """100 threads each using a unique key; no exceptions, dict is clean after."""
+        from src.scraper.table_cache import _key_lock, _key_locks
+
+        errors: list[Exception] = []
+
+        def worker(i: int):
+            try:
+                key = f"distinct-thread-key-{i}"
+                lock = _key_lock(key)
+                with lock:
+                    pass
+                del lock
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(100)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        gc.collect()
+        assert errors == []


### PR DESCRIPTION
## Summary

- `_key_locks` was a plain `dict[str, threading.Lock]` that grew forever — one entry per unique `(url, table_no)` ever scraped, never evicted
- Fix: replace with `weakref.WeakValueDictionary` + a `_KeyLock` wrapper class
- Locks are automatically removed from the dict once no thread holds a reference, so memory is bounded to only actively-used keys

## How it works

Each caller gets a strong local reference to `_KeyLock` for the duration of the `with` block. When the block exits the local variable drops, the `WeakValueDictionary` sees no more strong references, and the GC removes the entry automatically.

## Test plan
- [ ] 10 tests pass: `pytest tests/test_table_cache_key_locks.py`
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)