### PR TITLE
tests: add coverage for expire_stale_jobs, enqueue/pop/count queue functions (#262)

### DIFF
--- a/src/db/scraper_jobs.py
+++ b/src/db/scraper_jobs.py
@@ -164,8 +164,8 @@ def pop_next_queued_job(conn=None) -> dict | None:
             return None
         job_id = row[0]
         conn.execute(
-            "UPDATE scraper_jobs SET status = %s, updated_at = NOW() WHERE id = %s",
-            ("running", job_id),
+            "UPDATE scraper_jobs SET status = %s, updated_at = %s WHERE id = %s",
+            ("running", _now_iso(), job_id),
         )
         if own_conn:
             conn.commit()

--- a/src/db/test_scraper_jobs.py
+++ b/src/db/test_scraper_jobs.py
@@ -327,3 +327,379 @@ def test_delete_jobs_older_than_returns_count(db_path):
     deleted = db_jobs.delete_jobs_older_than(hours=1)
     assert isinstance(deleted, int)
     assert deleted >= 1
+
+
+# ---------------------------------------------------------------------------
+# enqueue_job
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_job_inserts_queued_status(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.enqueue_job("job-enqueue-1", "scrape", '{"run_mode": "delta"}')
+
+    record = db_jobs.get_job("job-enqueue-1")
+    assert record is not None
+    assert record["status"] == "queued"
+    assert record["type"] == "scrape"
+
+
+def test_enqueue_job_stores_params_json(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.enqueue_job("job-enqueue-params", "scrape", '{"run_mode": "full"}')
+
+    c = get_connection()
+    row = c.execute(
+        "SELECT job_params_json FROM scraper_jobs WHERE id = %s", ("job-enqueue-params",)
+    ).fetchone()
+    c.close()
+
+    assert row is not None
+    import json
+
+    params = json.loads(row[0])
+    assert params["run_mode"] == "full"
+
+
+def test_enqueue_job_sets_queued_at(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.enqueue_job("job-enqueue-ts", "scrape", "{}")
+
+    c = get_connection()
+    row = c.execute(
+        "SELECT queued_at FROM scraper_jobs WHERE id = %s", ("job-enqueue-ts",)
+    ).fetchone()
+    c.close()
+
+    assert row is not None
+    assert row[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# pop_next_queued_job
+# ---------------------------------------------------------------------------
+
+
+def test_pop_next_queued_job_claims_oldest_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    # Seed two queued jobs with distinct queued_at times
+    db_jobs.enqueue_job("job-pop-first", "scrape", '{"run_mode": "delta"}')
+    db_jobs.enqueue_job("job-pop-second", "scrape", '{"run_mode": "full"}')
+
+    # Set first job as older
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET queued_at = %s WHERE id = %s",
+        ("2000-01-01T00:00:00Z", "job-pop-first"),
+    )
+    c.commit()
+    c.close()
+
+    result = db_jobs.pop_next_queued_job()
+    assert result is not None
+    assert result["id"] == "job-pop-first"
+
+
+def test_pop_next_queued_job_sets_status_running(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    # Clear any leftover queued jobs so ours is the only candidate
+    c = get_connection()
+    c.execute("UPDATE scraper_jobs SET status = %s WHERE status = %s", ("error", "queued"))
+    c.commit()
+    c.close()
+
+    db_jobs.enqueue_job("job-pop-running", "scrape", "{}")
+    db_jobs.pop_next_queued_job()
+
+    record = db_jobs.get_job("job-pop-running")
+    assert record is not None
+    assert record["status"] == "running"
+
+
+def test_pop_next_queued_job_returns_params_json(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    # Clear any leftover queued jobs so ours is the only candidate
+    c = get_connection()
+    c.execute("UPDATE scraper_jobs SET status = %s WHERE status = %s", ("error", "queued"))
+    c.commit()
+    c.close()
+
+    db_jobs.enqueue_job("job-pop-params", "scrape", '{"run_mode": "bios_only"}')
+    result = db_jobs.pop_next_queued_job()
+    assert result is not None
+    assert result["job_params_json"] == '{"run_mode": "bios_only"}'
+
+
+def test_pop_next_queued_job_returns_none_when_empty(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    # Expire all queued jobs first
+    c = get_connection()
+    c.execute("UPDATE scraper_jobs SET status = %s WHERE status = %s", ("error", "queued"))
+    c.commit()
+    c.close()
+
+    result = db_jobs.pop_next_queued_job()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# count_active_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_count_active_jobs_counts_running_and_queued(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    # Reset: mark all existing active jobs as complete
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET status = %s WHERE status IN (%s, %s)",
+        ("complete", "running", "queued"),
+    )
+    c.commit()
+    c.close()
+
+    db_jobs.create_job("job-active-running", "scrape")  # status=running
+    db_jobs.enqueue_job("job-active-queued", "scrape", "{}")  # status=queued
+
+    count = db_jobs.count_active_jobs()
+    assert count >= 2
+
+
+def test_count_active_jobs_excludes_complete(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET status = %s WHERE status IN (%s, %s)",
+        ("complete", "running", "queued"),
+    )
+    c.commit()
+    c.close()
+
+    db_jobs.create_job("job-active-complete", "scrape")
+    db_jobs.update_job("job-active-complete", "complete")
+
+    count = db_jobs.count_active_jobs()
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# count_queued_jobs
+# ---------------------------------------------------------------------------
+
+
+def test_count_queued_jobs_counts_only_queued(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    # Clear active jobs
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET status = %s WHERE status IN (%s, %s)",
+        ("complete", "running", "queued"),
+    )
+    c.commit()
+    c.close()
+
+    db_jobs.enqueue_job("job-queue-count-1", "scrape", "{}")
+    db_jobs.enqueue_job("job-queue-count-2", "scrape", "{}")
+
+    count = db_jobs.count_queued_jobs()
+    assert count >= 2
+
+
+def test_count_queued_jobs_excludes_running(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET status = %s WHERE status IN (%s, %s)",
+        ("complete", "running", "queued"),
+    )
+    c.commit()
+    c.close()
+
+    db_jobs.create_job("job-queue-running-only", "scrape")  # running, not queued
+
+    count = db_jobs.count_queued_jobs()
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# expire_stale_jobs
+# ---------------------------------------------------------------------------
+
+
+def _age_job(db_path, job_id: str, hours_ago: float) -> None:
+    """Helper: backdates a job's created_at to simulate age."""
+    import os
+    from datetime import timedelta
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    from datetime import datetime, timezone
+
+    past = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    past_iso = past.strftime("%Y-%m-%dT%H:%M:%SZ")
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET created_at = %s, queued_at = %s WHERE id = %s",
+        (past_iso, past_iso, job_id),
+    )
+    c.commit()
+    c.close()
+
+
+def test_expire_stale_jobs_expires_old_running_full_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.create_job("job-expire-full", "full")
+    _age_job(db_path, "job-expire-full", hours_ago=25)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    ids = [e["id"] for e in expired]
+    assert "job-expire-full" in ids
+    assert db_jobs.get_job("job-expire-full")["status"] == "error"
+
+
+def test_expire_stale_jobs_does_not_expire_recent_full_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.create_job("job-expire-full-recent", "full")
+    _age_job(db_path, "job-expire-full-recent", hours_ago=1)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    ids = [e["id"] for e in expired]
+    assert "job-expire-full-recent" not in ids
+    assert db_jobs.get_job("job-expire-full-recent")["status"] == "running"
+
+
+def test_expire_stale_jobs_expires_old_running_nonfull_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.create_job("job-expire-delta", "delta")
+    _age_job(db_path, "job-expire-delta", hours_ago=9)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    ids = [e["id"] for e in expired]
+    assert "job-expire-delta" in ids
+    assert db_jobs.get_job("job-expire-delta")["status"] == "error"
+
+
+def test_expire_stale_jobs_does_not_expire_recent_nonfull_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.create_job("job-expire-delta-recent", "delta")
+    _age_job(db_path, "job-expire-delta-recent", hours_ago=1)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    ids = [e["id"] for e in expired]
+    assert "job-expire-delta-recent" not in ids
+    assert db_jobs.get_job("job-expire-delta-recent")["status"] == "running"
+
+
+def test_expire_stale_jobs_expires_old_queued_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.enqueue_job("job-expire-queued", "scrape", "{}")
+    _age_job(db_path, "job-expire-queued", hours_ago=13)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    ids = [e["id"] for e in expired]
+    assert "job-expire-queued" in ids
+    assert db_jobs.get_job("job-expire-queued")["status"] == "error"
+
+
+def test_expire_stale_jobs_does_not_expire_recent_queued_job(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.enqueue_job("job-expire-queued-recent", "scrape", "{}")
+    _age_job(db_path, "job-expire-queued-recent", hours_ago=1)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    ids = [e["id"] for e in expired]
+    assert "job-expire-queued-recent" not in ids
+    assert db_jobs.get_job("job-expire-queued-recent")["status"] == "queued"
+
+
+def test_expire_stale_jobs_returns_expired_list(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.create_job("job-expire-list", "delta")
+    _age_job(db_path, "job-expire-list", hours_ago=9)
+
+    expired = db_jobs.expire_stale_jobs()
+
+    assert isinstance(expired, list)
+    match = next((e for e in expired if e["id"] == "job-expire-list"), None)
+    assert match is not None
+    assert match["type"] == "delta"
+    assert "reason" in match
+
+
+def test_expire_stale_jobs_calls_cancel_callback(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    db_jobs.create_job("job-expire-cb", "delta")
+    _age_job(db_path, "job-expire-cb", hours_ago=9)
+
+    called_with: list[str] = []
+    db_jobs.expire_stale_jobs(cancel_callback=called_with.append)
+
+    assert "job-expire-cb" in called_with
+
+
+def test_expire_stale_jobs_returns_empty_when_nothing_stale(db_path):
+    import os
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+
+    # Mark all active jobs as complete so none are stale
+    c = get_connection()
+    c.execute(
+        "UPDATE scraper_jobs SET status = %s WHERE status IN (%s, %s)",
+        ("complete", "running", "queued"),
+    )
+    c.commit()
+    c.close()
+
+    expired = db_jobs.expire_stale_jobs()
+    assert expired == []


### PR DESCRIPTION
## Summary

- Fixes `pop_next_queued_job` to use `_now_iso()` instead of raw `NOW()` (PostgreSQL-only SQL that broke SQLite tests)
- Adds 20 new tests covering the previously-untested functions:
  - `enqueue_job` — queued status, params JSON stored, queued_at set
  - `pop_next_queued_job` — claims oldest job, sets status=running, returns params, returns None when empty
  - `count_active_jobs` — counts running + queued, excludes complete
  - `count_queued_jobs` — counts only queued, excludes running
  - `expire_stale_jobs` — full job >24h, nonfull >8h, queued >12h, recent jobs NOT expired, returns list with reason, calls cancel_callback, empty when nothing stale

## Test plan
- [x] `python -m pytest src/db/test_scraper_jobs.py -v` — 37 passed
- [x] Full suite: 832 passed (only pre-existing `anthropic` module failure)
- [x] `black --check` clean

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)