### PR TITLE
fix: align Claude and Gemini system prompts for page quality checks (#274)

### DIFF
--- a/src/db/ai_decisions.py
+++ b/src/db/ai_decisions.py
@@ -83,7 +83,8 @@ SELECT
     CAST(record_id AS TEXT) AS subject,
     check_type      AS action_taken,
     github_issue_url AS gh_issue_url,
-    created_at
+    created_at,
+    NULL            AS ai_votes
 FROM data_quality_reports
 
 UNION ALL
@@ -93,18 +94,21 @@ SELECT
     COALESCE(wiki_url, office_name, 'unknown') AS subject,
     error_type      AS action_taken,
     github_issue_url AS gh_issue_url,
-    created_at
+    created_at,
+    NULL            AS ai_votes
 FROM parse_error_reports
 
 UNION ALL
 
 SELECT
     'page_quality'  AS decision_type,
-    CAST(source_page_id AS TEXT) AS subject,
-    result          AS action_taken,
-    gh_issue_url,
-    created_at
-FROM page_quality_checks
+    COALESCE(sp.url, CAST(pqc.source_page_id AS TEXT)) AS subject,
+    pqc.result      AS action_taken,
+    pqc.gh_issue_url,
+    pqc.created_at,
+    pqc.ai_votes
+FROM page_quality_checks pqc
+LEFT JOIN source_pages sp ON sp.id = pqc.source_page_id
 
 UNION ALL
 
@@ -113,7 +117,8 @@ SELECT
     COALESCE(full_name, wiki_url, 'unknown') AS subject,
     result          AS action_taken,
     gh_issue_url,
-    created_at
+    created_at,
+    NULL            AS ai_votes
 FROM suspect_record_flags
 """
 
@@ -135,7 +140,7 @@ def _build_where(decision_type: str | None, result: str | None) -> tuple[str, li
 def _fetch_union(conn, decision_type, result, offset, limit) -> list[dict]:
     where, params = _build_where(decision_type, result)
     sql = f"""
-        SELECT decision_type, subject, action_taken, gh_issue_url, created_at
+        SELECT decision_type, subject, action_taken, gh_issue_url, created_at, ai_votes
         FROM ({_UNION_SQL}) AS combined
         {where}
         ORDER BY created_at DESC
@@ -143,8 +148,13 @@ def _fetch_union(conn, decision_type, result, offset, limit) -> list[dict]:
     """
     params += [limit, offset]
     cur = conn.execute(sql, params)
-    keys = ["decision_type", "subject", "action_taken", "gh_issue_url", "created_at"]
-    return [dict(zip(keys, row)) for row in cur.fetchall()]
+    keys = ["decision_type", "subject", "action_taken", "gh_issue_url", "created_at", "ai_votes"]
+    rows = []
+    for row in cur.fetchall():
+        d = dict(zip(keys, row))
+        d["ai_votes"] = _safe_json(d["ai_votes"])
+        rows.append(d)
+    return rows
 
 
 def _fetch_count(conn, decision_type, result) -> int:

--- a/src/services/claude_client.py
+++ b/src/services/claude_client.py
@@ -119,11 +119,19 @@ class ClaudeClient:
         self._client = anthropic.Anthropic(api_key=api_key)
         self._model = "claude-sonnet-4-20250514"
 
-    def check_data_quality(self, prompt: str, context: dict) -> DataQualityResult:
-        """Assess data quality for a record. Returns structured result."""
+    def check_data_quality(
+        self, prompt: str, context: dict, system_prompt: str | None = None
+    ) -> DataQualityResult:
+        """Assess data quality for a record or page. Returns structured result.
+
+        Args:
+            system_prompt: Override the default individual-record system prompt.
+                Pass consensus_voter._SYSTEM_PROMPT when used for page-level checks
+                so Claude uses the same framing as OpenAI and Gemini.
+        """
         try:
             user_prompt = self._build_prompt(prompt, context)
-            return self._call_claude(user_prompt)
+            return self._call_claude(user_prompt, system_prompt=system_prompt or _SYSTEM_PROMPT)
         except Exception:
             logger.exception("Claude data quality check failed")
             return DataQualityResult(is_valid=True, concerns=[], confidence="low")
@@ -136,7 +144,9 @@ class ClaudeClient:
                 lines.append(f"  {key}: {value}")
         return "\n".join(lines)
 
-    def _call_claude(self, user_prompt: str) -> DataQualityResult:
+    def _call_claude(
+        self, user_prompt: str, system_prompt: str = _SYSTEM_PROMPT
+    ) -> DataQualityResult:
         """Call Claude with exponential backoff on rate limit (HTTP 429).
 
         Retries up to 3 times, doubling the backoff delay each attempt (1 s → 2 s → 4 s).
@@ -149,7 +159,7 @@ class ClaudeClient:
                 response = self._client.messages.create(
                     model=self._model,
                     max_tokens=1024,
-                    system=_SYSTEM_PROMPT,
+                    system=system_prompt,
                     messages=[{"role": "user", "content": user_prompt}],
                 )
                 return self._parse_response(response)

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -148,7 +148,7 @@ def _vote_gemini(prompt: str, context: dict) -> AIVote:
         if researcher is None:
             return AIVote(provider="gemini", is_valid=None, error="client not configured")
 
-        result = researcher.check_data_quality(prompt)
+        result = researcher.check_data_quality(prompt, system_prompt=_SYSTEM_PROMPT)
         if result is None:
             return AIVote(provider="gemini", is_valid=None, error="empty response")
 
@@ -172,7 +172,7 @@ def _vote_claude(prompt: str, context: dict) -> AIVote:
         if client is None:
             return AIVote(provider="claude", is_valid=None, error="client not configured")
 
-        result = client.check_data_quality(prompt, context)
+        result = client.check_data_quality(prompt, context, system_prompt=_SYSTEM_PROMPT)
         return AIVote(
             provider="claude",
             is_valid=result.is_valid,

--- a/src/services/gemini_vitals_researcher.py
+++ b/src/services/gemini_vitals_researcher.py
@@ -290,9 +290,20 @@ class GeminiVitalsResearcher:
                     raise
         raise RuntimeError("unreachable")
 
-    def check_data_quality(self, prompt: str) -> dict | None:
-        """Run a data quality check via Gemini. Returns parsed JSON dict or None."""
+    def check_data_quality(self, prompt: str, system_prompt: str | None = None) -> dict | None:
+        """Run a data quality check via Gemini. Returns parsed JSON dict or None.
+
+        Args:
+            system_prompt: Override the default system instruction. Pass
+                consensus_voter._SYSTEM_PROMPT when used for page-level checks
+                so Gemini uses the same framing as OpenAI and Claude.
+        """
         from google.genai import types, errors
+
+        _default_instruction = (
+            "You are a data quality analyst. Assess the record and return JSON: "
+            '{"is_valid": bool, "concerns": [str], "confidence": "high"|"medium"|"low"}'
+        )
 
         backoff = 1.0
         for attempt in range(3):
@@ -306,10 +317,7 @@ class GeminiVitalsResearcher:
                         ),
                     ],
                     config=types.GenerateContentConfig(
-                        system_instruction=(
-                            "You are a data quality analyst. Assess the record and return JSON: "
-                            '{"is_valid": bool, "concerns": [str], "confidence": "high"|"medium"|"low"}'
-                        ),
+                        system_instruction=system_prompt or _default_instruction,
                         max_output_tokens=512,
                         response_mime_type="application/json",
                     ),

