### PR TITLE
fix: add expire_stale_scheduled_job_runs() and wire into maintenance + lifespan startup

### DIFF
--- a/src/db/scheduled_job_runs.py
+++ b/src/db/scheduled_job_runs.py
@@ -117,6 +117,62 @@ def get_last_run_for_job(job_name: str, conn=None) -> dict | None:
             conn.close()
 
 
+def expire_stale_scheduled_job_runs(stale_hours: int = 4, conn=None) -> int:
+    """Mark scheduled_job_runs rows stuck in 'running' as 'error' if older than *stale_hours*.
+
+    Mirrors expire_stale_jobs() in scraper_jobs.py but targets the scheduled_job_runs table.
+    Returns the count of rows expired.
+    """
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(hours=stale_hours)
+        rows = conn.execute(
+            "SELECT id, started_at FROM scheduled_job_runs WHERE status = %s",
+            ("running",),
+        ).fetchall()
+
+        expired_ids = []
+        for row in rows:
+            run_id, started_at_raw = row[0], row[1]
+            if isinstance(started_at_raw, datetime):
+                started_at = (
+                    started_at_raw
+                    if started_at_raw.tzinfo
+                    else started_at_raw.replace(tzinfo=timezone.utc)
+                )
+            else:
+                try:
+                    started_at = datetime.strptime(started_at_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
+                        tzinfo=timezone.utc
+                    )
+                except (ValueError, TypeError):
+                    continue
+            if started_at < cutoff:
+                expired_ids.append(run_id)
+
+        for run_id in expired_ids:
+            conn.execute(
+                "UPDATE scheduled_job_runs SET status = %s,"
+                " error = %s, finished_at = %s"
+                " WHERE id = %s",
+                (
+                    "error",
+                    f"Expired by stale-run cleanup after >{stale_hours}h in running state",
+                    now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    run_id,
+                ),
+            )
+        if own_conn:
+            conn.commit()
+        return len(expired_ids)
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def list_recent_runs(days: int = 90, conn=None) -> list[dict]:
     """Return runs from the last *days* days, newest first."""
     own_conn = conn is None

--- a/src/db/test_scheduled_job_runs.py
+++ b/src/db/test_scheduled_job_runs.py
@@ -217,6 +217,83 @@ def test_get_last_run_for_job_reflects_status(db_path):
 
 
 # ---------------------------------------------------------------------------
+# expire_stale_scheduled_job_runs
+# ---------------------------------------------------------------------------
+
+
+def test_expire_stale_no_running_rows(db_path):
+    """Returns 0 when there are no running rows."""
+    count = db_runs.expire_stale_scheduled_job_runs(stale_hours=4)
+    assert count == 0
+
+
+def test_expire_stale_one_stale_row(db_path):
+    """A running row with started_at > 4 h ago is marked error and counted."""
+    run_id = db_runs.create_run("daily_delta")
+
+    # Backdate started_at to 5 hours ago
+    c = get_connection()
+    c.execute(
+        "UPDATE scheduled_job_runs SET started_at = %s WHERE id = %s",
+        ("2000-01-01T00:00:00Z", run_id),
+    )
+    c.commit()
+    c.close()
+
+    count = db_runs.expire_stale_scheduled_job_runs(stale_hours=4)
+    assert count == 1
+
+    c = get_connection()
+    row = c.execute(
+        "SELECT status, error FROM scheduled_job_runs WHERE id = %s", (run_id,)
+    ).fetchone()
+    c.close()
+    assert row[0] == "error"
+    assert row[1] is not None
+
+
+def test_expire_stale_multiple_stale_rows(db_path):
+    """All running rows older than the threshold are expired; count reflects all of them."""
+    id1 = db_runs.create_run("daily_delta")
+    id2 = db_runs.create_run("gemini_research")
+
+    c = get_connection()
+    for run_id in (id1, id2):
+        c.execute(
+            "UPDATE scheduled_job_runs SET started_at = %s WHERE id = %s",
+            ("2000-01-01T00:00:00Z", run_id),
+        )
+    c.commit()
+    c.close()
+
+    count = db_runs.expire_stale_scheduled_job_runs(stale_hours=4)
+    assert count >= 2
+
+    c = get_connection()
+    for run_id in (id1, id2):
+        row = c.execute("SELECT status FROM scheduled_job_runs WHERE id = %s", (run_id,)).fetchone()
+        assert row[0] == "error"
+    c.close()
+
+
+def test_expire_stale_fresh_running_row_not_touched(db_path):
+    """A running row started less than stale_hours ago must not be expired."""
+    run_id = db_runs.create_run("daily_delta")
+
+    count = db_runs.expire_stale_scheduled_job_runs(stale_hours=4)
+    # The fresh row must not be counted
+    assert count == 0
+
+    c = get_connection()
+    row = c.execute("SELECT status FROM scheduled_job_runs WHERE id = %s", (run_id,)).fetchone()
+    c.close()
+    assert row[0] == "running"
+
+    # Clean up so it doesn't pollute other tests
+    db_runs.finish_run(run_id, "complete")
+
+
+# ---------------------------------------------------------------------------
 # list_recent_runs
 # ---------------------------------------------------------------------------
 

