### PR TITLE
fix: add Playwright UI tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,40 @@ jobs:
   gemini-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-gemini-policy.yml@main
     secrets: inherit
+
+  ui-tests:
+    name: Playwright UI tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Install Playwright
+        run: pip install playwright && playwright install chromium --with-deps
+
+      - name: Start test server
+        run: |
+          uvicorn src.main:app --host 127.0.0.1 --port 8000 &
+          echo $! > /tmp/uvicorn.pid
+          for i in $(seq 1 15); do
+            curl -sf http://127.0.0.1:8000/run > /dev/null 2>&1 && echo "Server ready" && break
+            sleep 2
+          done
+        env:
+          OFFICE_HOLDER_DB_PATH: /tmp/playwright_ci.db
+
+      - name: Run Playwright tests
+        run: pytest src/test_ui_edit_office_playwright.py src/test_ui_offices_list_playwright.py src/test_ui_run_playwright.py --tb=short -v
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:8000
+          OFFICE_HOLDER_DB_PATH: /tmp/playwright_ci.db
+
+      - name: Stop test server
+        if: always()
+        run: kill $(cat /tmp/uvicorn.pid) 2>/dev/null || true


### PR DESCRIPTION
## Summary
- New `ui-tests` job in `ci.yml` starts a FastAPI server, runs all 3 Playwright test files, then cleans up
- Playwright installed separately in the job (not added to `requirements.txt`) — keeps the existing `conftest.py` import guard working so other jobs still skip these tests when playwright isn't installed
- Health-check loop waits up to 30s for server to be ready before running tests

## Expected test outcome
- `test_ui_run_playwright.py` — 3 pass (page loads, mode switching, run submission)
- `test_ui_offices_list_playwright.py` — 2 pass, 1 skip (enable toggle needs pre-existing offices)
- `test_ui_edit_office_playwright.py` — 5 skip (`PLAYWRIGHT_EDIT_OFFICE_ID` not set in CI)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)