### PR TITLE
feat: improve scheduled_job_runs UI (#261)

### DIFF
--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -116,3 +116,32 @@ form { max-width: 640px; }
   margin-left: 0.75rem;
   color: var(--text-muted);
 }
+
+/* Badges — used across multiple pages */
+.badge { display:inline-flex;align-items:center;padding:0.15em 0.5em;border-radius:3px;font-size:0.8rem;font-weight:600; }
+.badge-ok    { background:rgba(47,158,68,0.2);  color:#6fcf97; }
+.badge-warn  { background:rgba(240,140,0,0.2);  color:#ffd8a8; }
+.badge-error { background:rgba(224,49,49,0.2);  color:#ff8787; }
+.badge-grey  { background:rgba(100,100,120,0.3);color:#9a9ba8; }
+.badge-blue  { background:rgba(92,124,250,0.2); color:#748ffc; }
+.badge-green { background:rgba(47,158,68,0.2);  color:#6fcf97; }
+.badge-red   { background:rgba(224,49,49,0.2);  color:#ff8787; }
+.badge-amber { background:rgba(240,140,0,0.2);  color:#ffd8a8; }
+
+/* Scheduled job run status colors */
+.status-complete { color:#6fcf97; font-weight:600; }
+.status-error    { color:#ff8787; font-weight:600; }
+.status-running  { color:#ffd8a8; font-weight:600; }
+
+/* Error snippet in tables */
+.error-snippet { margin:0; padding:0.25rem 0.5rem; background:var(--bg3); border:1px solid var(--border); border-radius:3px; font-size:0.75rem; white-space:pre-wrap; word-break:break-all; max-height:6rem; overflow-y:auto; color:#ff8787; }
+
+/* Error banner for failed runs */
+.error-banner {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--danger);
+  background: rgba(224, 49, 49, 0.15);
+  color: #ff8787;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}

--- a/src/templates/scheduled_job_runs.html
+++ b/src/templates/scheduled_job_runs.html
@@ -8,7 +8,7 @@
   <a href="?days=365">365d</a>
 </p>
 {% if runs and runs[0].status == 'error' %}
-<div class="sync-banner" role="alert">
+<div class="error-banner" role="alert">
   <strong>Most recent run failed:</strong> {{ runs[0].job_name }} — check the error column below.
 </div>
 {% endif %}
@@ -22,9 +22,7 @@
       <th>Finished</th>
       <th>Duration</th>
       <th>Status</th>
-      <th>Terms</th>
-      <th>Bio OK</th>
-      <th>Bio Err</th>
+      <th>Summary</th>
       <th>Error</th>
     </tr>
   </thead>
@@ -33,13 +31,40 @@
     <tr>
       <td>{{ r.id }}</td>
       <td>{{ r.job_name }}</td>
-      <td>{{ r.started_at or '—' }}</td>
-      <td>{{ r.finished_at or '—' }}</td>
+      <td>{{ (r.started_at or '')[:19] }}</td>
+      <td>{{ (r.finished_at or '')[:19] or '—' }}</td>
       <td>{% if r.duration_s is not none %}{{ "%.0f"|format(r.duration_s) }}s{% else %}—{% endif %}</td>
       <td class="status-{{ r.status }}">{{ r.status }}</td>
-      <td>{{ r.result.terms_parsed if r.result and r.result.terms_parsed is defined else '—' }}</td>
-      <td>{{ r.result.bio_ok if r.result and r.result.bio_ok is defined else '—' }}</td>
-      <td>{{ r.result.bio_errors if r.result and r.result.bio_errors is defined else '—' }}</td>
+      <td>
+        {% if r.result %}
+          {% if r.result.terms_parsed is defined %}
+            {{ r.result.terms_parsed }} terms,
+            {{ r.result.bio_success_count if r.result.bio_success_count is defined else 0 }} bio ok,
+            {{ r.result.bio_error_count if r.result.bio_error_count is defined else 0 }} bio err
+            {% if r.result.cache_deleted is defined and r.result.cache_deleted %}
+              <span style="color:var(--text-muted);font-size:0.85em">({{ r.result.cache_deleted }} cache del)</span>
+            {% endif %}
+          {% elif r.result.result is defined %}
+            {% set pq = r.result.result %}
+            {% if pq in ('ok', 'reparse_ok', 'allowed') %}
+              <span class="badge badge-ok">{{ pq }}</span>
+            {% elif pq in ('gh_issue', 'skipped', 'manual_review', 'no_data', 'skipped_no_data', 'no_pages') %}
+              <span class="badge badge-warn">{{ pq }}</span>
+            {% elif pq in ('fetch_failed', 'error') %}
+              <span class="badge badge-error">{{ pq }}</span>
+            {% else %}
+              <span class="badge badge-grey">{{ pq }}</span>
+            {% endif %}
+            {% if r.result.attempts is defined %}
+              <span style="color:var(--text-muted);font-size:0.85em">× {{ r.result.attempts }}</span>
+            {% endif %}
+          {% else %}
+            —
+          {% endif %}
+        {% else %}
+          —
+        {% endif %}
+      </td>
       <td>{% if r.error %}<pre class="error-snippet">{{ r.error[:300] }}</pre>{% else %}—{% endif %}</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Color-coded status cells: green=complete, red=error, orange=running
- Adaptive Summary column: scraper jobs show terms + bio counts; page_quality shows result badge + attempt count
- Fixed broken `bio_ok`/`bio_errors` template keys (correct keys: `bio_success_count`, `bio_error_count` — these columns always showed `—` before)
- Changed most-recent-error callout from orange `sync-banner` to red `error-banner`
- Added badge and status color CSS to `theme.css` (also fixes missing badge styles on the AI Decisions page)

## Test plan
- [ ] All CI checks green
- [ ] `/data/scheduled-job-runs` shows colored status cells
- [ ] Summary column shows `N terms, X bio ok, Y bio err` for delta/vitals/gemini runs
- [ ] Summary column shows result badge + attempt count for page_quality runs
- [ ] Most-recent-error banner shows in red when latest run has `status=error`

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)