### PR TITLE
fix: guard No link rows before infobox fetch; drain done futures on as_completed timeout

### DIFF
--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -1301,7 +1301,12 @@ class Offices:
                     return (None, None, term_start_year, term_end_year)
 
             # Find date in infobox: fetch full dates from person's bio; collect all matching terms from infobox
-            if table_config_to_parse["find_date_in_infobox"] == True:
+            if (
+                table_config_to_parse["find_date_in_infobox"] == True
+                and wiki_link
+                and wiki_link != "No link"
+                and wiki_link.startswith("https://")
+            ):
                 logger.debug(
                     f" parse_table_row found TRUE in find_date_in_infobox \n\n about to process {start_cell}"
                 )

--- a/src/scraper/test_table_parser_coverage.py
+++ b/src/scraper/test_table_parser_coverage.py
@@ -828,3 +828,90 @@ def test_short_row_logs_warning(caplog):
     assert any(
         "issue with table rows" in r.message for r in caplog.records
     ), "Expected a WARNING about too-few rows"
+
+
+# ---------------------------------------------------------------------------
+# #372 — find_date_in_infobox guard: "No link" must not trigger HTTP call
+# ---------------------------------------------------------------------------
+
+
+def _table_html_no_link_row() -> str:
+    """HTML table whose data row has no <a> tag (produces wiki_link='No link')."""
+    return (
+        "<table>"
+        "<tr><th>Name</th><th>Party</th><th>Start</th><th>End</th></tr>"
+        "<tr><td>Jane Doe</td><td>Independent</td><td>2020</td><td>2024</td></tr>"
+        "</table>"
+    )
+
+
+def _infobox_table_config() -> dict:
+    """Minimal table_config with find_date_in_infobox=True."""
+    return {
+        "url": "https://en.example.org/wiki/Test",
+        "table_no": 1,
+        "table_rows": 4,
+        "link_column": 0,
+        "party_column": 1,
+        "term_start_column": 2,
+        "term_end_column": 3,
+        "district_column": 0,
+        "dynamic_parse": False,
+        "read_columns_right_to_left": False,
+        "find_date_in_infobox": True,
+        "years_only": False,
+        "parse_rowspan": False,
+        "consolidate_rowspan_terms": False,
+        "rep_link": False,
+        "party_link": False,
+        "alt_links": [],
+        "alt_link_include_main": False,
+        "use_full_page_for_table": False,
+        "term_dates_merged": False,
+        "party_ignore": False,
+        "district_ignore": False,
+        "district_at_large": False,
+        "ignore_non_links": False,
+        "infobox_role_key": "",
+        "row_filter_column": None,
+        "row_filter_criteria": "",
+        "run_dynamic_parse": False,
+        "skip_infobox_for_urls": None,
+        "existing_dates_lookup": {},
+    }
+
+
+def _office_details() -> dict:
+    return {
+        "office_country": "United States",
+        "office_level": "Federal",
+        "office_branch": "Legislative",
+        "office_department": "",
+        "office_name": "Test Office",
+        "office_state": "",
+        "office_notes": "",
+    }
+
+
+def test_find_date_in_infobox_skips_no_link_row(monkeypatch):
+    """When wiki_link=='No link' and find_date_in_infobox=True, find_term_dates must not be called."""
+    import src.scraper.table_parser as tp_mod
+
+    calls: list[str] = []
+
+    def fake_find_term_dates(self, wiki_link, url, table_config, office_details, district, run_cache=None):
+        calls.append(wiki_link)
+        return [], []
+
+    monkeypatch.setattr(tp_mod.Biography, "find_term_dates", fake_find_term_dates)
+
+    offices = _offices()
+    offices.process_table(
+        _table_html_no_link_row(),
+        _infobox_table_config(),
+        _office_details(),
+        "https://en.example.org/wiki/Test",
+        [],
+    )
+
+    assert calls == [], f"find_term_dates must not be called for 'No link' rows, got calls: {calls}"

--- a/src/scraper/test_table_parser_coverage.py
+++ b/src/scraper/test_table_parser_coverage.py
@@ -899,7 +899,9 @@ def test_find_date_in_infobox_skips_no_link_row(monkeypatch):
 
     calls: list[str] = []
 
