### PR TITLE
fix: standardize Sentry context and exception capture across workers (#225)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,8 @@ import sys
 import threading
 import uuid
 
+import sentry_sdk
+
 logger = logging.getLogger(__name__)
 
 import requests
@@ -108,8 +110,6 @@ async def lifespan(app: FastAPI):
         init_db()
     except Exception as e:
         import traceback
-
-        import sentry_sdk
 
         sentry_sdk.capture_exception(e)
         traceback.print_exc()
@@ -259,7 +259,9 @@ async def auth_google(request: Request):
 async def auth_google_callback(request: Request):
     try:
         token = await _oauth.google.authorize_access_token(request)
-    except Exception:
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        logger.error("OAuth callback failed: %s", e, exc_info=True)
         return HTMLResponse(
             "<h2>Authentication failed. <a href='/login'>Try again</a>.</h2>", status_code=400
         )

--- a/src/routers/gemini_research.py
+++ b/src/routers/gemini_research.py
@@ -281,6 +281,7 @@ def _research_worker(job_id: str, individual_id: int) -> None:
         _update_job(job_id, status="complete", phase="done")
 
     except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         logger.exception("Research worker failed for individual %d", individual_id)
         _update_job(job_id, status="error", error=str(exc))
 

--- a/src/routers/preview.py
+++ b/src/routers/preview.py
@@ -122,6 +122,7 @@ def _preview_job_worker(job_id: str, draft: dict, max_rows: "int | None"):
                     }
                 )
 
+    sentry_sdk.set_context("preview_job", {"job_id": job_id})
     try:
         result = preview_with_config(draft, max_rows=max_rows, progress_callback=progress_callback)
         with _preview_job_lock:
@@ -157,6 +158,7 @@ def _export_job_worker(job_id: str, office_name: str, config: dict):
                     }
                 )
 
+    sentry_sdk.set_context("export_job", {"job_id": job_id, "office_name": office_name})
     try:
         with _export_job_lock:
             if job_id in _export_job_store:
@@ -328,6 +330,7 @@ def _export_job_worker(job_id: str, office_name: str, config: dict):
                     "filename": filename,
                 }
     except Exception as e:
+        sentry_sdk.capture_exception(e)
         with _export_job_lock:
             if job_id in _export_job_store:
                 _export_job_store[job_id]["status"] = "error"

--- a/src/routers/run_scraper.py
+++ b/src/routers/run_scraper.py
@@ -191,6 +191,7 @@ def _run_job_worker(
         with _run_job_lock:
             return _run_job_store.get(job_id, {}).get("cancelled", False)
 
+    sentry_sdk.set_context("scraper_job", {"job_id": job_id, "run_mode": run_mode})
     try:
         result = run_with_db(
             run_mode=run_mode,


### PR DESCRIPTION
## Summary

- `run_scraper.py`: `_run_job_worker` now calls `sentry_sdk.set_context("scraper_job", {"job_id": ..., "run_mode": ...})` before the try block, matching the `_batch_job_worker` pattern in `ai_offices.py`
- `preview.py`: `_preview_job_worker` gets `set_context("preview_job")`; `_export_job_worker` gets both `set_context("export_job")` and `capture_exception()` in its except block (was missing both)
- `gemini_research.py`: `_research_worker` now calls `capture_exception(exc)` explicitly in the except block — was relying solely on LoggingIntegration
- `main.py`: `auth_google_callback` now captures the exception and logs at ERROR before returning the 400 response; `sentry_sdk` promoted to top-level import (removes redundant local import in lifespan)

Closes #225

## Test plan

- [x] All existing tests pass (808 passed, 1 pre-existing skip for missing `anthropic` module)
- [x] black + ruff clean on all 4 changed files
- [x] Pattern matches reference implementation in `ai_offices.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)