### PR TITLE
feat: add filtering to Individuals page

### DIFF
--- a/src/db/individuals.py
+++ b/src/db/individuals.py
@@ -11,19 +11,48 @@ from . import office_terms as db_office_terms
 def list_individuals(
     limit: int = 500,
     offset: int = 0,
+    q: str | None = None,
+    is_living: int | None = None,
+    is_dead_link: int | None = None,
     conn=None,
 ) -> list[dict[str, Any]]:
-    """Return individuals with optional pagination."""
+    """Return individuals with optional pagination and filters.
+
+    Args:
+        q: Partial case-insensitive match on full_name.
+        is_living: 1 for living, 0 for deceased.
+        is_dead_link: 1 to show only dead-link records.
+    """
     own_conn = conn is None
     if own_conn:
         conn = get_connection()
     try:
+        where_clauses: list[str] = []
+        params: list[Any] = []
+
+        if q:
+            if is_postgres():
+                where_clauses.append("full_name ILIKE %s")
+            else:
+                where_clauses.append("full_name LIKE %s")
+            params.append(f"%{q}%")
+
+        if is_living is not None:
+            where_clauses.append("is_living = %s")
+            params.append(is_living)
+
+        if is_dead_link is not None:
+            where_clauses.append("is_dead_link = %s")
+            params.append(is_dead_link)
+
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
         cur = conn.execute(
-            """SELECT id, wiki_url, page_path, full_name, birth_date, death_date,
+            f"""SELECT id, wiki_url, page_path, full_name, birth_date, death_date,
                       birth_date_imprecise, death_date_imprecise,
-                      birth_place, death_place, is_dead_link, created_at, updated_at
-               FROM individuals ORDER BY full_name LIMIT %s OFFSET %s""",
-            (limit, offset),
+                      birth_place, death_place, is_living, is_dead_link, created_at, updated_at
+               FROM individuals {where_sql} ORDER BY full_name LIMIT %s OFFSET %s""",
+            (*params, limit, offset),
         )
         return [_row_to_dict(r) for r in cur.fetchall()]
     finally:

--- a/src/routers/data.py
+++ b/src/routers/data.py
@@ -16,10 +16,28 @@ router = APIRouter()
 
 @router.get("/data/individuals", response_class=HTMLResponse)
 async def data_individuals(
-    request: Request, limit: int = Query(100, le=500), offset: int = Query(0)
+    request: Request,
+    limit: int = Query(100, le=500),
+    offset: int = Query(0),
+    q: str | None = Query(None),
+    is_living: int | None = Query(None),
+    is_dead_link: int | None = Query(None),
 ):
