### PR TITLE
fix: PostgreSQL savepoint in upsert_individual prevents InFailedSqlTransaction

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -31,6 +31,47 @@ def is_postgres() -> bool:
     return bool(os.environ.get("DATABASE_URL"))
 
 
+class _PGSavepointContext:
+    """Context manager for a PostgreSQL savepoint within a shared transaction.
+
+    Use this to wrap an INSERT that may raise a UniqueViolation inside a function
+    that accepts a caller-owned connection.  Without a savepoint, any error puts
+    the entire outer transaction in an aborted state and all subsequent statements
+    fail with InFailedSqlTransaction.
+
+    SQLite does NOT need this: an IntegrityError on SQLite does not abort the
+    surrounding connection.  The context manager is a no-op when is_postgres()
+    is False so the same calling code works for both backends.
+
+    Usage::
+
+        with _PGSavepointContext(conn, "_my_insert"):
+            conn.execute("INSERT ...")
+            # If UniqueViolation is raised here the savepoint is rolled back;
+            # the outer transaction continues unharmed.
+        # After the with-block the savepoint is released (success path).
+    """
+
+    def __init__(self, conn, name: str) -> None:
+        self._conn = conn
+        self._name = name
+        self._active = is_postgres()
+
+    def __enter__(self) -> "_PGSavepointContext":
+        if self._active:
+            self._conn.execute(f"SAVEPOINT {self._name}")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if self._active:
+            if exc_type is None:
+                self._conn.execute(f"RELEASE SAVEPOINT {self._name}")
+            else:
+                self._conn.execute(f"ROLLBACK TO SAVEPOINT {self._name}")
+                self._conn.execute(f"RELEASE SAVEPOINT {self._name}")
+        return False  # never suppress the exception
+
+
 def get_db_path() -> Path:
     """Return the SQLite DB path (test use only). Uses OFFICE_HOLDER_DB_PATH env var when set."""
     env_path = os.environ.get("OFFICE_HOLDER_DB_PATH")

--- a/src/db/individuals.py
+++ b/src/db/individuals.py
@@ -3,7 +3,7 @@
 from datetime import date
 from typing import Any
 
-from .connection import get_connection, is_postgres, _DB_UNIQUE_ERRORS
+from .connection import get_connection, is_postgres, _DB_UNIQUE_ERRORS, _PGSavepointContext
 from .utils import _row_to_dict
 from . import office_terms as db_office_terms
 
@@ -127,24 +127,30 @@ def upsert_individual(data: dict[str, Any], conn=None) -> int:
             if own_conn:
                 conn.commit()
             return row["id"]
+        # Use a savepoint so a race-condition UniqueViolation on the INSERT only rolls
+        # back this sub-unit — not the caller's entire transaction.  Without this, any
+        # UniqueViolation puts a PostgreSQL shared connection into the aborted state and
+        # every subsequent statement fails with InFailedSqlTransaction.
+        # SQLite: _PGSavepointContext is a no-op (IntegrityError doesn't abort the conn).
         try:
-            cur = conn.execute(
-                """INSERT INTO individuals (wiki_url, page_path, full_name, birth_date, death_date, birth_date_imprecise, death_date_imprecise, birth_place, death_place, is_dead_link)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id""",
-                (
-                    wiki_url,
-                    data.get("page_path"),
-                    data.get("full_name"),
-                    data.get("birth_date"),
-                    data.get("death_date"),
-                    bd_imprecise,
-                    dd_imprecise,
-                    data.get("birth_place"),
-                    data.get("death_place"),
-                    is_dead_link,
-                ),
-            )
-            ind_id = cur.fetchone()["id"]
+            with _PGSavepointContext(conn, "_upsert_individual"):
+                cur = conn.execute(
+                    """INSERT INTO individuals (wiki_url, page_path, full_name, birth_date, death_date, birth_date_imprecise, death_date_imprecise, birth_place, death_place, is_dead_link)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id""",
+                    (
+                        wiki_url,
+                        data.get("page_path"),
+                        data.get("full_name"),
+                        data.get("birth_date"),
+                        data.get("death_date"),
+                        bd_imprecise,
+                        dd_imprecise,
+                        data.get("birth_place"),
+                        data.get("death_place"),
+                        is_dead_link,
+                    ),
+                )
+                ind_id = cur.fetchone()["id"]
             conn.execute("UPDATE individuals SET bio_batch = id %% 7 WHERE id = %s", (ind_id,))
             # New individuals start as living by default; recompute may downgrade to not living
             _recompute_is_living_for_individual(ind_id, conn)
@@ -152,7 +158,8 @@ def upsert_individual(data: dict[str, Any], conn=None) -> int:
                 conn.commit()
             return ind_id
         except _DB_UNIQUE_ERRORS:
-            # Race condition: another insert beat us — fall back to UPDATE path
+            # Race condition: another insert beat us — fall back to UPDATE path.
+            # The savepoint above ensures the outer transaction is still healthy here.
             cur = conn.execute("SELECT id FROM individuals WHERE wiki_url = %s", (wiki_url,))
             row = cur.fetchone()
             if row is None:


### PR DESCRIPTION
## Root cause

This fixes the actual cause of job ea1ee915 running for 6 days without writing any data.

When two concurrent processes attempt to insert the same `wiki_url` into `individuals`, a `UniqueViolation` is raised. In PostgreSQL, **any error puts the entire connection into an aborted state**. Every subsequent statement on that connection then fails with:

```
psycopg2.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block
```

The runner uses a single long-lived `conn` spanning hundreds of table rows (runner.py:2465 calls `upsert_individual(payload, conn=conn)`). Once aborted, all remaining DB writes silently failed, but the runner kept looping — no progress, no Sentry alert, no expiry until the 24-hour timeout fired.

## Fix

Wrap the `INSERT` in `upsert_individual` in a `_PGSavepointContext` so a `UniqueViolation` only rolls back the sub-unit, leaving the caller's outer transaction healthy:

```python
with _PGSavepointContext(conn, "_upsert_individual"):
    cur = conn.execute("INSERT INTO individuals ...")
    ind_id = cur.fetchone()["id"]
# savepoint released on success; rolled back on UniqueViolation
# outer transaction continues unharmed either way
```

Also adds the `_PGSavepointContext` context manager helper to `connection.py` (closes #266). It is a no-op on SQLite (`is_postgres() == False`), so tests are unaffected.

## Why only this callsite?

All other `upsert_individual` calls in `runner.py` do **not** pass a `conn` argument — they open their own connection, so a `UniqueViolation` there aborts only their own short-lived connection. Only the call at **runner.py:2465** shares the long-lived outer transaction.

All other `_DB_UNIQUE_ERRORS` catches across `refs.py`, `office_category.py`, `infobox_role_key_filter.py`, and `offices.py` are UI-only CRUD endpoints that always open their own connection — they are not in the scraper hot path.

## Test plan
- [x] `python -m pytest` — 766 passed, 11 skipped
- [x] black formatting clean

Closes #253 #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)