### PR TITLE
feat: instrument scraper subprocesses for Sentry visibility (#226)

### DIFF
--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -44,16 +44,28 @@ def is_daily_delta_enabled() -> bool:
 def _run_daily_delta_in_subprocess(today_batch: int) -> dict:
     """Run scraper in a child process so memory is fully released when job ends."""
     payload = f"""
-import json
-from src.scraper.runner import run_with_db
+import json, os, sentry_sdk
 
-result = run_with_db(
-    run_mode="delta",
-    run_bio=True,
-    run_office_bio=True,
-    bio_batch={today_batch},
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN"),
+    environment=os.environ.get("APP_ENVIRONMENT", "dev"),
 )
-print(json.dumps(result))
+sentry_sdk.set_tag("subprocess_job", "daily_delta")
+sentry_sdk.set_context("subprocess", {{"bio_batch": {today_batch}}})
+
+try:
+    from src.scraper.runner import run_with_db
+    result = run_with_db(
+        run_mode="delta",
+        run_bio=True,
+        run_office_bio=True,
+        bio_batch={today_batch},
+    )
+    print(json.dumps(result))
+except Exception as _exc:
+    sentry_sdk.capture_exception(_exc)
+    sentry_sdk.flush(timeout=5)
+    raise
 """
     completed = subprocess.run(
         [sys.executable, "-c", payload],
@@ -228,14 +240,26 @@ def run_daily_delta() -> None:
 def _run_mode_in_subprocess(run_mode: str, today_batch: int) -> dict:
     """Run a specific scraper mode in a child process so memory is fully released."""
     payload = f"""
-import json
-from src.scraper.runner import run_with_db
+import json, os, sentry_sdk
 
-result = run_with_db(
-    run_mode="{run_mode}",
-    bio_batch={today_batch},
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN"),
+    environment=os.environ.get("APP_ENVIRONMENT", "dev"),
 )
-print(json.dumps(result))
+sentry_sdk.set_tag("subprocess_job", "{run_mode}")
+sentry_sdk.set_context("subprocess", {{"run_mode": "{run_mode}", "bio_batch": {today_batch}}})
+
+try:
+    from src.scraper.runner import run_with_db
+    result = run_with_db(
+        run_mode="{run_mode}",
+        bio_batch={today_batch},
+    )
+    print(json.dumps(result))
+except Exception as _exc:
+    sentry_sdk.capture_exception(_exc)
+    sentry_sdk.flush(timeout=5)
+    raise
 """
     completed = subprocess.run(
         [sys.executable, "-c", payload],

--- a/src/test_scheduled_tasks.py
+++ b/src/test_scheduled_tasks.py
@@ -147,3 +147,72 @@ def test_run_daily_delta_skips_when_disabled(monkeypatch):
     run_daily_delta()
 
     assert called["subprocess"] is False
+
+
+# ---------------------------------------------------------------------------
+# Sentry subprocess instrumentation — verify real payload content
+# ---------------------------------------------------------------------------
+
+
+import subprocess
+import json as _json
+from unittest.mock import patch, MagicMock
+
+
+def _make_completed_process(stdout: str, returncode: int = 0) -> "subprocess.CompletedProcess":
+    cp = MagicMock(spec=subprocess.CompletedProcess)
+    cp.returncode = returncode
+    cp.stdout = stdout
+    cp.stderr = ""
+    return cp
+
+
+def test_daily_delta_subprocess_payload_contains_sentry_instrumentation():
+    """_run_daily_delta_in_subprocess payload must init Sentry, set context, and capture exceptions."""
+    captured_payload: list[str] = []
+
+    fake_result = _json.dumps({"office_count": 1, "terms_parsed": 0})
+
+    def _fake_run(cmd, **kwargs):
+        # cmd is [sys.executable, "-c", payload]
+        captured_payload.append(cmd[2])
+        return _make_completed_process(stdout=fake_result)
+
+    with patch("src.scheduled_tasks.subprocess.run", side_effect=_fake_run):
+        from src.scheduled_tasks import _run_daily_delta_in_subprocess
+
+        _run_daily_delta_in_subprocess(today_batch=3)
+
+    assert len(captured_payload) == 1
+    payload = captured_payload[0]
+    assert "sentry_sdk.init(" in payload
+    assert 'set_tag("subprocess_job", "daily_delta")' in payload
+    assert '"bio_batch": 3' in payload
+    assert "sentry_sdk.capture_exception(_exc)" in payload
+    assert "sentry_sdk.flush(timeout=5)" in payload
+
+
+def test_run_mode_subprocess_payload_contains_sentry_instrumentation():
+    """_run_mode_in_subprocess payload must init Sentry, set context, and capture exceptions."""
+    for mode in ("delta_insufficient_vitals", "gemini_vitals_research"):
+        captured_payload: list[str] = []
+
+        fake_result = _json.dumps({"office_count": 0})
+
+        def _fake_run(cmd, **kwargs):
+            captured_payload.append(cmd[2])
+            return _make_completed_process(stdout=fake_result)
+
+        with patch("src.scheduled_tasks.subprocess.run", side_effect=_fake_run):
+            from src.scheduled_tasks import _run_mode_in_subprocess
+
+            _run_mode_in_subprocess(run_mode=mode, today_batch=15)
+
+        assert len(captured_payload) == 1, f"expected one subprocess call for mode {mode}"
+        payload = captured_payload[0]
+        assert "sentry_sdk.init(" in payload, f"missing sentry_sdk.init for mode {mode}"
+        assert f'set_tag("subprocess_job", "{mode}")' in payload
+        assert f'"run_mode": "{mode}"' in payload
+        assert '"bio_batch": 15' in payload
+        assert "sentry_sdk.capture_exception(_exc)" in payload
+        assert "sentry_sdk.flush(timeout=5)" in payload


### PR DESCRIPTION
## Summary

The three daily scheduled jobs run `run_with_db()` inside a subprocess for memory isolation. Previously, when the scraper crashed inside the subprocess, Sentry only captured the `RuntimeError` wrapper from the parent — losing the real exception class, traceback, and run context.

- `_run_daily_delta_in_subprocess`: payload now initializes `sentry_sdk`, sets `subprocess_job=daily_delta` tag and `bio_batch` context, wraps `run_with_db` in `try/except` with `capture_exception()` + `flush(timeout=5)` before re-raise
- `_run_mode_in_subprocess`: same pattern applied to `insufficient_vitals` and `gemini_research` subprocess payloads
- `sentry_sdk.flush(timeout=5)` called before `raise` so the event drains before the process exits
- Subprocess DSN and environment are inherited from the parent via `os.environ.get()`

Closes #226

## Test plan

- [x] Two new tests mock `subprocess.run` and assert the actual generated payload strings contain `sentry_sdk.init(`, `capture_exception`, `flush`, and correct tag/context values
- [x] All existing tests pass (810 passed, 1 pre-existing skip)
- [x] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)