-    individuals = db_individuals.list_individuals(limit=limit, offset=offset)
-    return templates.TemplateResponse(request, "individuals.html", {"individuals": individuals})
+    individuals = db_individuals.list_individuals(
+        limit=limit, offset=offset, q=q, is_living=is_living, is_dead_link=is_dead_link
+    )
+    return templates.TemplateResponse(
+        request,
+        "individuals.html",
+        {
+            "individuals": individuals,
+            "q": q or "",
+            "is_living": is_living,
+            "is_dead_link": is_dead_link,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
 
 
 @router.get("/data/office-terms", response_class=HTMLResponse)

--- a/src/templates/individuals.html
+++ b/src/templates/individuals.html
@@ -2,24 +2,65 @@
 {% block title %}Individuals – Office Holder{% endblock %}
 {% block content %}
 <h1>Individuals</h1>
+
+<form method="get" action="/data/individuals">
+  <input type="hidden" name="limit" value="{{ limit }}">
+  <input type="text" name="q" value="{{ q }}" placeholder="Search name…" aria-label="Search name">
+  <select name="is_living" aria-label="Living status">
+    <option value="" {% if is_living is none %}selected{% endif %}>All</option>
+    <option value="1" {% if is_living == 1 %}selected{% endif %}>Living</option>
+    <option value="0" {% if is_living == 0 %}selected{% endif %}>Deceased</option>
+  </select>
+  <label>
+    <input type="checkbox" name="is_dead_link" value="1" {% if is_dead_link == 1 %}checked{% endif %}>
+    Dead links only
+  </label>
+  <button type="submit">Filter</button>
+  {% if q or is_living is not none or is_dead_link %}
+  <a href="/data/individuals?limit={{ limit }}">Clear filters</a>
+  {% endif %}
+</form>
+
 {% if individuals %}
 <table>
   <thead>
-    <tr><th>Full name</th><th>Wiki URL</th><th>Birth</th><th>Death</th></tr>
+    <tr>
+      <th>Full name</th>
+      <th>Wiki URL</th>
+      <th>Living</th>
+      <th>Dead link</th>
+      <th>Birth</th>
+      <th>Death</th>
+      <th>Birth place</th>
+      <th>Death place</th>
+    </tr>
   </thead>
   <tbody>
     {% for i in individuals %}
     <tr>
       <td>{{ i.full_name or '—' }}</td>
       <td>{% if i.wiki_url %}<a href="{{ i.wiki_url }}" target="_blank" rel="noopener">{{ i.wiki_url[:50] }}…</a>{% else %}—{% endif %}</td>
+      <td>{% if i.is_living %}Yes{% elif i.is_living == 0 %}No{% else %}—{% endif %}</td>
+      <td>{% if i.is_dead_link %}&#x26A0;{% else %}—{% endif %}</td>
       <td>{{ i.birth_date or '—' }}{% if i.birth_date_imprecise %} <span class="imprecise-hint">(imprecise)</span>{% endif %}</td>
       <td>{{ i.death_date or '—' }}{% if i.death_date_imprecise %} <span class="imprecise-hint">(imprecise)</span>{% endif %}</td>
+      <td>{{ i.birth_place or '—' }}</td>
+      <td>{{ i.death_place or '—' }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
-<p><small>Showing up to 100. Add limit/offset query params for more.</small></p>
+
+<nav aria-label="Pagination">
+  {% if offset > 0 %}
+  <a href="?q={{ q }}&amp;{% if is_living is not none %}is_living={{ is_living }}&amp;{% endif %}{% if is_dead_link %}is_dead_link=1&amp;{% endif %}limit={{ limit }}&amp;offset={{ [offset - limit, 0]|max }}">← Prev</a>
+  {% endif %}
+  {% if individuals|length == limit %}
+  <a href="?q={{ q }}&amp;{% if is_living is not none %}is_living={{ is_living }}&amp;{% endif %}{% if is_dead_link %}is_dead_link=1&amp;{% endif %}limit={{ limit }}&amp;offset={{ offset + limit }}">Next →</a>
+  {% endif %}
+</nav>
+<p><small>Showing {{ individuals|length }} record(s) (offset {{ offset }}, limit {{ limit }}).</small></p>
 {% else %}
-<p>No individuals yet. Run the scraper with “Run biography” checked.</p>
+<p>No individuals match the current filters.</p>
 {% endif %}
 {% endblock %}

--- a/tests/test_individuals_filtering.py
+++ b/tests/test_individuals_filtering.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Tests for list_individuals() filtering and /data/individuals route filters."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.db.connection import _SQLiteConnWrapper
+from src.db import individuals as db_individuals
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn(tmp_path: Path):
+    db_path = tmp_path / "test.db"
+    raw = sqlite3.connect(str(db_path))
+    raw.row_factory = sqlite3.Row
+    conn = _SQLiteConnWrapper(raw)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS individuals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            wiki_url TEXT,
+            page_path TEXT,
+            full_name TEXT,
+            birth_date TEXT,
+            death_date TEXT,
+            birth_date_imprecise INTEGER NOT NULL DEFAULT 0,
+            death_date_imprecise INTEGER NOT NULL DEFAULT 0,
+            birth_place TEXT,
+            death_place TEXT,
+            is_living INTEGER NOT NULL DEFAULT 1,
+            is_dead_link INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT,
+            updated_at TEXT
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert(conn, full_name, is_living=1, is_dead_link=0, wiki_url=None):
+    conn.execute(
+        "INSERT INTO individuals (full_name, is_living, is_dead_link, wiki_url) VALUES (?, ?, ?, ?)",
+        (full_name, is_living, is_dead_link, wiki_url),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# list_individuals — no filters
+# ---------------------------------------------------------------------------
+
+
+class TestListIndividualsNoFilter:
+    def test_returns_all_rows(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith")
+        _insert(conn, "Bob Jones")
+        rows = db_individuals.list_individuals(conn=conn)
+        assert len(rows) == 2
+
+    def test_is_living_included_in_result(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith", is_living=1)
+        rows = db_individuals.list_individuals(conn=conn)
+        assert "is_living" in rows[0]
+
+    def test_is_dead_link_included_in_result(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith", is_dead_link=1)
+        rows = db_individuals.list_individuals(conn=conn)
+        assert "is_dead_link" in rows[0]
+
+
+# ---------------------------------------------------------------------------
+# list_individuals — q filter
+# ---------------------------------------------------------------------------
+
+
+class TestListIndividualsQFilter:
+    def test_partial_name_match(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith")
+        _insert(conn, "Bob Jones")
+        rows = db_individuals.list_individuals(q="alice", conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["full_name"] == "Alice Smith"
+
+    def test_case_insensitive(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith")
+        rows = db_individuals.list_individuals(q="ALICE", conn=conn)
+        assert len(rows) == 1
+
+    def test_no_match_returns_empty(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith")
+        rows = db_individuals.list_individuals(q="zzz", conn=conn)
+        assert rows == []
+
+    def test_empty_q_returns_all(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith")
+        _insert(conn, "Bob Jones")
+        rows = db_individuals.list_individuals(q="", conn=conn)
+        assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# list_individuals — is_living filter
+# ---------------------------------------------------------------------------
+
+
+class TestListIndividualsIsLivingFilter:
+    def test_living_only(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice", is_living=1)
+        _insert(conn, "Bob", is_living=0)
+        rows = db_individuals.list_individuals(is_living=1, conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["full_name"] == "Alice"
+
+    def test_deceased_only(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice", is_living=1)
+        _insert(conn, "Bob", is_living=0)
+        rows = db_individuals.list_individuals(is_living=0, conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["full_name"] == "Bob"
+
+
+# ---------------------------------------------------------------------------
+# list_individuals — is_dead_link filter
+# ---------------------------------------------------------------------------
+
+
+class TestListIndividualsDeadLinkFilter:
+    def test_dead_links_only(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice", is_dead_link=0)
+        _insert(conn, "No link", is_dead_link=1)
+        rows = db_individuals.list_individuals(is_dead_link=1, conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["full_name"] == "No link"
+
+
+# ---------------------------------------------------------------------------
+# list_individuals — composed filters
+# ---------------------------------------------------------------------------
+
+
+class TestListIndividualsComposedFilters:
+    def test_q_and_is_living(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith", is_living=1)
+        _insert(conn, "Alice Brown", is_living=0)
+        _insert(conn, "Bob Jones", is_living=1)
+        rows = db_individuals.list_individuals(q="alice", is_living=1, conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["full_name"] == "Alice Smith"
+
+    def test_q_and_is_dead_link(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        _insert(conn, "Alice Smith", is_dead_link=0)
+        _insert(conn, "Alice No Link", is_dead_link=1)
+        rows = db_individuals.list_individuals(q="alice", is_dead_link=1, conn=conn)
+        assert len(rows) == 1
+        assert rows[0]["full_name"] == "Alice No Link"
+
+
+# ---------------------------------------------------------------------------
+# Route integration tests — filter params accepted, reflected in response
+# ---------------------------------------------------------------------------
+
+
+import os
+from starlette.testclient import TestClient
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("ind_filter_db")
+    db_path = tmp / "ind_filter_test.db"
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    import src.main as main_mod
+
+    with TestClient(main_mod.app, raise_server_exceptions=False) as c:
+        yield c
+    os.environ.pop("OFFICE_HOLDER_DB_PATH", None)
+
+
+def test_route_no_filters_200(client):
+    resp = client.get("/data/individuals")
+    assert resp.status_code == 200
+
+
+def test_route_q_param_accepted(client):
+    resp = client.get("/data/individuals?q=alice")
+    assert resp.status_code == 200
+
+
+def test_route_is_living_param_accepted(client):
+    resp = client.get("/data/individuals?is_living=1")
+    assert resp.status_code == 200
+
+
+def test_route_is_dead_link_param_accepted(client):
+    resp = client.get("/data/individuals?is_dead_link=1")
+    assert resp.status_code == 200
+
+
+def test_route_composed_filters_accepted(client):
+    resp = client.get("/data/individuals?q=smith&is_living=1&is_dead_link=0")
+    assert resp.status_code == 200
+
+
+def test_route_filter_form_present_in_html(client):
+    resp = client.get("/data/individuals")
+    assert resp.status_code == 200
+    assert 'name="q"' in resp.text
+    assert 'name="is_living"' in resp.text
+    assert 'name="is_dead_link"' in resp.text
+
+
+def test_route_q_value_reflected_in_html(client):
+    resp = client.get("/data/individuals?q=testname")
+    assert "testname" in resp.text


### PR DESCRIPTION
## Summary
- `list_individuals()` now accepts `q` (name search), `is_living`, and `is_dead_link` filter params
- Filters compose and use parameterized queries (no f-string SQL injection risk)
- `/data/individuals` route exposes all filters as bookmarkable GET params
- Template adds filter form, pagination nav (prev/next), and four new columns: is_living, is_dead_link, birth_place, death_place

## Test plan
- [ ] CI green
- [ ] Name search returns partial, case-insensitive matches
- [ ] Living/Deceased dropdown filters correctly
- [ ] Dead links checkbox filters correctly
- [ ] Filters compose (e.g. name + living)
- [ ] URL preserves filter state (bookmarkable)

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)