### PR TITLE
fix: remove alt_links migration block to unblock startup (#317)

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -594,89 +594,13 @@ def _run_pg_migrations(conn) -> None:
         " updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
     )
 
-    # Migrate alt_links off the legacy offices table (issue #311).
-    # Step 1 — backfill office_details_id for any pre-M14 rows that still carry
-    # only office_id.  Guard with an information_schema check so that databases
-    # whose alt_links table was created from the updated SCHEMA_PG_SQL (which no
-    # longer has office_id) skip the backfill entirely — nothing to migrate.
-    _apply(
-        "pg_alt_links_backfill_office_details_id",
-        """
-        DO $$
-        DECLARE before_count INTEGER;
-        DECLARE unmapped INTEGER;
-        BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM information_schema.columns
-                WHERE table_name = 'alt_links' AND column_name = 'office_id'
-            ) THEN
-                RAISE NOTICE 'pg_alt_links_backfill: office_id column absent, skipping';
-                RETURN;
-            END IF;
-
-            SELECT COUNT(*) INTO before_count
-            FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
-            RAISE NOTICE 'pg_alt_links_backfill: % rows to backfill', before_count;
-
-            UPDATE alt_links al
-            SET office_details_id = od.id
-            FROM offices o
-            JOIN source_pages sp ON sp.url = o.url
-            JOIN office_details od ON od.source_page_id = sp.id AND od.name = o.name
-            WHERE al.office_id = o.id AND al.office_details_id IS NULL;
-
-            SELECT COUNT(*) INTO unmapped
-            FROM alt_links WHERE office_id IS NOT NULL AND office_details_id IS NULL;
-            IF unmapped > 0 THEN
-                RAISE EXCEPTION
-                    'pg_alt_links_backfill: % rows could not be mapped to office_details — aborting',
-                    unmapped;
-            END IF;
-        END $$
-        """,
-    )
-    # Step 2 — drop the old UNIQUE(office_id, link_path) constraint and index,
-    # then drop the office_id column itself.  IF EXISTS makes these idempotent.
-    _apply(
-        "pg_alt_links_drop_unique_constraint",
-        "ALTER TABLE alt_links DROP CONSTRAINT IF EXISTS alt_links_office_id_link_path_key",
-    )
-    _apply(
-        "pg_alt_links_drop_office_id_index",
-        "DROP INDEX IF EXISTS idx_alt_links_office_id",
-    )
-    _apply(
-        "pg_alt_links_drop_office_id",
-        "ALTER TABLE alt_links DROP COLUMN IF EXISTS office_id",
-    )
-    # Step 3 — enforce NOT NULL and add the new unique constraint.
-    # Use DO $$ guards so these are safe on fresh-schema databases where the
-    # column is already NOT NULL and the constraint already exists.
-    _apply(
-        "pg_alt_links_office_details_id_not_null",
-        """
-        DO $$
-        BEGIN
-            ALTER TABLE alt_links ALTER COLUMN office_details_id SET NOT NULL;
-        EXCEPTION
-            WHEN others THEN
-                RAISE NOTICE 'pg_alt_links_not_null: already enforced, skipping (%)', SQLERRM;
-        END $$
-        """,
-    )
-    _apply(
-        "pg_alt_links_add_unique_office_details_link_path",
-        """
-        DO $$
-        BEGIN
-            ALTER TABLE alt_links ADD CONSTRAINT alt_links_office_details_id_link_path_key
-                UNIQUE (office_details_id, link_path);
-        EXCEPTION
-            WHEN duplicate_object THEN
-                RAISE NOTICE 'pg_alt_links_unique: constraint already exists, skipping';
-        END $$
-        """,
-    )
+    # TODO(issue #317): alt_links migration (backfill office_details_id, drop office_id,
+    # add UNIQUE constraint) is deferred — production has duplicate (office_details_id,
+    # link_path) rows that must be cleaned up before the UNIQUE constraint can be added.
+    # The migrations pg_alt_links_backfill_office_details_id through
+    # pg_alt_links_office_details_id_not_null already ran on production and are recorded
+    # in schema_migrations; pg_alt_links_add_unique_office_details_link_path is still
+    # pending and will be re-introduced once the duplicate data is resolved.
 
 
 def _sqlite_add_columns_if_missing(conn) -> None:


### PR DESCRIPTION
## Problem

`pg_alt_links_add_unique_office_details_link_path` fails on production because there are duplicate `(office_details_id, link_path)` rows (e.g. `office_details_id=1256`, `/wiki/Attorney_General_of_North_Carolina`). This blocks app startup.

## What this PR does

Removes all 6 alt_links `_apply` calls from `_run_pg_migrations` so the app starts cleanly.

**State of production DB after the failed deploys:**
- `pg_alt_links_backfill_office_details_id` through `pg_alt_links_office_details_id_not_null` — already committed to `schema_migrations`, so they won't re-run
- `pg_alt_links_add_unique_office_details_link_path` — never committed (failed), still pending

**What's NOT in this PR:**
- Deduplicating the `alt_links` rows (tracked in #317)
- Re-introducing the UNIQUE constraint migration

## Test plan

- [ ] CI green
- [ ] Merge to dev → merge dev to main → production starts successfully
- [ ] Follow-up issue to deduplicate alt_links and re-add the constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)