--- a/src/main.py
+++ b/src/main.py
@@ -193,6 +193,17 @@ async def lifespan(app: FastAPI):
         f"[scheduler] Page quality inspection scheduled at {quality_h:02d}:{quality_m:02d} UTC"
     )
 
+    from src.db.scheduled_job_runs import expire_stale_scheduled_job_runs
+
+    expired_count = expire_stale_scheduled_job_runs()
+    if expired_count:
+        logger.warning(
+            "[startup] Cleared %d stale scheduled_job_runs row(s) left over from previous OOM kill",
+            expired_count,
+        )
+    else:
+        logger.info("[startup] No stale scheduled_job_runs rows found")
+
     scheduler.start()
     yield
     scheduler.shutdown(wait=False)

--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -242,6 +242,16 @@ def run_daily_maintenance() -> None:
     sentry_sdk.set_tag("scheduled_task", "daily_maintenance")
     _expire_stale_jobs_with_email()
 
+    from src.db.scheduled_job_runs import expire_stale_scheduled_job_runs
+
+    expired_count = expire_stale_scheduled_job_runs()
+    if expired_count:
+        logger.warning(
+            "daily_maintenance: expired %d stale scheduled_job_runs row(s)", expired_count
+        )
+    else:
+        logger.info("daily_maintenance: no stale scheduled_job_runs rows found")
+
 
 def run_daily_delta() -> None:
     """Entry point called by APScheduler at 06:00 UTC each day."""

--- a/src/test_scheduled_tasks.py
+++ b/src/test_scheduled_tasks.py
@@ -219,6 +219,7 @@ def test_run_daily_maintenance_always_calls_expiry(monkeypatch):
         "src.scheduled_tasks._expire_stale_jobs_with_email",
         lambda: called.__setitem__("expire", True),
     )
+    monkeypatch.setattr("src.db.scheduled_job_runs.expire_stale_scheduled_job_runs", lambda: 0)
 
     from src.scheduled_tasks import run_daily_maintenance
 

--- a/src/test_scheduled_tasks.py
+++ b/src/test_scheduled_tasks.py
@@ -237,12 +237,34 @@ def test_run_daily_maintenance_ignores_job_pause_state(monkeypatch):
 
     monkeypatch.setattr("src.db.scheduler_settings.is_job_paused", _should_not_check)
     monkeypatch.setattr("src.scheduled_tasks._expire_stale_jobs_with_email", lambda: None)
+    monkeypatch.setattr("src.db.scheduled_job_runs.expire_stale_scheduled_job_runs", lambda: 0)
 
     from src.scheduled_tasks import run_daily_maintenance
 
     run_daily_maintenance()
 
     assert not pause_checked["checked"]
+
+
+def test_run_daily_maintenance_calls_expire_stale_scheduled_job_runs(monkeypatch):
+    """run_daily_maintenance must call expire_stale_scheduled_job_runs() (#375)."""
+    monkeypatch.setattr("src.scheduled_tasks._expire_stale_jobs_with_email", lambda: None)
+
+    called = {"count": 0}
+
+    def fake_expire():
+        called["count"] += 1
+        return 0
+
+    monkeypatch.setattr("src.db.scheduled_job_runs.expire_stale_scheduled_job_runs", fake_expire)
+
+    from src.scheduled_tasks import run_daily_maintenance
+
+    run_daily_maintenance()
+
+    assert (
+        called["count"] == 1
+    ), "expire_stale_scheduled_job_runs must be called once by maintenance"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduled_job_runs.py
+++ b/tests/test_scheduled_job_runs.py
@@ -245,3 +245,108 @@ def test_run_daily_delta_finishes_with_error_on_crash(monkeypatch, tmp_path):
 
     assert len(finished) == 1
     assert finished[0] == (77, "error")
