### PR TITLE
perf: preload party lookup + bulk alt_links at run start

### DIFF
--- a/src/db/offices.py
+++ b/src/db/offices.py
@@ -488,17 +488,17 @@ def list_runnable_units(conn: Any | None = None) -> list[dict[str, Any]]:
                ORDER BY p.id, od.id, tc.id"""
         )
         rows = cur.fetchall()
+        # Bulk-load all alt_links in a single query instead of one per office.
+        alt_links_by_od: dict[int, list[str]] = {}
+        for al_row in conn.execute(
+            "SELECT office_details_id, link_path FROM alt_links ORDER BY office_details_id, id"
+        ).fetchall():
+            alt_links_by_od.setdefault(al_row["office_details_id"], []).append(al_row["link_path"])
         out = []
         for r in rows:
             rd = _row_to_dict(r)
             od_id = rd["office_details_id"]
-            alt_links = [
-                row["link_path"]
-                for row in conn.execute(
-                    "SELECT link_path FROM alt_links WHERE office_details_id = %s ORDER BY id",
-                    (od_id,),
-                ).fetchall()
-            ]
+            alt_links = alt_links_by_od.get(od_id, [])
             c, s, lv, b = _ref_names(
                 conn,
                 rd.get("country_id"),

--- a/src/db/parties.py
+++ b/src/db/parties.py
@@ -95,6 +95,38 @@ def update_party(party_id: int, data: dict[str, Any], conn=None) -> bool:
             conn.close()
 
 
+def load_all_as_lookup(conn=None) -> dict[tuple[int, str], int]:
+    """Return a dict mapping (country_id, name_or_link) -> party_id for all parties.
+
+    Used to replace per-row resolve_party_id_by_country() calls with a single
+    preload query at run start.  Both party_name and party_link are indexed as keys
+    so the lookup matches the same rows the per-query path would find.
+    """
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cur = conn.execute("SELECT id, country_id, party_name, party_link FROM parties")
+        lookup: dict[tuple[int, str], int] = {}
+        for row in cur.fetchall():
+            pid, cid, name, link = (
+                row["id"],
+                row["country_id"],
+                row["party_name"],
+                row["party_link"],
+            )
+            if cid is None:
+                continue
+            if name:
+                lookup[(cid, name.strip())] = pid
+            if link and link != name:
+                lookup[(cid, link.strip())] = pid
+        return lookup
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def resolve_party_id_by_country(
     country_id: int,
     party_name_or_link: str | None,

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -2570,6 +2570,9 @@ def run_with_db(
             report("saving", 0, 1, "Writing to database…", {"terms": total_terms})
             conn = get_connection()
             try:
+                # Preload party lookup once per run to avoid per-row SELECT.
+                _party_cache = db_parties.load_all_as_lookup(conn=conn)
+
                 db_office_terms.delete_office_terms_for_offices(
                     list(replaceable_office_ids), conn=conn
                 )
@@ -2652,9 +2655,13 @@ def run_with_db(
                     tc_id = row.get("_office_table_config_id")
                     country_id = row.get("_country_id")
                     if od_id is not None and tc_id is not None and country_id is not None:
-                        party_id = db_parties.resolve_party_id_by_country(
-                            country_id, party_text, conn=conn
-                        )
+                        party_key = (country_id, party_text.strip()) if party_text else None
+                        party_id = _party_cache.get(party_key) if party_key else None
+                        if party_id is None and party_text:
+                            # Fallback for newly inserted parties not in the preloaded cache.
+                            party_id = db_parties.resolve_party_id_by_country(
+                                country_id, party_text, conn=conn
+                            )
                         db_office_terms.insert_office_term(
                             office_details_id=od_id,
                             office_table_config_id=tc_id,


### PR DESCRIPTION
## Summary

- **#350** — Add `load_all_as_lookup()` to `parties.py`; preload at write-phase start as `_party_cache` dict keyed by `(country_id, name_or_link)`. Replaces `resolve_party_id_by_country()` per-row DB call with a dict lookup. DB fallback retained for newly inserted parties not yet in the cache. Cuts hundreds of per-row SELECTs down to a single preload query on large offices.
- **#354** — Replace the per-office `alt_links` SELECT inside `list_runnable_units()` loop with a single bulk `SELECT office_details_id, link_path FROM alt_links` query upfront; build a `{office_details_id: [links]}` dict before iterating. Eliminates O(offices) round-trips at run start (typically 50+ SELECTs → 1).

## Test plan

- [x] 828 tests passing, 11 skipped
- [x] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)