### PR TITLE
feat: migrate alt_links off offices — backfill office_details_id, drop office_id

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -9,12 +9,11 @@ SQLite database. Schema defined in `src/db/schema.py` (`SCHEMA_SQL`). Migrations
 ```
 countries ──┬── states ── cities
             │
-            ├── source_pages ── office_details ── office_table_config ──→ infobox_role_key_filter
-            │                       │
+            ├── source_pages ── office_details ──┬── office_table_config ──→ infobox_role_key_filter
+            │                       │            └── alt_links
             │                   (office_category)
             │
             ├── offices (LEGACY flat table — still in active use)
-            │       └── alt_links
             │
             ├── parties
             │
@@ -122,9 +121,9 @@ The original flat design. Still used by all scraper runs. Contains all fields fr
 | Column | Type | Notes |
 |---|---|---|
 | `id` | INTEGER PK | |
-| `office_id` | FK → offices | |
+| `office_details_id` | FK → office_details (NOT NULL) | |
 | `link_path` | TEXT | Wikipedia path (e.g. `/wiki/John_Smith`) |
-| | | UNIQUE(office_id, link_path) |
+| | | UNIQUE(office_details_id, link_path) |
 
 Alt links are alternate Wikipedia URLs associated with an office — used to look up infobox data from different pages than the main office holder link.
 

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -588,6 +588,66 @@ def _run_pg_migrations(conn) -> None:
         " updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
     )
 
+    # Migrate alt_links off the legacy offices table (issue #311).
+    # Step 1 — backfill office_details_id for any pre-M14 rows that still carry
+    # only office_id.  The mapping is: offices.url → source_pages.url →
+    # office_details.source_page_id, with offices.name = office_details.name.
+    # Abort if any rows cannot be resolved so that no link paths are silently lost.
+    _apply(
+        "pg_alt_links_backfill_office_details_id",
+        """
+        DO $$
+        DECLARE before_count INTEGER;
+        DECLARE unmapped INTEGER;
+        BEGIN
+            SELECT COUNT(*) INTO before_count
+            FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
+            RAISE NOTICE 'pg_alt_links_backfill: % rows to backfill', before_count;
+
+            UPDATE alt_links al
+            SET office_details_id = od.id
+            FROM offices o
+            JOIN source_pages sp ON sp.url = o.url
+            JOIN office_details od ON od.source_page_id = sp.id AND od.name = o.name
+            WHERE al.office_id = o.id AND al.office_details_id IS NULL;
+
+            SELECT COUNT(*) INTO unmapped
+            FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
+            IF unmapped > 0 THEN
+                RAISE EXCEPTION
+                    'pg_alt_links_backfill: % rows could not be mapped to office_details — aborting',
+                    unmapped;
+            END IF;
+        END $$
+        """,
+    )
+    # Step 2 — drop the old UNIQUE(office_id, link_path) constraint and index,
+    # then drop the office_id column itself.
+    _apply(
+        "pg_alt_links_drop_unique_constraint",
+        "ALTER TABLE alt_links DROP CONSTRAINT IF EXISTS alt_links_office_id_link_path_key",
+    )
+    _apply(
+        "pg_alt_links_drop_office_id_index",
+        "DROP INDEX IF EXISTS idx_alt_links_office_id",
+    )
+    _apply(
+        "pg_alt_links_drop_office_id",
+        "ALTER TABLE alt_links DROP COLUMN IF EXISTS office_id",
+    )
+    # Step 3 — enforce NOT NULL and add the new unique constraint.
+    # If any office_details_id is still NULL at this point the SET NOT NULL will
+    # fail, acting as a final assertion that the backfill was complete.
+    _apply(
+        "pg_alt_links_office_details_id_not_null",
+        "ALTER TABLE alt_links ALTER COLUMN office_details_id SET NOT NULL",
+    )
+    _apply(
+        "pg_alt_links_add_unique_office_details_link_path",
+        "ALTER TABLE alt_links ADD CONSTRAINT alt_links_office_details_id_link_path_key"
+        " UNIQUE (office_details_id, link_path)",
+    )
+
 
 def _sqlite_add_columns_if_missing(conn) -> None:
     """Idempotently add new columns to pre-existing SQLite tables.

--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -2355,7 +2355,6 @@ def delete_office(office_id: int, conn: Any | None = None) -> bool:
             conn.execute("DELETE FROM office_details WHERE id = %s", (office_id,))
             conn.commit()
             return True
-        conn.execute("DELETE FROM alt_links WHERE office_id = %s", (office_id,))
         cur = conn.execute("DELETE FROM offices WHERE id = %s", (office_id,))
         conn.commit()
         return cur.rowcount > 0
@@ -2424,19 +2423,13 @@ def deduplicate_source_pages_by_url(conn: Any | None = None) -> dict[str, Any]:
 
 
 def list_alt_links(office_id: int, conn: Any | None = None) -> list[str]:
-    """Return list of link_path strings for the office (office_details_id in hierarchy)."""
+    """Return list of link_path strings for the office (office_details_id)."""
     own_conn = conn is None
     if own_conn:
         conn = get_connection()
     try:
-        if _use_hierarchy(conn):
-            cur = conn.execute(
-                "SELECT link_path FROM alt_links WHERE office_details_id = %s ORDER BY id",
-                (office_id,),
-            )
-            return [row["link_path"] for row in cur.fetchall()]
         cur = conn.execute(
-            "SELECT link_path FROM alt_links WHERE office_id = %s ORDER BY id",
+            "SELECT link_path FROM alt_links WHERE office_details_id = %s ORDER BY id",
             (office_id,),
         )
         return [row["link_path"] for row in cur.fetchall()]
@@ -2446,29 +2439,19 @@ def list_alt_links(office_id: int, conn: Any | None = None) -> list[str]:
 
 
 def set_alt_links_for_office(office_id: int, paths: list[str], conn: Any | None = None) -> None:
-    """Replace all alt links for the office (office_details_id in hierarchy)."""
+    """Replace all alt links for the office (office_details_id)."""
     own_conn = conn is None
     if own_conn:
         conn = get_connection()
     try:
-        if _use_hierarchy(conn):
-            conn.execute("DELETE FROM alt_links WHERE office_details_id = %s", (office_id,))
-            for raw in paths:
-                path = _normalize_alt_link_path(raw)
-                if path:
-                    conn.execute(
-                        "INSERT INTO alt_links (office_details_id, link_path) VALUES (%s, %s) ON CONFLICT DO NOTHING",
-                        (office_id, path),
-                    )
-        else:
-            conn.execute("DELETE FROM alt_links WHERE office_id = %s", (office_id,))
-            for raw in paths:
-                path = _normalize_alt_link_path(raw)
-                if path:
-                    conn.execute(
-                        "INSERT INTO alt_links (office_id, link_path) VALUES (%s, %s) ON CONFLICT DO NOTHING",
-                        (office_id, path),
-                    )
+        conn.execute("DELETE FROM alt_links WHERE office_details_id = %s", (office_id,))
+        for raw in paths:
+            path = _normalize_alt_link_path(raw)
+            if path:
+                conn.execute(
+                    "INSERT INTO alt_links (office_details_id, link_path) VALUES (%s, %s) ON CONFLICT DO NOTHING",
+                    (office_id, path),
+                )
         conn.commit()
     finally:
         if own_conn:

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -235,15 +235,13 @@ CREATE TABLE IF NOT EXISTS offices (
 );
 
 -- Alt links: one row per office alternate infobox link (offices may have many)
--- office_id is nullable: hierarchy entries use office_details_id and leave office_id NULL
 CREATE TABLE IF NOT EXISTS alt_links (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    office_id INTEGER REFERENCES offices(id),
-    office_details_id INTEGER REFERENCES office_details(id),
+    office_details_id INTEGER NOT NULL REFERENCES office_details(id),
     link_path TEXT NOT NULL,
-    UNIQUE(office_id, link_path)
+    UNIQUE(office_details_id, link_path)
 );
-CREATE INDEX IF NOT EXISTS idx_alt_links_office_id ON alt_links(office_id);
+CREATE INDEX IF NOT EXISTS idx_alt_links_office_details_id ON alt_links(office_details_id);
 
 -- Parties: party list for resolving party links (before office_terms for FK)
 CREATE TABLE IF NOT EXISTS parties (
@@ -703,15 +701,13 @@ CREATE TABLE IF NOT EXISTS offices (
 );
 
 -- Alt links
--- office_id is nullable: hierarchy entries use office_details_id and leave office_id NULL
 CREATE TABLE IF NOT EXISTS alt_links (
     id SERIAL PRIMARY KEY,
-    office_id INTEGER REFERENCES offices(id),
-    office_details_id INTEGER REFERENCES office_details(id),
+    office_details_id INTEGER NOT NULL REFERENCES office_details(id),
     link_path TEXT NOT NULL,
-    UNIQUE(office_id, link_path)
+    UNIQUE(office_details_id, link_path)
 );
-CREATE INDEX IF NOT EXISTS idx_alt_links_office_id ON alt_links(office_id);
+CREATE INDEX IF NOT EXISTS idx_alt_links_office_details_id ON alt_links(office_details_id);
 
 -- Parties
 CREATE TABLE IF NOT EXISTS parties (


### PR DESCRIPTION
Closes #311.

## Summary
- **schema.py**: Drop `office_id` from `alt_links` DDL (both SQLite and PG); `office_details_id` is now `NOT NULL`; `UNIQUE` constraint is now `(office_details_id, link_path)`
- **connection.py**: Six idempotent `_run_pg_migrations` entries: a `DO $$` block that backfills `office_details_id` via `offices → source_pages → office_details` join (raises `EXCEPTION` if any row is unmapped), drops the old constraint + index + column, sets `NOT NULL`, then adds the new unique constraint
- **offices.py**: Remove `_use_hierarchy` branching from `list_alt_links()` and `set_alt_links_for_office()`; drop the stale `DELETE FROM alt_links WHERE office_id` line in `delete_office()`
- **docs/schema.md**: Update `alt_links` table docs and diagram

## Test plan
- [x] `test_schema_sync.py` — both SQLite and PG DDLs stay in sync
- [x] `test_db_layer.py` — DB layer round-trips pass
- [x] `test_helpers.py` — alt_links parsing tests pass
- [x] Full `src/` suite: 875 passed, pre-existing failures in `tests/` only (unrelated Claude client tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)