+
+
+# ---------------------------------------------------------------------------
+# expire_stale_scheduled_job_runs (#374)
+# ---------------------------------------------------------------------------
+
+
+class TestExpireStaleScheduledJobRuns:
+    def test_no_running_rows_returns_zero(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        assert sjr.expire_stale_scheduled_job_runs(stale_hours=4, conn=conn) == 0
+
+    def test_one_stale_row_marked_error(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        run_id = sjr.create_run("daily_delta", conn=conn)
+        conn.execute(
+            "UPDATE scheduled_job_runs SET started_at = %s WHERE id = %s",
+            ("2000-01-01T00:00:00Z", run_id),
+        )
+        conn.commit()
+
+        count = sjr.expire_stale_scheduled_job_runs(stale_hours=4, conn=conn)
+        assert count == 1
+
+        row = conn.execute(
+            "SELECT status, error FROM scheduled_job_runs WHERE id = %s", (run_id,)
+        ).fetchone()
+        assert row[0] == "error"
+        assert row[1] is not None
+
+    def test_multiple_stale_rows_all_expired(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        id1 = sjr.create_run("daily_delta", conn=conn)
+        id2 = sjr.create_run("gemini_research", conn=conn)
+        for run_id in (id1, id2):
+            conn.execute(
+                "UPDATE scheduled_job_runs SET started_at = %s WHERE id = %s",
+                ("2000-01-01T00:00:00Z", run_id),
+            )
+        conn.commit()
+
+        count = sjr.expire_stale_scheduled_job_runs(stale_hours=4, conn=conn)
+        assert count == 2
+        for run_id in (id1, id2):
+            row = conn.execute(
+                "SELECT status FROM scheduled_job_runs WHERE id = %s", (run_id,)
+            ).fetchone()
+            assert row[0] == "error"
+
+    def test_fresh_running_row_not_touched(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        run_id = sjr.create_run("daily_delta", conn=conn)
+
+        count = sjr.expire_stale_scheduled_job_runs(stale_hours=4, conn=conn)
+        assert count == 0
+
+        row = conn.execute(
+            "SELECT status FROM scheduled_job_runs WHERE id = %s", (run_id,)
+        ).fetchone()
+        assert row[0] == "running"
+
+    def test_stale_row_gets_finished_at(self, tmp_path):
+        conn = _make_conn(tmp_path)
+        run_id = sjr.create_run("daily_delta", conn=conn)
+        conn.execute(
+            "UPDATE scheduled_job_runs SET started_at = %s WHERE id = %s",
+            ("2000-01-01T00:00:00Z", run_id),
+        )
+        conn.commit()
+
+        sjr.expire_stale_scheduled_job_runs(stale_hours=4, conn=conn)
+        row = conn.execute(
+            "SELECT finished_at FROM scheduled_job_runs WHERE id = %s", (run_id,)
+        ).fetchone()
+        assert row[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# lifespan startup wiring (#376)
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_calls_expire_stale_scheduled_job_runs_on_startup(monkeypatch, tmp_path):
+    """expire_stale_scheduled_job_runs must be called during lifespan startup (#376)."""
+    calls = {"count": 0}
+
+    def fake_expire():
+        calls["count"] += 1
+        return 0
+
+    monkeypatch.setattr("src.db.scheduled_job_runs.expire_stale_scheduled_job_runs", fake_expire)
+    monkeypatch.setattr("src.main.init_db", lambda: None)
+    monkeypatch.setattr("src.main.AsyncIOScheduler", MagicMock())
+    monkeypatch.setattr("src.db.app_settings.get_setting", lambda key, default=None: default)
+
+    import asyncio
+    from src.main import lifespan, app
+
+    async def _run():
+        async with lifespan(app):
+            pass
+
+    asyncio.run(_run())
+
+    assert calls["count"] == 1, "expire_stale_scheduled_job_runs must be called once at startup"


### PR DESCRIPTION
## Summary
- **#374** — `scheduled_job_runs.py`: adds `expire_stale_scheduled_job_runs()` — marks rows stuck in `status='running'` for >4 hours as `status='error'`; mirrors `expire_stale_jobs()` from `scraper_jobs.py`
- **#375** — `scheduled_tasks.py`: calls `expire_stale_scheduled_job_runs()` inside `run_daily_maintenance()` (05:30 UTC), cleaning up stale rows from overnight OOM kills before the day's jobs start
- **#376** — `main.py`: calls `expire_stale_scheduled_job_runs()` during lifespan startup so stale rows are cleared immediately on the next deploy, not waiting up to 23.5 h

## Test plan
- [ ] `TestExpireStaleScheduledJobRuns` (5 tests): no rows, one stale, multiple stale, fresh not touched, finished_at set
- [ ] `test_expire_stale_*` (4 tests) in `src/db/test_scheduled_job_runs.py`: same coverage via SQLite in-memory fixture
- [ ] `test_run_daily_maintenance_calls_expire_stale_scheduled_job_runs` — verifies #375 wiring
- [ ] `test_run_daily_maintenance_ignores_job_pause_state` — updated to patch new call
- [ ] `test_lifespan_calls_expire_stale_scheduled_job_runs_on_startup` — verifies #376 wiring

Closes #374
Closes #375
Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)