### PR TITLE
feat: complete alt_links UNIQUE constraint and drop offices table (#311 #313)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -13,18 +13,16 @@ countries ──┬── states ── cities
             │                       │            └── alt_links
             │                   (office_category)
             │
-            ├── offices (LEGACY flat table — still in active use)
-            │
             ├── parties
             │
             └── (via office_terms)
                     ↓
-              office_terms ──→ offices (legacy)
-                    ↓               ↓
-              individuals       parties
+              office_terms ──→ office_table_config (via office_id)
+                    ↓
+              individuals    parties
 ```
 
-**Key:** `office_terms` links to the legacy `offices` table (not `office_table_config`). All scraper run results write to `office_terms` via the legacy `office_id`.
+**Key:** `office_terms.office_id` stores the `office_table_config.id` value in hierarchy mode.
 
 ---
 
@@ -110,13 +108,6 @@ One row per HTML table being parsed for an office.
 
 ---
 
-## Legacy Flat Table
-
-### `offices`
-The original flat design. Still used by all scraper runs. Contains all fields from `source_pages` + `office_details` + `office_table_config` in one row.
-
-**Important:** When adding new config fields, they must be added to `offices` AND `office_table_config` (with a migration for each).
-
 ### `alt_links`
 | Column | Type | Notes |
 |---|---|---|
@@ -158,7 +149,7 @@ One row per scraped term (a person holding an office for a period).
 | Column | Type | Notes |
 |---|---|---|
 | `id` | INTEGER PK | |
-| `office_id` | INTEGER FK → offices | Legacy office ID |
+| `office_id` | INTEGER (office_table_config.id in hierarchy mode) | Scraper output key |
 | `individual_id` | FK → individuals | Nullable (if no wiki link) |
 | `party_id` | FK → parties | Nullable |
 | `district` | TEXT | |
@@ -435,3 +426,12 @@ The following are **PostgreSQL-only inline migrations** applied at startup via `
 | `pg_create_nolink_supersede_log` | Add `nolink_supersede_log` table |
 | `pg_create_scheduler_settings` | Add `scheduler_settings` table |
 | `pg_create_app_settings` | Add `app_settings` table |
+| `pg_alt_links_backfill_office_details_id` | Backfill `alt_links.office_details_id` from legacy `office_id` via offices→source_pages mapping |
+| `pg_alt_links_drop_unique_constraint` | Drop old UNIQUE(office_id, link_path) constraint |
+| `pg_alt_links_drop_office_id_index` | Drop index on `alt_links.office_id` |
+| `pg_alt_links_drop_office_id` | Drop `alt_links.office_id` column |
+| `pg_alt_links_office_details_id_not_null` | Set `alt_links.office_details_id` NOT NULL |
+| `pg_alt_links_dedup_before_unique` | Remove duplicate `(office_details_id, link_path)` rows, keeping max-id row per pair (issue #311/#317) |
+| `pg_alt_links_add_unique_office_details_link_path` | Add UNIQUE(office_details_id, link_path) to `alt_links` |
+| `pg_drop_offices_indexes` | Drop indexes on legacy `offices` table columns |
+| `pg_drop_offices_table` | Drop legacy `offices` table (issue #313) |

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -594,13 +594,57 @@ def _run_pg_migrations(conn) -> None:
         " updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
     )
 
-    # TODO(issue #317): alt_links migration (backfill office_details_id, drop office_id,
-    # add UNIQUE constraint) is deferred — production has duplicate (office_details_id,
-    # link_path) rows that must be cleaned up before the UNIQUE constraint can be added.
-    # The migrations pg_alt_links_backfill_office_details_id through
-    # pg_alt_links_office_details_id_not_null already ran on production and are recorded
-    # in schema_migrations; pg_alt_links_add_unique_office_details_link_path is still
-    # pending and will be re-introduced once the duplicate data is resolved.
+    # Issue #311 residual: deduplicate alt_links before adding the UNIQUE constraint.
+    # The preceding 5 migrations (backfill through not-null) already ran on production.
+    # Production had duplicate (office_details_id, link_path) pairs (e.g. office_details_id=1256)
+    # that blocked the constraint; this step removes them, keeping the max-id row per pair.
+    _apply(
+        "pg_alt_links_dedup_before_unique",
+        """
+        DO $$
+        DECLARE
+            dup_count INTEGER;
+            deleted_count INTEGER;
+        BEGIN
+            SELECT COUNT(*) INTO dup_count
+            FROM (
+                SELECT office_details_id, link_path
+                FROM alt_links
+                GROUP BY office_details_id, link_path
+                HAVING COUNT(*) > 1
+            ) dupes;
+            RAISE NOTICE 'pg_alt_links_dedup: % duplicate (office_details_id, link_path) pairs found', dup_count;
+
+            DELETE FROM alt_links
+            WHERE id NOT IN (
+                SELECT MAX(id)
+                FROM alt_links
+                GROUP BY office_details_id, link_path
+            );
+            GET DIAGNOSTICS deleted_count = ROW_COUNT;
+            RAISE NOTICE 'pg_alt_links_dedup: % duplicate rows deleted', deleted_count;
+        END $$;
+        """,
+    )
+    _apply(
+        "pg_alt_links_add_unique_office_details_link_path",
+        "ALTER TABLE alt_links ADD CONSTRAINT alt_links_office_details_id_link_path_key"
+        " UNIQUE (office_details_id, link_path)",
+    )
+    # Issue #313: drop the legacy offices table now that all FK references are gone.
+    # office_terms.office_id FK was dropped in pg_drop_office_terms_office_id_fkey.
+    # alt_links.office_id was dropped in pg_alt_links_drop_office_id.
+    _apply(
+        "pg_drop_offices_indexes",
+        "DROP INDEX IF EXISTS idx_offices_country_id;"
+        "DROP INDEX IF EXISTS idx_offices_state_id;"
+        "DROP INDEX IF EXISTS idx_offices_level_id;"
+        "DROP INDEX IF EXISTS idx_offices_branch_id",
+    )
+    _apply(
+        "pg_drop_offices_table",
+        "DROP TABLE IF EXISTS offices",
+    )
 
 
 def _sqlite_add_columns_if_missing(conn) -> None:

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -192,49 +192,7 @@ CREATE INDEX IF NOT EXISTS idx_office_table_config_office_details_id ON office_t
 CREATE INDEX IF NOT EXISTS idx_office_table_config_enabled ON office_table_config(enabled);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_office_table_config_office_table_no ON office_table_config(office_details_id, table_no);
 
--- Offices: office definitions (what we scrape) — link by FK to countries, states, levels, branches (legacy, migrated to hierarchy)
-CREATE TABLE IF NOT EXISTS offices (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    country_id INTEGER NOT NULL REFERENCES countries(id),
-    state_id INTEGER REFERENCES states(id),
-    level_id INTEGER REFERENCES levels(id),
-    branch_id INTEGER REFERENCES branches(id),
-    department TEXT,
-    name TEXT NOT NULL,
-    enabled INTEGER NOT NULL DEFAULT 1,
-    notes TEXT,
-    url TEXT NOT NULL,
-    table_no INTEGER NOT NULL DEFAULT 1,
-    table_rows INTEGER NOT NULL DEFAULT 4,
-    link_column INTEGER NOT NULL DEFAULT 1,
-    party_column INTEGER NOT NULL DEFAULT 0,
-    term_start_column INTEGER NOT NULL DEFAULT 4,
-    term_end_column INTEGER NOT NULL DEFAULT 5,
-    district_column INTEGER NOT NULL DEFAULT 0,
-    filter_column INTEGER NOT NULL DEFAULT 0,
-    filter_criteria TEXT NOT NULL DEFAULT '',
-    dynamic_parse INTEGER NOT NULL DEFAULT 1,
-    read_right_to_left INTEGER NOT NULL DEFAULT 0,
-    find_date_in_infobox INTEGER NOT NULL DEFAULT 0,
-    parse_rowspan INTEGER NOT NULL DEFAULT 0,
-    consolidate_rowspan_terms INTEGER NOT NULL DEFAULT 0,
-    rep_link INTEGER NOT NULL DEFAULT 0,
-    party_link INTEGER NOT NULL DEFAULT 0,
-    alt_link_include_main INTEGER NOT NULL DEFAULT 0,
-    use_full_page_for_table INTEGER NOT NULL DEFAULT 0,
-    years_only INTEGER NOT NULL DEFAULT 0,
-    term_dates_merged INTEGER NOT NULL DEFAULT 0,
-    party_ignore INTEGER NOT NULL DEFAULT 0,
-    district_ignore INTEGER NOT NULL DEFAULT 0,
-    district_at_large INTEGER NOT NULL DEFAULT 0,
-    ignore_non_links INTEGER NOT NULL DEFAULT 0,
-    remove_duplicates INTEGER NOT NULL DEFAULT 0,
-    infobox_role_key TEXT NOT NULL DEFAULT '',
-    infobox_role_key_filter_id INTEGER REFERENCES infobox_role_key_filter(id),
-    created_at TEXT DEFAULT (datetime('now'))
-);
-
--- Alt links: one row per office alternate infobox link (offices may have many)
+-- Alt links: one row per office_details alternate infobox link
 CREATE TABLE IF NOT EXISTS alt_links (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     office_details_id INTEGER NOT NULL REFERENCES office_details(id),
@@ -370,11 +328,7 @@ CREATE TABLE IF NOT EXISTS data_quality_reports (
 );
 CREATE INDEX IF NOT EXISTS idx_data_quality_reports_fingerprint ON data_quality_reports(fingerprint);
 
--- Indexes on offices/parties/office_terms FK columns
-CREATE INDEX IF NOT EXISTS idx_offices_country_id ON offices(country_id);
-CREATE INDEX IF NOT EXISTS idx_offices_state_id ON offices(state_id);
-CREATE INDEX IF NOT EXISTS idx_offices_level_id ON offices(level_id);
-CREATE INDEX IF NOT EXISTS idx_offices_branch_id ON offices(branch_id);
+-- Indexes on parties/office_terms FK columns
 CREATE INDEX IF NOT EXISTS idx_parties_country_id ON parties(country_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_party_id ON office_terms(party_id);
 
@@ -461,10 +415,6 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 # For SQLite (tests) these are now embedded in SCHEMA_SQL above; this constant is still used
 # by _init_postgres() which passes it separately after the main schema.
 OFFICES_PARTIES_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_offices_country_id ON offices(country_id);
-CREATE INDEX IF NOT EXISTS idx_offices_state_id ON offices(state_id);
-CREATE INDEX IF NOT EXISTS idx_offices_level_id ON offices(level_id);
-CREATE INDEX IF NOT EXISTS idx_offices_branch_id ON offices(branch_id);
 CREATE INDEX IF NOT EXISTS idx_parties_country_id ON parties(country_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_party_id ON office_terms(party_id);
 """
@@ -657,48 +607,6 @@ CREATE TABLE IF NOT EXISTS office_table_config (
 CREATE INDEX IF NOT EXISTS idx_office_table_config_office_details_id ON office_table_config(office_details_id);
 CREATE INDEX IF NOT EXISTS idx_office_table_config_enabled ON office_table_config(enabled);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_office_table_config_office_table_no ON office_table_config(office_details_id, table_no);
-
--- Offices (legacy — new data goes through source_pages → office_details → office_table_config)
-CREATE TABLE IF NOT EXISTS offices (
-    id SERIAL PRIMARY KEY,
-    country_id INTEGER NOT NULL REFERENCES countries(id),
-    state_id INTEGER REFERENCES states(id),
-    level_id INTEGER REFERENCES levels(id),
-    branch_id INTEGER REFERENCES branches(id),
-    department TEXT,
-    name TEXT NOT NULL,
-    enabled INTEGER NOT NULL DEFAULT 1,
-    notes TEXT,
-    url TEXT NOT NULL,
-    table_no INTEGER NOT NULL DEFAULT 1,
-    table_rows INTEGER NOT NULL DEFAULT 4,
-    link_column INTEGER NOT NULL DEFAULT 1,
-    party_column INTEGER NOT NULL DEFAULT 0,
-    term_start_column INTEGER NOT NULL DEFAULT 4,
-    term_end_column INTEGER NOT NULL DEFAULT 5,
-    district_column INTEGER NOT NULL DEFAULT 0,
-    filter_column INTEGER NOT NULL DEFAULT 0,
-    filter_criteria TEXT NOT NULL DEFAULT '',
-    dynamic_parse INTEGER NOT NULL DEFAULT 1,
-    read_right_to_left INTEGER NOT NULL DEFAULT 0,
-    find_date_in_infobox INTEGER NOT NULL DEFAULT 0,
-    parse_rowspan INTEGER NOT NULL DEFAULT 0,
-    consolidate_rowspan_terms INTEGER NOT NULL DEFAULT 0,
-    rep_link INTEGER NOT NULL DEFAULT 0,
-    party_link INTEGER NOT NULL DEFAULT 0,
-    alt_link_include_main INTEGER NOT NULL DEFAULT 0,
-    use_full_page_for_table INTEGER NOT NULL DEFAULT 0,
-    years_only INTEGER NOT NULL DEFAULT 0,
-    term_dates_merged INTEGER NOT NULL DEFAULT 0,
-    party_ignore INTEGER NOT NULL DEFAULT 0,
-    district_ignore INTEGER NOT NULL DEFAULT 0,
-    district_at_large INTEGER NOT NULL DEFAULT 0,
-    ignore_non_links INTEGER NOT NULL DEFAULT 0,
-    remove_duplicates INTEGER NOT NULL DEFAULT 0,
-    infobox_role_key TEXT NOT NULL DEFAULT '',
-    infobox_role_key_filter_id INTEGER REFERENCES infobox_role_key_filter(id),
-    created_at TIMESTAMPTZ DEFAULT NOW()
-);
 
 -- Alt links
 CREATE TABLE IF NOT EXISTS alt_links (


### PR DESCRIPTION
## Summary
- **Issue #311 residual**: adds `pg_alt_links_dedup_before_unique` migration to remove duplicate `(office_details_id, link_path)` rows (keeping max-id per pair), then adds the long-deferred `UNIQUE(office_details_id, link_path)` constraint that was blocked on startup since PR #324
- **Issue #313**: adds `pg_drop_offices_indexes` and `pg_drop_offices_table` migrations to remove the legacy `offices` table; all FK references were already gone before this PR
- `schema.py`: removes `offices` CREATE TABLE from both SQLite and PostgreSQL sections; removes offices indexes from `SCHEMA_SQL` and `OFFICES_PARTIES_INDEX_SQL`
- `docs/schema.md`: removes Legacy Flat Table section, updates relationship diagram, adds new migrations to history

## Why 313 is unblocked
- `alt_links.office_id` (FK → offices) was dropped in `pg_alt_links_drop_office_id` (landed in PR #314)
- `office_terms` FK constraint was dropped in `pg_drop_office_terms_office_id_fkey` (earlier migration)
- No other table has a FK referencing `offices` — confirmed via `grep -rn "REFERENCES offices"` returning zero results

## Test plan
- [ ] `828 passed` in `src/` test suite (excluding Playwright)
- [ ] `test_schema_sync.py` 34/34 pass
- [ ] Verify on production: `pg_alt_links_dedup_before_unique` logs duplicate count before deleting, `pg_drop_offices_table` completes without error
- [ ] `SELECT * FROM offices` returns error (table does not exist) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)