-    def fake_find_term_dates(self, wiki_link, url, table_config, office_details, district, run_cache=None):
+    def fake_find_term_dates(
+        self, wiki_link, url, table_config, office_details, district, run_cache=None
+    ):
         calls.append(wiki_link)
         return [], []
 

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -261,10 +261,13 @@ class ConsensusVoter:
             future_to_provider = {
                 executor.submit(fn, prompt, context): name for name, fn in providers
             }
-            for future in as_completed(future_to_provider, timeout=timeout_s + 5):
+            pending_futures = set(future_to_provider)
+
+            def _collect(future: object) -> None:
+                pending_futures.discard(future)
                 provider_name = future_to_provider[future]
                 try:
-                    vote = future.result(timeout=timeout_s)
+                    vote = future.result(timeout=0)
                 except FuturesTimeoutError:
                     logger.warning(
                         "ConsensusVoter: %s timed out after %.0f s", provider_name, timeout_s
@@ -278,6 +281,30 @@ class ConsensusVoter:
                     logger.exception("ConsensusVoter: %s raised unexpected error", provider_name)
                     vote = AIVote(provider=provider_name, is_valid=None, error=str(exc))
                 votes.append(vote)
+
+            try:
+                for future in as_completed(future_to_provider, timeout=timeout_s + 5):
+                    _collect(future)
+            except FuturesTimeoutError:
+                pass
+
+            # Drain any futures that finished but weren't yielded before the timeout fired
+            # (sub-millisecond overshoot can leave done futures in pending)
+            for future in list(pending_futures):
+                if future.done():
+                    _collect(future)
+                else:
+                    provider_name = future_to_provider[future]
+                    logger.warning(
+                        "ConsensusVoter: %s timed out after %.0f s", provider_name, timeout_s
+                    )
+                    votes.append(
+                        AIVote(
+                            provider=provider_name,
+                            is_valid=None,
+                            error=f"timed out after {timeout_s:.0f}s",
+                        )
+                    )
 
         # Sort for deterministic ordering in tests / logs
         votes.sort(key=lambda v: v.provider)

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -520,3 +520,115 @@ class TestSystemPromptAlignment:
         assert (
             passed_system == _SYSTEM_PROMPT
         ), "Gemini must use the shared consensus _SYSTEM_PROMPT, not its vitals-research prompt"
+
+
+# ---------------------------------------------------------------------------
+# #373 — sub-millisecond overshoot: done futures not yielded by as_completed
+# must still be collected via the drain loop
+# ---------------------------------------------------------------------------
+
+
+class TestConsensusVoterSubmsTimeoutDrain:
+    """When as_completed raises TimeoutError due to a sub-ms clock overshoot,
+    any futures that are already done must be drained rather than silently dropped."""
+
+    def test_done_futures_drained_after_timeout_overshoot(self):
+        """as_completed yields 2 of 3 futures then raises TimeoutError; the 3rd
+        is already done — all 3 votes must appear in the result."""
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        voter = ConsensusVoter()
+
+        def fake_as_completed(fs, timeout=None):
+            fs_list = list(fs)
+            # Yield all but the last, then simulate the sub-ms clock overshoot
+            for f in fs_list[:-1]:
+                yield f
+            raise FuturesTimeoutError("sub-ms overshoot simulation")
+
+        with (
+            patch(
+                "src.services.consensus_voter._vote_openai",
+                return_value=_valid_vote("openai"),
+            ),
+            patch(
+                "src.services.consensus_voter._vote_gemini",
+                return_value=_valid_vote("gemini"),
+            ),
+            patch(
+                "src.services.consensus_voter._vote_claude",
+                return_value=_valid_vote("claude"),
+            ),
+            patch("src.services.consensus_voter.as_completed", fake_as_completed),
+        ):
+            result = voter.vote("prompt", {})
+
+        assert len(result.votes) == 3, (
+            "All 3 votes must be collected even when as_completed raises TimeoutError "
+            f"due to sub-ms overshoot; got {len(result.votes)}"
+        )
+        assert result.verdict == Verdict.VALID
+
+    def test_truly_timed_out_futures_get_timeout_vote(self):
+        """Futures that are genuinely not done when TimeoutError fires must receive
+        a timeout AIVote rather than being silently dropped."""
+        from concurrent.futures import Future, TimeoutError as FuturesTimeoutError
+
+        voter = ConsensusVoter()
+
+        # A future that will never complete (simulates genuine timeout)
+        stuck_future: Future = Future()
+
+        original_submit_calls: list = []
+
+        def fake_as_completed(fs, timeout=None):
+            fs_list = list(fs)
+            # Yield the first two, leave the third (stuck_future) pending
+            for f in fs_list[:-1]:
+                yield f
+            raise FuturesTimeoutError("genuine timeout simulation")
+
+        with (
+            patch(
+                "src.services.consensus_voter._vote_openai",
+                return_value=_valid_vote("openai"),
+            ),
+            patch(
+                "src.services.consensus_voter._vote_gemini",
+                return_value=_valid_vote("gemini"),
+            ),
+            patch(
+                "src.services.consensus_voter._vote_claude",
+                return_value=_valid_vote("claude"),
+            ),
+            patch("src.services.consensus_voter.as_completed", fake_as_completed),
+            patch(
+                "src.services.consensus_voter.ThreadPoolExecutor"
+            ) as mock_executor_cls,
+        ):
+            # Build 3 pre-resolved futures for the first 2 providers + stuck for the 3rd
+            done_f1: Future = Future()
+            done_f1.set_result(_valid_vote("openai"))
+            done_f2: Future = Future()
+            done_f2.set_result(_valid_vote("gemini"))
+
+            submit_returns = [done_f1, done_f2, stuck_future]
+            submit_idx = [0]
+
+            mock_executor = MagicMock()
+            mock_executor_cls.return_value.__enter__.return_value = mock_executor
+
+            def fake_submit(fn, *args, **kwargs):
+                f = submit_returns[submit_idx[0]]
+                submit_idx[0] += 1
+                return f
+
+            mock_executor.submit.side_effect = fake_submit
+
+            result = voter.vote("prompt", {})
+
+        assert len(result.votes) == 3, (
+            f"Expect 3 votes (2 valid + 1 timeout), got {len(result.votes)}"
+        )
+        timeout_votes = [v for v in result.votes if v.error and "timed out" in v.error]
+        assert len(timeout_votes) == 1, "Genuinely stuck future must produce a timeout vote"

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -602,9 +602,7 @@ class TestConsensusVoterSubmsTimeoutDrain:
                 return_value=_valid_vote("claude"),
             ),
             patch("src.services.consensus_voter.as_completed", fake_as_completed),