--- a/src/templates/ai_decisions.html
+++ b/src/templates/ai_decisions.html
@@ -44,15 +44,47 @@
     {% for row in rows %}
     <tr>
       <td><code>{{ row.decision_type }}</code></td>
-      <td>{{ row.subject or '—' }}</td>
+      <td>
+        {% if row.decision_type == 'page_quality' and row.subject and row.subject.startswith('http') %}
+          <a href="{{ row.subject }}" target="_blank" rel="noopener" style="word-break:break-all">{{ row.subject }}</a>
+        {% else %}
+          {{ row.subject or '—' }}
+        {% endif %}
+      </td>
       <td>
         {% set r = row.action_taken or '' %}
         {% if r in ('ok', 'reparse_ok', 'allowed') %}
           <span class="badge badge-ok">{{ r }}</span>
-        {% elif r in ('gh_issue', 'skipped', 'manual_review') %}
+        {% elif r in ('gh_issue', 'skipped', 'manual_review', 'no_data', 'skipped_no_data') %}
           <span class="badge badge-warn">{{ r }}</span>
+        {% elif r in ('fetch_failed', 'error') %}
+          <span class="badge badge-error">{{ r }}</span>
         {% else %}
           {{ r or '—' }}
+        {% endif %}
+        {% if row.ai_votes %}
+        <details style="margin-top:4px;font-size:0.85em">
+          <summary style="cursor:pointer;color:#666">votes ({{ row.ai_votes | length }})</summary>
+          <table style="margin-top:4px;border-collapse:collapse">
+            {% for v in row.ai_votes %}
+            <tr>
+              <td style="padding:2px 6px;font-weight:bold">{{ v.provider }}</td>
+              <td style="padding:2px 6px">
+                {% if v.is_valid is none or v.is_valid == none %}
+                  <span style="color:#888">unavailable{% if v.error %}: {{ v.error }}{% endif %}</span>
+                {% elif v.is_valid %}
+                  <span style="color:green">accurate</span>
+                {% else %}
+                  <span style="color:#c00">inaccurate</span>
+                {% endif %}
+              </td>
+              <td style="padding:2px 6px;color:#555">
+                {% if v.concerns %}{{ v.concerns | join('; ') }}{% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </table>
+        </details>
         {% endif %}
       </td>
       <td>{% if row.gh_issue_url %}<a href="{{ row.gh_issue_url }}" target="_blank" rel="noopener">issue</a>{% else %}—{% endif %}</td>

--- a/tests/test_ai_decisions.py
+++ b/tests/test_ai_decisions.py
@@ -57,6 +57,13 @@ CREATE TABLE IF NOT EXISTS parse_error_reports (
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS source_pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL UNIQUE,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    last_quality_checked_at TEXT
+);
+
 CREATE TABLE IF NOT EXISTS page_quality_checks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     source_page_id INTEGER NOT NULL DEFAULT 1,
@@ -179,6 +186,7 @@ class TestListAiDecisions:
             "action_taken",
             "gh_issue_url",
             "created_at",
+            "ai_votes",
         }
 
     def test_unknown_type_filter_returns_empty(self, tmp_path):

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -465,3 +465,58 @@ class TestVoteOrdering:
             result = voter.vote("prompt", {})
         names = [v.provider for v in result.votes]
         assert names == sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# System prompt alignment — Claude and Gemini must receive _SYSTEM_PROMPT
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptAlignment:
+    """_vote_claude and _vote_gemini must pass the shared _SYSTEM_PROMPT so all
+    three providers evaluate the page quality question under the same framing.
+    Regression guard for Issue #274."""
+
+    def test_vote_claude_passes_shared_system_prompt(self):
+        from src.services.claude_client import DataQualityResult
+        from src.services.consensus_voter import _SYSTEM_PROMPT, _vote_claude
+
+        mock_client = MagicMock()
+        mock_client.check_data_quality.return_value = DataQualityResult(
+            is_valid=True, concerns=[], confidence="high"
+        )
+        with patch("src.services.claude_client.get_claude_client", return_value=mock_client):
+            _vote_claude("some prompt", {})
+
+        call_kwargs = mock_client.check_data_quality.call_args
+        assert call_kwargs is not None
+        passed_system = call_kwargs.kwargs.get("system_prompt") or (
+            call_kwargs.args[2] if len(call_kwargs.args) > 2 else None
+        )
+        assert (
+            passed_system == _SYSTEM_PROMPT
+        ), "Claude must use the shared consensus _SYSTEM_PROMPT, not the individual-record prompt"
+
+    def test_vote_gemini_passes_shared_system_prompt(self):
+        from src.services.consensus_voter import _SYSTEM_PROMPT, _vote_gemini
+
+        mock_researcher = MagicMock()
+        mock_researcher.check_data_quality.return_value = {
+            "is_valid": True,
+            "concerns": [],
+            "confidence": "high",
+        }
+        with patch(
+            "src.services.gemini_vitals_researcher.get_gemini_researcher",
+            return_value=mock_researcher,
+        ):
+            _vote_gemini("some prompt", {})
+
+        call_kwargs = mock_researcher.check_data_quality.call_args
+        assert call_kwargs is not None
+        passed_system = call_kwargs.kwargs.get("system_prompt") or (
+            call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
+        )
+        assert (
+            passed_system == _SYSTEM_PROMPT
+        ), "Gemini must use the shared consensus _SYSTEM_PROMPT, not its vitals-research prompt"


### PR DESCRIPTION
Closes #274

## Summary
- `_vote_claude` and `_vote_gemini` in `consensus_voter.py` now pass the shared `_SYSTEM_PROMPT` to `check_data_quality()`, replacing the wrong individual-record prompt (Claude) and the short inline instruction (Gemini)
- Both `ClaudeClient.check_data_quality` and `GeminiVitalsResearcher.check_data_quality` accept an optional `system_prompt` parameter; existing callers outside ConsensusVoter are unaffected (default falls back to their original prompts)
- AI decisions page: `page_quality` rows now show the full Wikipedia page URL via LEFT JOIN to `source_pages`
- AI decisions page: per-provider vote breakdown (`accurate`/`inaccurate` + concerns) exposed in a collapsible `<details>` element per row

## Test plan
- [ ] All 28 `test_consensus_voter.py` tests pass, including two new regression guards asserting `system_prompt=_SYSTEM_PROMPT` is passed to both providers
- [ ] `python -m pytest` — 960+ passing
- [ ] Visit `/data/ai-decisions`, filter to `page_quality` — rows show page URL, votes expandable

🤖 Generated with [Claude Code](https://claude.com/claude-code)