### PR TITLE
docs: add two-table design comment to scraper_jobs.py (#265)

### DIFF
--- a/src/db/scraper_jobs.py
+++ b/src/db/scraper_jobs.py
@@ -6,6 +6,22 @@ Each job represents one run_scraper or preview run.  The table is the durable
 backing store; the routers keep an in-memory dict for live progress updates.
 
 Status lifecycle: running → complete | cancelled | error
+
+--- Two-table design ---
+
+scraper_jobs (this module)
+    Records every *user-triggered* job: full runs, delta runs, single-bio, preview, etc.
+    Supports queuing (status='queued'), live cancellation, and stale-job expiry.
+    Consumed by /data/scraper-jobs in the UI and by the in-memory run_scraper router.
+
+scheduled_job_runs (src/db/scheduled_job_runs.py)
+    Records every *APScheduler* job execution: daily_delta, insufficient_vitals, etc.
+    Rows are written by the scheduled task functions, never by the user-facing router.
+    Consumed by /data/scheduled-job-runs and /data/scheduled-jobs in the UI.
+
+The separation is intentional: user-triggered and scheduler-triggered runs have
+different lifecycles, queue semantics, and UI surfaces.  Merging them would require
+complex filtering on every query and obscure the queue-depth checks that gate new runs.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Closes out issue #265 (5 code quality items in runner/scheduler code).

Items 1–4 were already addressed in earlier PRs:
- Silent enqueue exception → log + 500 (#267)
- `_MAX_QUEUED_JOBS = 1` constant (#267)
- Malformed `job_params_json` → error status, no thread (#267)
- `expire_stale_jobs` commit hygiene — `if own_conn:` unconditional (#267)

This PR adds item 5: a doc comment at the top of `scraper_jobs.py` explaining the intentional two-table design (`scraper_jobs` vs `scheduled_job_runs`) — why they're separate, what each owns, and why merging them would be harmful.

## Test plan
- [x] `black --check` clean
- [x] `pytest src/db/test_scraper_jobs.py` — 37 passed

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)