### PR TITLE
fix: datetime slice TypeError in scheduled_job_runs + bio 404 Sentry noise

### DIFF
--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -1867,7 +1867,7 @@ class Biography:
                     details = {"page_path": urlparse(wiki_link).path.split("/")[-1].strip()}
                 return details
             else:
-                logger.error(
+                logger.warning(
                     f"Failed to fetch biography URL with status code: {response.status_code}"
                 )
                 return {}

--- a/src/templates/scheduled_job_runs.html
+++ b/src/templates/scheduled_job_runs.html
@@ -31,8 +31,8 @@
     <tr>
       <td>{{ r.id }}</td>
       <td>{{ r.job_name }}</td>
-      <td>{{ (r.started_at or '')[:19] }}</td>
-      <td>{{ (r.finished_at or '')[:19] or '—' }}</td>
+      <td>{{ r.started_at.strftime('%Y-%m-%d %H:%M:%S') if r.started_at else '—' }}</td>
+      <td>{{ r.finished_at.strftime('%Y-%m-%d %H:%M:%S') if r.finished_at else '—' }}</td>
       <td>{% if r.duration_s is not none %}{{ "%.0f"|format(r.duration_s) }}s{% else %}—{% endif %}</td>
       <td class="status-{{ r.status }}">{{ r.status }}</td>
       <td>


### PR DESCRIPTION
Closes #336, #337

## Summary
- **#337** `scheduled_job_runs.html`: `(r.started_at or '')[:19]` crashed because psycopg2 returns `TIMESTAMPTZ` columns as `datetime` objects, not strings. Replaced with `strftime('%Y-%m-%d %H:%M:%S')`.
- **#336** `table_parser.py`: Bio fetch 404s are expected (stale/moved wiki URLs) and already handled gracefully (`return {}`). Downgraded log level from `error` → `warning` so Sentry stops capturing them as issues.

## Test plan
- [x] `tests/test_data_routes.py` + `tests/test_page_quality_inspector.py` — 43 passed locally
- [x] No template tests exist for datetime rendering; the fix is straightforward (datetime objects have `.strftime()`, strings do not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)