### PR TITLE
fix: _PGConnWrapper passes empty tuple to psycopg2, causing startup IndexError (#317)

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -114,7 +114,13 @@ class _PGConnWrapper:
 
     def execute(self, sql, params=None):
         cur = self._conn.cursor()
-        cur.execute(sql, params if params is not None else ())
+        if params is not None:
+            cur.execute(sql, params)
+        else:
+            # Do NOT pass an empty tuple — psycopg2 would scan the SQL for '%'
+            # placeholders and raise IndexError when it finds one (e.g. inside a
+            # DO $$ RAISE NOTICE '% rows ...' block) with nothing to substitute.
+            cur.execute(sql)
         return cur
 
     def executemany(self, sql, seq_of_params):
@@ -610,7 +616,7 @@ def _run_pg_migrations(conn) -> None:
 
             SELECT COUNT(*) INTO before_count
             FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
-            RAISE NOTICE 'pg_alt_links_backfill: % rows to backfill', before_count;
+            RAISE NOTICE 'pg_alt_links_backfill: %% rows to backfill', before_count;
 
             UPDATE alt_links al
             SET office_details_id = od.id
@@ -623,7 +629,7 @@ def _run_pg_migrations(conn) -> None:
             FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
             IF unmapped > 0 THEN
                 RAISE EXCEPTION
-                    'pg_alt_links_backfill: % rows could not be mapped to office_details — aborting',
+                    'pg_alt_links_backfill: %% rows could not be mapped to office_details — aborting',
                     unmapped;
             END IF;
         END $$
@@ -666,7 +672,7 @@ def _run_pg_migrations(conn) -> None:
             ALTER TABLE alt_links ADD CONSTRAINT alt_links_office_details_id_link_path_key
                 UNIQUE (office_details_id, link_path);
         EXCEPTION
-            WHEN duplicate_table THEN
+            WHEN duplicate_object THEN
                 RAISE NOTICE 'pg_alt_links_unique: constraint already exists, skipping';
         END $$
         """,


### PR DESCRIPTION
## Root cause

`_PGConnWrapper.execute()` was calling:
```python
cur.execute(sql, params if params is not None else ())
```

When called without params (e.g. `conn.execute(migration_sql)` inside `_apply`), psycopg2 received an empty tuple `()`. psycopg2 then scans the **entire** SQL string for `%` placeholders before sending it to PostgreSQL. The DO \$\$ migration blocks contain `RAISE NOTICE '% rows to backfill'` — when psycopg2 sees `%` followed by any character with an empty params tuple, it tries to access `params[0]`, raising:

```
IndexError: tuple index out of range
```

Which surfaced as `RuntimeError: Database startup failed: tuple index out of range`.

The previous fix (information_schema guard on the backfill block) didn't help because psycopg2 processes `%` in the SQL string **before** sending to PostgreSQL — the guard inside the DO block is irrelevant at the Python layer.

## Fix

- `_PGConnWrapper.execute()`: call `cur.execute(sql)` with no params when `params is None`, so psycopg2 skips `%` processing entirely
- Escape `%` → `%%` in RAISE NOTICE/EXCEPTION strings inside the DO \$\$ blocks (defence-in-depth)
- Fix `WHEN duplicate_table` → `WHEN duplicate_object` (correct PostgreSQL exception name for a duplicate constraint)

## Test plan

- [ ] 829 non-Playwright tests pass locally ✓
- [ ] CI green on this PR
- [ ] Merge to dev → merge dev to main → production starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)