### PR TITLE
docs: subprocess execution model, dual backend, render.yaml, UI pages (#292)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,37 @@ Wikipedia REST API      SQLite file
 
 **Auth:** Google OAuth via `authlib`. `require_login()` middleware gates all routes except `/login`, `/auth/google*`, `/static`. When `GOOGLE_CLIENT_ID` is not set, auth is fully bypassed (local dev).
 
-**Async jobs:** Runs, bulk imports, previews, and UI tests each use an in-memory job store (`_run_job_store`, `_populate_job_store`, etc.) + background thread. Single-process only — no task queue. Job stores are lost on server restart.
+**Async jobs — two execution models:**
+
+| Job type | Execution model | Why |
+|---|---|---|
+| Scheduled jobs (`daily_delta`, `delta_insufficient_vitals`, `gemini_vitals_research`, `daily_page_quality`) | **Child subprocess** via `subprocess.run([sys.executable, "-c", payload])` | Memory is fully reclaimed after the job ends — critical on Render starter plan |
+| Manual/UI-triggered jobs (`POST /api/run`) | **Background thread** in the FastAPI worker process | No persistent disk + faster startup; memory not reclaimed until server restart |
+
+**Subprocess job flow:** Parent serializes `run_with_db()` call params into a Python one-liner, captures stdout/stderr, parses the JSON result printed to stdout. Non-zero exit, empty stdout, or invalid JSON → `finish_run(status="error")`. The child initializes its own Sentry SDK with `sentry_sdk.set_tag("subprocess_job", ...)` and `sentry_sdk.set_context("subprocess", {...})`.
+
+**In-memory job stores** (`_run_job_store`, `_populate_job_store`, etc.) are lost on server restart. The `scraper_jobs` DB table provides a persistent fallback for UI-triggered jobs.
+
+**UI pages:**
+
+| URL | Description |
+|---|---|
+| `/run` | Trigger scraper runs; select run mode, office category, individual ref |
+| `/offices` | List and search offices (legacy flat table) |
+| `/offices/<id>` | Edit individual office config |
+| `/source-pages` | List source pages (Wikipedia URLs) in the hierarchy |
+| `/data/individuals` | Filterable table of all individuals with batch bio-refresh action |
+| `/data/scheduled-jobs` | View/pause/resume scheduled jobs; edit cron times and operational settings inline |
+| `/data/scheduled-job-runs` | APScheduler execution history with per-run result summaries |
+| `/data/scraper-jobs` | Manual + queued scraper job history |
+| `/data/runner-registry` | Static registry of run modes and expiry thresholds |
+| `/data/ai-decisions` | AI decision log across data quality, parse errors, page quality, suspect flags |
+| `/data/wiki-drafts` | Wikipedia draft proposals; list view |
+| `/data/wiki-drafts/<id>` | Draft proposal detail; submit button |
+| `/gemini-research` | Interactive Gemini+OpenAI vitals research test page |
+| `/ai-offices` | AI batch office creation via OpenAI |
+| `/refs` | Reference data index (countries, states, cities, levels, branches, parties, etc.) |
+| `/refs/parties` | Party CRUD |
 
 ---
 
@@ -81,10 +111,30 @@ office_holder_cursor/
 │   ├── test_run.db                # Test database (used by scenario runner)
 │   ├── logs/                      # Log files from scraper runs
 │   └── wiki_cache/                # Gzip cache of fetched Wikipedia HTML tables
-├── render.yaml                    # Deployment manifest (dev + prd services)
+├── render.yaml                    # Deployment manifest: PostgreSQL service (office-holder-pg, starter plan);
+│                                  #   web service with 1 GB persistent disk mounted at /data
+│                                  #   (logs + wiki_cache survive deploys); DATABASE_URL auto-wired;
+│                                  #   SECRET_KEY auto-generated; DATA_QUALITY_ENABLED=0 by default
 ├── requirements.txt               # Python dependencies
 └── runner_head.py                 # UTF-16 encoded backup of runner.py — NOT used at runtime
 ```
+
+---
+
+## SQLite / PostgreSQL Dual Backend
+
+The app supports two database backends selected by the `DATABASE_URL` env var:
+
+| Environment | Backend | Schema constant | Connection |
+|---|---|---|---|
+| Local dev / CI | SQLite | `SCHEMA_SQL` in `schema.py` | `sqlite3`, file at `data/office_holder.db` |
+| Production (Render) | PostgreSQL | `SCHEMA_PG_SQL` in `schema.py` | `psycopg2`, URL from `DATABASE_URL` |
+
+**Key abstractions:**
+- `_PGConnWrapper` — thin shim that gives psycopg2 connections a sqlite3-compatible `.execute("?")` API (converts `?` → `%s` placeholders and `.lastrowid` → `.fetchone()[0]`)
+- `is_postgres()` — used throughout the DB layer to gate PostgreSQL-specific behavior (e.g. `RETURNING id`, `ON CONFLICT DO UPDATE`)
+- `_run_pg_migrations()` — runs PostgreSQL-only `ALTER TABLE` migrations at startup (idempotent, tracked in `schema_migrations` table). **Rule: when adding a column, update both `SCHEMA_SQL` and `SCHEMA_PG_SQL`, and add an entry to `_run_pg_migrations()`.**
+- `src/db/test_schema_sync.py` — CI check that fails if the two schemas drift; enforces the add-to-both rule
 
 ---
 
@@ -121,6 +171,7 @@ Auth is bypassed locally when `GOOGLE_CLIENT_ID` is not set. Database is created
 | `EMAIL_APP_PASSWORD` | For email | — | Gmail App Password for daily run summary email (myaccount.google.com/apppasswords) |
 | `EMAIL_FROM` | No | `wcmchenry3@gmail.com` | Sender address for summary email |
 | `EMAIL_TO` | No | `wcmchenry3@gmail.com` | Recipient address for summary email |
+| `DAILY_DELTA_ENABLED` | Legacy/render.yaml | `1` | Present in `render.yaml` (value `"1"`) but **not read by any current Python source**. Kept in render.yaml as a placeholder; `RUNNERS_ENABLED` is the active kill switch for all scheduled jobs. |
 | `GEMINI_OFFICE_HOLDER` | For Gemini | — | Google Gemini API key for deep vitals research (Feature C). If unset, Gemini research is silently disabled. |
 | `WIKIPEDIA_BOT_USERNAME` | For wiki submit | — | Wikipedia bot account username for article submission via MediaWiki Action API. If unset, submit is disabled. |
 | `WIKIPEDIA_BOT_PASSWORD` | For wiki submit | — | Wikipedia bot account password. If unset, submit is disabled. |

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -3,6 +3,7 @@
 ## Key Conventions
 
 - **Migrations:** Always idempotent. Check `PRAGMA table_info(...)` or `PRAGMA index_list(...)` before altering. Never alter schema manually — always add a function to `migrate_to_fk()` in `src/db/migrate.py`.
+- **Dual backend schema rule:** When adding a column or table, update **both** `SCHEMA_SQL` (SQLite, `src/db/schema.py`) **and** `SCHEMA_PG_SQL` (PostgreSQL, same file), **and** add an entry to `_run_pg_migrations()` in `src/db/connection.py`. `test_schema_sync.py` in CI will fail if the two schemas drift.
 - **DB rows:** `sqlite3.Row` with `row_factory` — access columns by name like a dict. Passed around as `dict[str, Any]`.
 - **Party matching:** By `country_id` + `party_name` or `party_link`. Unmatched parties stored as text; matched parties get `party_id` FK.
 - **Office row helpers:** Always use `db_offices.office_row_to_table_config()` and `office_row_to_office_details()` to convert a flat `offices` row into structured dicts for the parser. Don't build config dicts manually.


### PR DESCRIPTION
## Summary
**architecture.md:**
- Corrects scheduled jobs: uses child subprocess (not background thread) — explains memory reclamation motivation and failure modes
- New "SQLite/PostgreSQL Dual Backend" section: `_PGConnWrapper`, `is_postgres()`, `_run_pg_migrations()`, `test_schema_sync.py` CI enforcement, and the add-to-both rule
- Expands `render.yaml` directory entry: PostgreSQL service, 1GB persistent disk at `/data`, auto-generated `SECRET_KEY`, `DATA_QUALITY_ENABLED=0` default
- Adds `DAILY_DELTA_ENABLED` env var row (present in render.yaml, not read by Python — legacy placeholder; `RUNNERS_ENABLED` is the active kill switch)
- Adds UI pages table with all 16 major routes

**conventions.md:**
- Adds dual backend schema rule to Key Conventions

Closes #292

## Test plan
- [ ] Verify subprocess model matches `src/scheduled_tasks.py` (`_run_daily_delta_in_subprocess`, `_run_mode_in_subprocess`)
- [ ] Verify `render.yaml` matches documented configuration
- [ ] Confirm dual backend rule matches `src/db/connection.py` / `schema.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)