### PR TITLE
fix: guard ::date cast with regex to skip year-only dates in milestone report (closes #344)

### DIFF
--- a/src/db/reports.py
+++ b/src/db/reports.py
@@ -13,14 +13,16 @@ def get_recent_deaths(conn=None) -> list[dict[str, Any]]:
         conn = get_connection()
     try:
         if is_postgres():
-            since = "CURRENT_DATE - INTERVAL '90 days'"
-            date_col = "death_date::date"
+            # Guard the ::date cast — year-only values like '1891' raise InvalidDatetimeFormat.
+            where = (
+                "death_date ~ '^\\d{4}-\\d{2}-\\d{2}$'"
+                " AND death_date::date BETWEEN CURRENT_DATE - INTERVAL '90 days' AND CURRENT_DATE"
+            )
         else:
-            since = "date('now', '-90 days')"
-            date_col = "death_date"
+            where = "death_date BETWEEN date('now', '-90 days') AND CURRENT_DATE"
         cur = conn.execute(f"""SELECT full_name, birth_date, death_date
                FROM individuals
-               WHERE {date_col} BETWEEN {since} AND CURRENT_DATE
+               WHERE {where}
                ORDER BY death_date DESC""")
         return [_row_to_dict(r) for r in cur.fetchall()]
     finally:
@@ -35,11 +37,13 @@ def _term_report_query(
 ) -> list[dict[str, Any]]:
     """Shared logic: term report filtered by date_column (term_start or term_end), ordered by order_column."""
     if is_postgres():
-        since = "CURRENT_DATE - INTERVAL '90 days'"
-        date_col = f"ot.{date_column}::date"
+        # Guard the ::date cast — year-only values like '1891' raise InvalidDatetimeFormat.
+        where = (
+            f"ot.{date_column} ~ '^\\d{{4}}-\\d{{2}}-\\d{{2}}$'"
+            f" AND ot.{date_column}::date BETWEEN CURRENT_DATE - INTERVAL '90 days' AND CURRENT_DATE"
+        )
     else:
-        since = "date('now', '-90 days')"
-        date_col = f"ot.{date_column}"
+        where = f"ot.{date_column} BETWEEN date('now', '-90 days') AND CURRENT_DATE"
     cur = conn.execute(f"""
         SELECT
           i.full_name AS "Name",
@@ -59,7 +63,7 @@ def _term_report_query(
         LEFT JOIN states s ON s.id = sp.state_id
         LEFT JOIN levels l ON l.id = sp.level_id
         LEFT JOIN branches b ON b.id = sp.branch_id
-        WHERE {date_col} BETWEEN {since} AND CURRENT_DATE
+        WHERE {where}
         ORDER BY ot.{order_column} DESC
         """)
     return [_row_to_dict(r) for r in cur.fetchall()]


### PR DESCRIPTION
## Summary
Fixes Sentry issue RULERSAI-7393026191 — `/report/milestones` returning 500.

**Root cause:** `death_date::date` in PostgreSQL throws `InvalidDatetimeFormat` when any row has a year-only value like `'1891'`. PostgreSQL requires `YYYY-MM-DD` for a `::date` cast — a bare year fails. The same risk exists for `term_start::date` and `term_end::date` in the term reports.

**Fix:** Prefix every `::date` cast with a regex guard (`~ '^\d{4}-\d{2}-\d{2}$'`) so only properly-formatted dates are cast. Year-only values are excluded — they can't fall in a 90-day window anyway.

## Test plan
- [x] `tests/test_data_quality_reports.py` + `tests/test_data_routes.py` — 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)