### PR TITLE
perf: run-level infobox cache + batch is_living recompute

### DIFF
--- a/src/db/individuals.py
+++ b/src/db/individuals.py
@@ -284,6 +284,72 @@ def _recompute_is_living_for_individual(individual_id: int, conn) -> None:
         )
 
 
+def recompute_is_living_batch(individual_ids: list[int], conn) -> int:
+    """Batch recompute is_living for a set of individuals. Returns count updated.
+
+    Equivalent to calling _recompute_is_living_for_individual for each id, but
+    uses two queries total (one SELECT, one bulk earliest-year query) instead of
+    two queries per individual.
+    """
+    if not individual_ids:
+        return 0
+
+    placeholders = ",".join(["%s"] * len(individual_ids))
+
+    # Load current is_living + death_date for all touched individuals in one query.
+    rows = conn.execute(
+        f"SELECT id, is_living, death_date FROM individuals WHERE id IN ({placeholders})",
+        individual_ids,
+    ).fetchall()
+
+    # Only consider individuals still marked living — never flip back.
+    living_ids = [
+        r["id"] for r in rows if r["is_living"] == 1 and not (r["death_date"] or "").strip()
+    ]
+    dead_by_death_date = [
+        r["id"] for r in rows if r["is_living"] == 1 and (r["death_date"] or "").strip()
+    ]
+
+    # Bulk earliest-term-year for still-living individuals (no death_date set).
+    earliest_by_id: dict[int, int] = {}
+    if living_ids:
+        lp = ",".join(["%s"] * len(living_ids))
+        if is_postgres():
+            year_expr = "EXTRACT(YEAR FROM term_start::date)::integer"
+        else:
+            year_expr = "CAST(strftime('%Y', term_start) AS INTEGER)"
+        for ey_row in conn.execute(
+            f"""SELECT individual_id,
+                       MIN(COALESCE(term_start_year, {year_expr})) AS y
+                FROM office_terms
+                WHERE individual_id IN ({lp})
+                GROUP BY individual_id""",
+            living_ids,
+        ).fetchall():
+            try:
+                if ey_row["y"] is not None:
+                    earliest_by_id[ey_row["individual_id"]] = int(ey_row["y"])
+            except (TypeError, ValueError):
+                pass
+
+    current_year = date.today().year
+    to_flip = list(dead_by_death_date)
+    for ind_id in living_ids:
+        earliest = earliest_by_id.get(ind_id)
+        if earliest is not None and current_year - earliest > 80:
+            to_flip.append(ind_id)
+
+    if not to_flip:
+        return 0
+
+    fp = ",".join(["%s"] * len(to_flip))
+    conn.execute(
+        f"UPDATE individuals SET is_living = 0 WHERE id IN ({fp})",
+        to_flip,
+    )
+    return len(to_flip)
+
+
 def get_living_individual_wiki_urls(conn=None) -> set[str]:
     """Return set of wiki_urls for individuals considered living (is_living = 1, not dead-link, not No link: placeholder)."""
     own_conn = conn is None

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -2572,6 +2572,7 @@ def run_with_db(
             try:
                 # Preload party lookup once per run to avoid per-row SELECT.
                 _party_cache = db_parties.load_all_as_lookup(conn=conn)
+                _touched_individual_ids: list[int] = []
 
                 db_office_terms.delete_office_terms_for_offices(
                     list(replaceable_office_ids), conn=conn
@@ -2694,7 +2695,7 @@ def run_with_db(
                             conn=conn,
                         )
                     if individual_id:
-                        db_individuals._recompute_is_living_for_individual(individual_id, conn)
+                        _touched_individual_ids.append(individual_id)
                     # Collect records for quality checking (auto mode)
                     if _quality_checker and individual_id:
                         _quality_checker.collect(
@@ -2717,6 +2718,10 @@ def run_with_db(
                                 "party_id": party_id,
                             },
                         )
+                # Batch recompute is_living for all touched individuals after inserts complete.
+                db_individuals.recompute_is_living_batch(
+                    list(set(_touched_individual_ids)), conn=conn
+                )
                 for tc_id, h in html_hashes_to_update.items():
                     db_offices.update_html_hash(tc_id, h, conn=conn)
                 for tc_id, rate in fill_rates_to_update.items():

--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -588,8 +588,10 @@ class Offices:
                 "skip_infobox_for_urls": frozenset(skip_infobox_for_urls),
             }
 
-        # Per-table cache so we only call find_term_dates once per wiki_link (same person in multiple rows)
-        self._infobox_cache = {}
+        # Run-level infobox cache: persists across tables for the same parser instance so the
+        # same individual appearing in multiple tables only pays one HTTP infobox call per run.
+        if not hasattr(self, "_infobox_cache"):
+            self._infobox_cache = {}
         # tracks the previous entry --> this helps the rowspan function track
         previous_row_wiki_link = None
         previous_row_district = None


### PR DESCRIPTION
## Summary

- **#353** — Promote `_infobox_cache` from per-table reset to run-level persistence. Changed `self._infobox_cache = {}` at the top of `process_table()` to `if not hasattr(self, '_infobox_cache')` — the same `offices_parser` instance now retains infobox results across all tables in a run. Individuals appearing in multiple tables (e.g. cabinet members across term periods) pay one HTTP infobox call per run instead of one per table.

- **#351** — Replace the per-row `_recompute_is_living_for_individual()` call inside the write loop with ID collection. New `recompute_is_living_batch()` in `individuals.py` uses two queries total — one `SELECT` for current state across all touched IDs, one bulk `MIN(earliest_term_year)` query, one batch `UPDATE` for IDs that need flipping — regardless of row count. Eliminates up to 3 queries per inserted row on large write phases.

## Note on prior work

- **#352** (page-level HTML cache) — already implemented in commit `8aea7f4` via `RunPageCache`; closed separately.
- **#337** (datetime template crash) — already fixed in commit `f3036d7`; closed separately.

## Test plan

- [x] 828 tests passing, 11 skipped
- [x] black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)