### PR TITLE
fix: revert %% to % in PL/pgSQL RAISE statements with arguments

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -616,7 +616,7 @@ def _run_pg_migrations(conn) -> None:
 
             SELECT COUNT(*) INTO before_count
             FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
-            RAISE NOTICE 'pg_alt_links_backfill: %% rows to backfill', before_count;
+            RAISE NOTICE 'pg_alt_links_backfill: % rows to backfill', before_count;
 
             UPDATE alt_links al
             SET office_details_id = od.id
@@ -629,7 +629,7 @@ def _run_pg_migrations(conn) -> None:
             FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
             IF unmapped > 0 THEN
                 RAISE EXCEPTION
-                    'pg_alt_links_backfill: %% rows could not be mapped to office_details — aborting',
+                    'pg_alt_links_backfill: % rows could not be mapped to office_details — aborting',
                     unmapped;
             END IF;
         END $$
@@ -660,7 +660,7 @@ def _run_pg_migrations(conn) -> None:
             ALTER TABLE alt_links ALTER COLUMN office_details_id SET NOT NULL;
         EXCEPTION
             WHEN others THEN
-                RAISE NOTICE 'pg_alt_links_not_null: already enforced, skipping (%%)', SQLERRM;
+                RAISE NOTICE 'pg_alt_links_not_null: already enforced, skipping (%)', SQLERRM;
         END $$
         """,
     )


### PR DESCRIPTION
## What went wrong

After fixing `_PGConnWrapper.execute()` to not pass an empty params tuple (#320), psycopg2 no longer processes `%` in SQL strings sent without params. The PL/pgSQL `%` format placeholder is now delivered to PostgreSQL intact.

However #320 also changed those `%` to `%%` as defence-in-depth. In PL/pgSQL, `%%` is a **literal percent sign** (0 format slots). With positional arguments still present after the format string, PostgreSQL raised:

```
SyntaxError: too many parameters specified for RAISE
CONTEXT: compilation of PL/pgSQL function "inline_code_block" near line 15
```

## Fix

Revert the three `%%` → `%` in RAISE NOTICE / RAISE EXCEPTION format strings that have positional arguments:
- `'% rows to backfill', before_count`
- `'% rows could not be mapped...', unmapped`
- `'skipping (%)', SQLERRM`

The `_PGConnWrapper.execute()` fix (no empty tuple) from #320 remains — that is the actual fix to the startup crash.

## Test plan

- [ ] 829 non-Playwright tests pass locally ✓
- [ ] CI green
- [ ] Merge to dev → merge dev to main → production starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)