### PR TITLE
fix: add RETURNING id to scheduled_job_runs INSERT

### DIFF
--- a/src/db/scheduled_job_runs.py
+++ b/src/db/scheduled_job_runs.py
@@ -25,7 +25,8 @@ def create_run(job_name: str, conn=None) -> int:
     try:
         now = _now_iso()
         cursor = conn.execute(
-            "INSERT INTO scheduled_job_runs (job_name, started_at, status)" " VALUES (%s, %s, %s)",
+            "INSERT INTO scheduled_job_runs (job_name, started_at, status)"
+            " VALUES (%s, %s, %s) RETURNING id",
             (job_name, now, "running"),
         )
         # PostgreSQL: use RETURNING; SQLite: use lastrowid


### PR DESCRIPTION
The INSERT in create_run() was missing RETURNING id, so
cursor.fetchone() raised psycopg2.ProgrammingError on PostgreSQL.
This broke all four daily scheduled jobs (daily_delta,
insufficient_vitals, gemini_research, daily_page_quality).

https://claude.ai/code/session_01P1e2axiHouyVrj5h7KAvrz