### PR TITLE
feat: move parties under /refs namespace (#250)

### DIFF
--- a/src/routers/parties.py
+++ b/src/routers/parties.py
@@ -1,4 +1,4 @@
-"""Party management routes."""
+"""Party management routes (under /refs/parties)."""
 
 import tempfile
 from pathlib import Path
@@ -14,7 +14,7 @@ from src.routers._deps import templates
 router = APIRouter()
 
 
-@router.get("/parties", response_class=HTMLResponse)
+@router.get("/refs/parties", response_class=HTMLResponse)
 async def parties_list(request: Request):
     parties = db_parties.list_parties()
     saved = request.query_params.get("saved") == "1"
@@ -34,12 +34,12 @@ async def parties_list(request: Request):
     )
 
 
-@router.get("/parties/import", response_class=HTMLResponse)
+@router.get("/refs/parties/import", response_class=HTMLResponse)
 async def parties_import_page(request: Request):
     return templates.TemplateResponse(request, "import_parties.html")
 
 
-@router.post("/parties/import")
+@router.post("/refs/parties/import")
 async def parties_import(
     request: Request,
     mode: str = Form("append"),
@@ -87,7 +87,7 @@ async def parties_import(
             overwrite = mode == "overwrite"
             imported, errors = bulk_import_parties_from_csv(tmp_path, overwrite=overwrite)
             return RedirectResponse(
-                f"/parties?imported=1&count={imported}&errors={errors}", status_code=302
+                f"/refs/parties?imported=1&count={imported}&errors={errors}", status_code=302
             )
         finally:
             tmp_path.unlink(missing_ok=True)
@@ -99,7 +99,7 @@ async def parties_import(
         )
 
 
-@router.get("/parties/new", response_class=HTMLResponse)
+@router.get("/refs/parties/new", response_class=HTMLResponse)
 async def party_new(request: Request):
     countries = db_refs.list_countries()
     return templates.TemplateResponse(
@@ -107,7 +107,7 @@ async def party_new(request: Request):
     )
 
 
-@router.post("/parties/new")
+@router.post("/refs/parties/new")
 async def party_create(
     country_id: int = Form(0),
     party_name: str = Form(""),
@@ -116,10 +116,10 @@ async def party_create(
     db_parties.create_party(
         {"country_id": country_id, "party_name": party_name, "party_link": party_link}
     )
-    return RedirectResponse("/parties?saved=1", status_code=302)
+    return RedirectResponse("/refs/parties?saved=1", status_code=302)
 
 
-@router.get("/parties/{party_id}", response_class=HTMLResponse)
+@router.get("/refs/parties/{party_id}", response_class=HTMLResponse)
 async def party_edit_page(request: Request, party_id: int):
     party = db_parties.get_party(party_id)
     if not party:
@@ -130,7 +130,7 @@ async def party_edit_page(request: Request, party_id: int):
     )
 
 
-@router.post("/parties/{party_id}")
+@router.post("/refs/parties/{party_id}")
 async def party_update(
     party_id: int,
     country_id: int = Form(0),
@@ -140,10 +140,10 @@ async def party_update(
     db_parties.update_party(
         party_id, {"country_id": country_id, "party_name": party_name, "party_link": party_link}
     )
-    return RedirectResponse("/parties?saved=1", status_code=302)
+    return RedirectResponse("/refs/parties?saved=1", status_code=302)
 
 
-@router.post("/parties/{party_id}/delete")
+@router.post("/refs/parties/{party_id}/delete")
 async def party_delete(party_id: int):
     db_parties.delete_party(party_id)
-    return RedirectResponse("/parties", status_code=302)
+    return RedirectResponse("/refs/parties", status_code=302)

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -35,7 +35,7 @@
     <ul>
       <li><a href="/offices">Offices</a></li>
       <li><a href="/ai-offices">AI Offices</a></li>
-      <li><a href="/parties">Parties</a></li>
+      <li><a href="/refs/parties">Parties</a></li>
       <li><a href="/refs">Reference data</a></li>
       <li><a href="/data/individuals">Individuals</a></li>
       <li><a href="/data/office-terms">Office terms</a></li>

--- a/src/templates/import_parties.html
+++ b/src/templates/import_parties.html
@@ -5,7 +5,7 @@
 <p>Import parties from a CSV with columns: <strong>Country</strong>, <strong>Party name</strong> (or Party Name), <strong>Party link</strong> (or Party Link).</p>
 <p>Country must match a name in the reference data (e.g. United States).</p>
 {% if error %}<div class="alert alert-error">{{ error }}</div>{% endif %}
-<form method="post" action="/parties/import" enctype="multipart/form-data">
+<form method="post" action="/refs/parties/import" enctype="multipart/form-data">
   <div class="form-group">
     <label>CSV file</label>
     <input type="file" name="csv_file" accept=".csv" required>
@@ -20,6 +20,6 @@
     </div>
   </div>
   <button type="submit" class="btn">Import</button>
-  <a href="/parties" class="btn btn-secondary">Back to parties</a>
+  <a href="/refs/parties" class="btn btn-secondary">Back to parties</a>
 </form>
 {% endblock %}

--- a/src/templates/parties.html
+++ b/src/templates/parties.html
@@ -5,8 +5,8 @@
 {% if saved %}<div class="alert alert-success">Saved to local database (data/office_holder.db).</div>{% endif %}
 {% if imported %}<div class="alert alert-success">Imported {{ imported_count }} parties. {{ imported_errors }} errors.</div>{% endif %}
 <div class="actions">
-  <a href="/parties/new" class="btn">Add party</a>
-  <a href="/parties/import" class="btn btn-secondary">Bulk import</a>
+  <a href="/refs/parties/new" class="btn">Add party</a>
+  <a href="/refs/parties/import" class="btn btn-secondary">Bulk import</a>
 </div>
 {% if parties %}
 <table>
@@ -17,11 +17,11 @@
     {% for p in parties %}
     <tr>
       <td>{{ p.country_name or '—' }}</td>
-      <td><a href="/parties/{{ p.id }}">{{ p.party_name or '—' }}</a></td>
+      <td><a href="/refs/parties/{{ p.id }}">{{ p.party_name or '—' }}</a></td>
       <td>{% if p.party_link %}<a href="{{ p.party_link }}" target="_blank" rel="noopener">{{ (p.party_link[:40] + '…') if p.party_link|length > 40 else p.party_link }}</a>{% else %}—{% endif %}</td>
       <td>
-        <a href="/parties/{{ p.id }}" class="btn btn-sm btn-secondary">Edit</a>
-        <form action="/parties/{{ p.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete?');">
+        <a href="/refs/parties/{{ p.id }}" class="btn btn-sm btn-secondary">Edit</a>
+        <form action="/refs/parties/{{ p.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete?');">
           <button type="submit" class="btn btn-sm btn-danger">Delete</button>
         </form>
       </td>
@@ -30,6 +30,6 @@
   </tbody>
 </table>
 {% else %}
-<p>No parties yet. <a href="/parties/new">Add one</a>.</p>
+<p>No parties yet. <a href="/refs/parties/new">Add one</a>.</p>
 {% endif %}
 {% endblock %}

--- a/src/templates/party_form.html
+++ b/src/templates/party_form.html
@@ -2,7 +2,7 @@
 {% block title %}{{ "Edit" if party else "New" }} party – Office Holder{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if party else "New" }} party</h1>
-<form method="post" action="{% if party %}/parties/{{ party.id }}{% else %}/parties/new{% endif %}">
+<form method="post" action="{% if party %}/refs/parties/{{ party.id }}{% else %}/refs/parties/new{% endif %}">
   <div class="form-group">
     <label>Country</label>
     <select name="country_id" required>
@@ -16,9 +16,9 @@
   <div class="form-group"><label>Party link (Wikipedia URL)</label><input type="url" name="party_link" value="{{ party.party_link if party else '' }}" required></div>
   <div class="actions">
     <button type="submit" class="btn">Save</button>
-    <a href="/parties" class="btn btn-secondary">Cancel</a>
+    <a href="/refs/parties" class="btn btn-secondary">Cancel</a>
     {% if party %}
-    <form action="/parties/{{ party.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete?');">
+    <form action="/refs/parties/{{ party.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Delete?');">
       <button type="submit" class="btn btn-danger">Delete</button>
     </form>
     {% endif %}

--- a/src/templates/refs.html
+++ b/src/templates/refs.html
@@ -11,5 +11,6 @@
   <li><a href="/refs/cities">Cities</a></li>
   <li><a href="/refs/office-categories">Office categories</a></li>
   <li><a href="/refs/infobox-role-key-filters">Infobox role key filters</a></li>
+  <li><a href="/refs/parties">Parties</a></li>
 </ul>
 {% endblock %}

--- a/src/test_router_parties.py
+++ b/src/test_router_parties.py
@@ -60,18 +60,18 @@ def party_id(db_path):
 
 
 def test_parties_list_returns_200(client):
-    resp = client.get("/parties")
+    resp = client.get("/refs/parties")
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
 
 def test_parties_list_with_saved_flag(client):
-    resp = client.get("/parties?saved=1")
+    resp = client.get("/refs/parties?saved=1")
     assert resp.status_code == 200
 
 
 def test_parties_list_with_imported_flag(client):
-    resp = client.get("/parties?imported=1&count=3&errors=0")
+    resp = client.get("/refs/parties?imported=1&count=3&errors=0")
     assert resp.status_code == 200
 
 
@@ -81,7 +81,7 @@ def test_parties_list_with_imported_flag(client):
 
 
 def test_parties_import_page_returns_200(client):
-    resp = client.get("/parties/import")
+    resp = client.get("/refs/parties/import")
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
@@ -92,7 +92,7 @@ def test_parties_import_page_returns_200(client):
 
 
 def test_parties_import_no_file_returns_form_with_error(client):
-    resp = client.post("/parties/import", data={"mode": "append"})
+    resp = client.post("/refs/parties/import", data={"mode": "append"})
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
@@ -101,7 +101,7 @@ def test_parties_import_non_csv_returns_form_with_error(client):
     from io import BytesIO
 
     resp = client.post(
-        "/parties/import",
+        "/refs/parties/import",
         data={"mode": "append"},
         files={"csv_file": ("parties.txt", BytesIO(b"Country,Party name\n"), "text/plain")},
     )
@@ -114,7 +114,7 @@ def test_parties_import_non_csv_returns_form_with_error(client):
 
 
 def test_party_new_form_returns_200(client):
-    resp = client.get("/parties/new")
+    resp = client.get("/refs/parties/new")
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
@@ -126,7 +126,7 @@ def test_party_new_form_returns_200(client):
 
 def test_party_create_redirects_on_success(client):
     resp = client.post(
-        "/parties/new",
+        "/refs/parties/new",
         data={
             "country_id": "1",
             "party_name": "New Test Party",
@@ -142,13 +142,13 @@ def test_party_create_redirects_on_success(client):
 
 
 def test_party_edit_page_returns_200(client, party_id):
-    resp = client.get(f"/parties/{party_id}")
+    resp = client.get(f"/refs/parties/{party_id}")
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
 
 def test_party_edit_page_404_for_unknown(client):
-    resp = client.get("/parties/999999")
+    resp = client.get("/refs/parties/999999")
     assert resp.status_code == 404
 
 
@@ -159,7 +159,7 @@ def test_party_edit_page_404_for_unknown(client):
 
 def test_party_update_redirects_on_success(client, party_id):
     resp = client.post(
-        f"/parties/{party_id}",
+        f"/refs/parties/{party_id}",
         data={
             "country_id": "1",
             "party_name": "Updated Party",
@@ -179,7 +179,7 @@ def test_party_delete_redirects(client, db_path):
     pid = db_parties.create_party(
         {"country_id": 1, "party_name": "Delete Me", "party_link": "/wiki/Delete_Me"}
     )
-    resp = client.post(f"/parties/{pid}/delete")
+    resp = client.post(f"/refs/parties/{pid}/delete")
     assert resp.status_code in (302, 200)
 
 

--- a/src/test_security.py
+++ b/src/test_security.py
@@ -196,10 +196,10 @@ def test_sql_injection_in_offices_query_params(client):
 
 @pytest.mark.security
 def test_csv_upload_rejects_non_csv_extension(client):
-    """Uploading a non-CSV file to /parties/import must be rejected gracefully."""
+    """Uploading a non-CSV file to /refs/parties/import must be rejected gracefully."""
     fake_exe = io.BytesIO(b"MZ\x90\x00")  # PE header magic bytes
     resp = client.post(
-        "/parties/import",
+        "/refs/parties/import",
         files={"file": ("malware.exe", fake_exe, "application/octet-stream")},
     )
     # Must not be a 500; should be 200 (error page) or 400/422


### PR DESCRIPTION
## Summary
- All party routes moved from `/parties/*` → `/refs/parties/*` for consistency with other reference data (countries, states, levels, branches, cities, office-categories, infobox-role-key-filters)
- Parties added to the `/refs` index page
- Nav link in `base.html` updated
- All internal template links updated
- All test URLs updated in `test_router_parties.py` and `test_security.py`

## Test plan
- [ ] All CI checks green
- [ ] `/refs` index page shows Parties link
- [ ] `/refs/parties` lists parties (nav link works)
- [ ] Add/edit/delete party flows redirect correctly to `/refs/parties`
- [ ] Bulk import redirects to `/refs/parties`
- [ ] Old `/parties` URLs return 404

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)