-            patch(
-                "src.services.consensus_voter.ThreadPoolExecutor"
-            ) as mock_executor_cls,
+            patch("src.services.consensus_voter.ThreadPoolExecutor") as mock_executor_cls,
         ):
             # Build 3 pre-resolved futures for the first 2 providers + stuck for the 3rd
             done_f1: Future = Future()
@@ -627,8 +625,8 @@ class TestConsensusVoterSubmsTimeoutDrain:
 
             result = voter.vote("prompt", {})
 
-        assert len(result.votes) == 3, (
-            f"Expect 3 votes (2 valid + 1 timeout), got {len(result.votes)}"
-        )
+        assert (
+            len(result.votes) == 3
+        ), f"Expect 3 votes (2 valid + 1 timeout), got {len(result.votes)}"
         timeout_votes = [v for v in result.votes if v.error and "timed out" in v.error]
         assert len(timeout_votes) == 1, "Genuinely stuck future must produce a timeout vote"


### PR DESCRIPTION
## Summary
- **#372** — `table_parser.py`: add `wiki_link != "No link"` and `startswith("https://")` guard at the `find_date_in_infobox` branch entry so rows with no Wikipedia link never reach `find_term_dates()`, eliminating the `MissingSchema` Sentry noise from daily_delta
- **#373** — `consensus_voter.py`: catch `FuturesTimeoutError` from `as_completed` and drain any futures that are already done before the timeout fired (sub-ms clock overshoot); genuinely pending futures still receive a timeout `AIVote`

## Test plan
- [ ] `test_find_date_in_infobox_skips_no_link_row` — verifies `find_term_dates` is never called for "No link" rows
- [ ] `TestConsensusVoterSubmsTimeoutDrain::test_done_futures_drained_after_timeout_overshoot` — verifies all 3 votes collected when `as_completed` raises `TimeoutError` but futures are done
- [ ] `TestConsensusVoterSubmsTimeoutDrain::test_truly_timed_out_futures_get_timeout_vote` — verifies genuinely stuck futures produce a timeout vote
- [ ] Full test suite passes (excluding pre-existing `test_auto_fix.py` missing-`anthropic` failure)

Closes #372
Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)