### PR TITLE
fix: add linear scheduling guard to prevent overlapping scheduled job runs

### DIFF
--- a/src/db/scheduled_job_runs.py
+++ b/src/db/scheduled_job_runs.py
@@ -117,6 +117,28 @@ def get_last_run_for_job(job_name: str, conn=None) -> dict | None:
             conn.close()
 
 
+def count_active_scheduled_runs(active_hours: int = 4, conn=None) -> int:
+    """Return the number of rows with status='running' started within *active_hours*.
+
+    Used by the linear scheduling guard to detect concurrent job invocations.
+    """
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=active_hours)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        row = conn.execute(
+            "SELECT COUNT(*) FROM scheduled_job_runs" " WHERE status = %s AND started_at >= %s",
+            ("running", cutoff),
+        ).fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        if own_conn:
+            conn.close()
+
+
 def expire_stale_scheduled_job_runs(stale_hours: int = 4, conn=None) -> int:
     """Mark scheduled_job_runs rows stuck in 'running' as 'error' if older than *stale_hours*.
 

--- a/src/db/test_scheduled_job_runs.py
+++ b/src/db/test_scheduled_job_runs.py
@@ -217,14 +217,76 @@ def test_get_last_run_for_job_reflects_status(db_path):
 
 
 # ---------------------------------------------------------------------------
+# count_active_scheduled_runs  (use fresh conn to avoid shared-DB pollution)
+# ---------------------------------------------------------------------------
+
+
+def _fresh_conn(tmp_path_factory):
+    """Return a fresh in-memory-style SQLite conn with the scheduled_job_runs table."""
+    import sqlite3
+    from src.db.connection import _SQLiteConnWrapper
+
+    raw = sqlite3.connect(":memory:")
+    raw.row_factory = sqlite3.Row
+    conn = _SQLiteConnWrapper(raw)
+    conn.executescript("""
+        CREATE TABLE scheduled_job_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_name TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            status TEXT NOT NULL DEFAULT 'running',
+            duration_s REAL,
+            result_json TEXT,
+            error TEXT
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def test_count_active_no_rows(tmp_path_factory):
+    """Returns 0 when no running rows exist."""
+    conn = _fresh_conn(tmp_path_factory)
+    assert db_runs.count_active_scheduled_runs(conn=conn) == 0
+
+
+def test_count_active_counts_fresh_running_row(tmp_path_factory):
+    """A just-started running row is counted."""
+    conn = _fresh_conn(tmp_path_factory)
+    db_runs.create_run("daily_delta", conn=conn)
+    assert db_runs.count_active_scheduled_runs(active_hours=4, conn=conn) >= 1
+
+
+def test_count_active_ignores_stale_running_row(tmp_path_factory):
+    """A running row started >active_hours ago is not counted."""
+    conn = _fresh_conn(tmp_path_factory)
+    run_id = db_runs.create_run("daily_delta", conn=conn)
+    conn.execute(
+        "UPDATE scheduled_job_runs SET started_at = %s WHERE id = %s",
+        ("2000-01-01T00:00:00Z", run_id),
+    )
+    conn.commit()
+    assert db_runs.count_active_scheduled_runs(active_hours=4, conn=conn) == 0
+
+
+def test_count_active_ignores_completed_rows(tmp_path_factory):
+    """Rows with status='complete' or 'error' are not counted."""
+    conn = _fresh_conn(tmp_path_factory)
+    run_id = db_runs.create_run("daily_delta", conn=conn)
+    db_runs.finish_run(run_id, "complete", conn=conn)
+    assert db_runs.count_active_scheduled_runs(active_hours=4, conn=conn) == 0
+
+
+# ---------------------------------------------------------------------------
 # expire_stale_scheduled_job_runs
 # ---------------------------------------------------------------------------
 
 
-def test_expire_stale_no_running_rows(db_path):
+def test_expire_stale_no_running_rows(tmp_path_factory):
     """Returns 0 when there are no running rows."""
-    count = db_runs.expire_stale_scheduled_job_runs(stale_hours=4)
-    assert count == 0
+    conn = _fresh_conn(tmp_path_factory)
+    assert db_runs.expire_stale_scheduled_job_runs(stale_hours=4, conn=conn) == 0
 
 
 def test_expire_stale_one_stale_row(db_path):

--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -146,6 +146,38 @@ except Exception as _exc:
     return parsed
 
 
+def _has_active_scheduled_run(job_name: str) -> bool:
+    """Return True if another scheduled job is currently running (started within 4 h).
+
+    Used as a linear scheduling guard: if any row in scheduled_job_runs has
+    status='running' and started_at within the last 4 hours, the calling job
+    should skip its invocation to prevent concurrent runs.
+
+    Re-entrancy safe: a job's own row does not exist yet when this guard fires
+    (create_run is called after the guard), so there is no risk of a job
+    blocking itself via its own row.
+    """
+    try:
+        from src.db.scheduled_job_runs import count_active_scheduled_runs
+
+        active = count_active_scheduled_runs()
+        if active > 0:
+            logger.warning(
+                "%s skipped: %d other scheduled job(s) running (linear scheduling guard)",
+                job_name,
+                active,
+            )
+            return True
+        return False
+    except Exception as exc:
+        logger.warning(
+            "Could not check for overlapping scheduled runs (%s), proceeding (non-fatal): %s",
+            job_name,
+            exc,
+        )
+        return False
+
+
 def _expire_stale_jobs_with_email() -> None:
     """Expire stale jobs and send an email notification for each expired job.
 
@@ -286,6 +318,9 @@ def run_daily_delta() -> None:
     except Exception as e:
         logger.warning("Could not check active jobs (non-fatal): %s", e)
 
+    if _has_active_scheduled_run("daily_delta"):
+        return
+
     from src.scraper.runner import _cleanup_disk_cache
 
     run_start = datetime.now(timezone.utc)
@@ -415,6 +450,9 @@ def run_daily_insufficient_vitals() -> None:
     except Exception as e:
         logger.warning("Could not check active jobs (non-fatal): %s", e)
 
+    if _has_active_scheduled_run("insufficient_vitals"):
+        return
+
     run_start = datetime.now(timezone.utc)
     today_batch = run_start.day % 30
     logger.info(
@@ -474,6 +512,9 @@ def run_daily_gemini_research() -> None:
     except Exception as e:
         logger.warning("Could not check active jobs (non-fatal): %s", e)
 
+    if _has_active_scheduled_run("gemini_research"):
+        return
+
     run_start = datetime.now(timezone.utc)
     today_batch = run_start.day % 30
     logger.info(
@@ -528,6 +569,9 @@ def run_daily_page_quality() -> None:
             return
     except Exception as e:
         logger.warning("Could not check pause state for daily_page_quality (non-fatal): %s", e)
+
+    if _has_active_scheduled_run("daily_page_quality"):
+        return
 
     run_start = datetime.now(timezone.utc)
     logger.info(

--- a/src/test_scheduled_tasks.py
+++ b/src/test_scheduled_tasks.py
@@ -113,6 +113,7 @@ def test_run_daily_delta_sends_crash_email_on_exception(monkeypatch):
     monkeypatch.setattr("src.scheduled_tasks._run_daily_delta_in_subprocess", _explode)
     monkeypatch.setattr("src.db.scheduled_job_runs.create_run", lambda *a, **kw: 1)
     monkeypatch.setattr("src.db.scheduled_job_runs.finish_run", lambda *a, **kw: None)
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
 
     from src.scheduled_tasks import run_daily_delta
 
@@ -163,6 +164,8 @@ def test_run_daily_delta_skips_when_active_job_running(monkeypatch):
     monkeypatch.setattr("src.db.scheduler_settings.is_job_paused", lambda *a, **kw: False)
     monkeypatch.setattr("src.db.scraper_jobs.count_active_jobs", lambda: 1)
     monkeypatch.setattr("src.scheduled_tasks._expire_stale_jobs_with_email", lambda: None)
+    # count_active_jobs returns 1 → guard is never reached; patch anyway for safety
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
 
     called = {"subprocess": False}
 
@@ -195,6 +198,8 @@ def test_run_daily_delta_calls_expire_before_active_check(monkeypatch):
         "src.db.scraper_jobs.count_active_jobs",
         lambda: call_order.append("count") or 1,
     )
+    # count_active_jobs returns 1 → guard is never reached; patch anyway for safety
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
 
     from src.scheduled_tasks import run_daily_delta
 
@@ -269,6 +274,129 @@ def test_run_daily_maintenance_calls_expire_stale_scheduled_job_runs(monkeypatch
 
 
 # ---------------------------------------------------------------------------
+# _has_active_scheduled_run / linear scheduling guard (#378)
+# ---------------------------------------------------------------------------
+
+
+def _patch_job_base(monkeypatch, job_name: str) -> None:
+    """Patch the common prereqs so a job handler can reach the guard."""
+    monkeypatch.setenv("RUNNERS_ENABLED", "1")
+    monkeypatch.setattr("src.db.scheduler_settings.is_job_paused", lambda *a, **kw: False)
+    monkeypatch.setattr("src.scheduled_tasks._expire_stale_jobs_with_email", lambda: None)
+    # Prevent the scraper_jobs active-jobs check from hitting a real DB
+    monkeypatch.setattr("src.db.scraper_jobs.count_active_jobs", lambda: 0, raising=False)
+
+
+def test_guard_skips_daily_delta_when_another_run_active(monkeypatch):
+    """run_daily_delta must not start a new run when another scheduled job is running."""
+    _patch_job_base(monkeypatch, "daily_delta")
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 1)
+    create_called = {"n": 0}
+    monkeypatch.setattr(
+        "src.db.scheduled_job_runs.create_run",
+        lambda *a, **kw: create_called.__setitem__("n", create_called["n"] + 1) or 1,
+    )
+
+    from src.scheduled_tasks import run_daily_delta
+
+    run_daily_delta()
+    assert create_called["n"] == 0, "create_run must not be called when guard fires"
+
+
+def test_guard_proceeds_daily_delta_when_no_active_run(monkeypatch):
+    """run_daily_delta must proceed normally when no other scheduled job is running."""
+    _patch_job_base(monkeypatch, "daily_delta")
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
+    monkeypatch.setattr("src.db.scheduled_job_runs.create_run", lambda *a, **kw: 99)
+    monkeypatch.setattr("src.db.scheduled_job_runs.finish_run", lambda *a, **kw: None)
+    monkeypatch.setattr("src.scraper.runner._cleanup_disk_cache", lambda **_: 0)
+    monkeypatch.setattr(
+        "src.db.scraper_jobs.delete_jobs_older_than", lambda hours: 0, raising=False
+    )
+    monkeypatch.setattr(
+        "src.scheduled_tasks._run_daily_delta_in_subprocess",
+        lambda today_batch: {"offices_updated": 0},
+    )
+
+    from src.scheduled_tasks import run_daily_delta
+
+    run_daily_delta()  # must not raise; subprocess mock returns cleanly
+
+
+def test_guard_skips_insufficient_vitals_when_another_run_active(monkeypatch):
+    """run_daily_insufficient_vitals must skip when another scheduled job is running."""
+    _patch_job_base(monkeypatch, "insufficient_vitals")
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 1)
+    create_called = {"n": 0}
+    monkeypatch.setattr(
+        "src.db.scheduled_job_runs.create_run",
+        lambda *a, **kw: create_called.__setitem__("n", create_called["n"] + 1) or 1,
+    )
+
+    from src.scheduled_tasks import run_daily_insufficient_vitals
+
+    run_daily_insufficient_vitals()
+    assert create_called["n"] == 0
+
+
+def test_guard_skips_gemini_research_when_another_run_active(monkeypatch):
+    """run_daily_gemini_research must skip when another scheduled job is running."""
+    _patch_job_base(monkeypatch, "gemini_research")
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 1)
+    create_called = {"n": 0}
+    monkeypatch.setattr(
+        "src.db.scheduled_job_runs.create_run",
+        lambda *a, **kw: create_called.__setitem__("n", create_called["n"] + 1) or 1,
+    )
+
+    from src.scheduled_tasks import run_daily_gemini_research
+
+    run_daily_gemini_research()
+    assert create_called["n"] == 0
+
+
+def test_guard_skips_page_quality_when_another_run_active(monkeypatch):
+    """run_daily_page_quality must skip when another scheduled job is running."""
+    monkeypatch.setenv("RUNNERS_ENABLED", "1")
+    monkeypatch.setattr("src.db.scheduler_settings.is_job_paused", lambda *a, **kw: False)
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 1)
+    create_called = {"n": 0}
+    monkeypatch.setattr(
+        "src.db.scheduled_job_runs.create_run",
+        lambda *a, **kw: create_called.__setitem__("n", create_called["n"] + 1) or 1,
+    )
+
+    from src.scheduled_tasks import run_daily_page_quality
+
+    run_daily_page_quality()
+    assert create_called["n"] == 0
+
+
+def test_guard_db_error_does_not_block_job(monkeypatch):
+    """If count_active_scheduled_runs raises, the guard must not block the job (non-fatal)."""
+    _patch_job_base(monkeypatch, "daily_delta")
+
+    def _raise(**kw):
+        raise RuntimeError("DB unavailable")
+
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", _raise)
+    monkeypatch.setattr("src.db.scheduled_job_runs.create_run", lambda *a, **kw: 99)
+    monkeypatch.setattr("src.db.scheduled_job_runs.finish_run", lambda *a, **kw: None)
+    monkeypatch.setattr("src.scraper.runner._cleanup_disk_cache", lambda **_: 0)
+    monkeypatch.setattr(
+        "src.db.scraper_jobs.delete_jobs_older_than", lambda hours: 0, raising=False
+    )
+    monkeypatch.setattr(
+        "src.scheduled_tasks._run_daily_delta_in_subprocess",
+        lambda today_batch: {"offices_updated": 0},
+    )
+
+    from src.scheduled_tasks import run_daily_delta
+
+    run_daily_delta()  # must not raise; DB error is non-fatal
+
+
+# ---------------------------------------------------------------------------
 # run_daily_page_quality
 # ---------------------------------------------------------------------------
 
@@ -277,6 +405,7 @@ def _patch_page_quality_deps(monkeypatch, inspect_side_effect):
     """Patch all DB/external deps for run_daily_page_quality tests."""
     monkeypatch.setenv("RUNNERS_ENABLED", "1")
     monkeypatch.setattr("src.db.scheduler_settings.is_job_paused", lambda *a, **kw: False)
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
     monkeypatch.setattr("src.db.scheduled_job_runs.create_run", lambda *a, **kw: 1)
     monkeypatch.setattr("src.db.scheduled_job_runs.finish_run", lambda *a, **kw: None)
     monkeypatch.setattr("src.services.page_quality_inspector.inspect_one_page", inspect_side_effect)
@@ -289,6 +418,7 @@ def test_run_daily_page_quality_records_run_in_db(monkeypatch):
 
     monkeypatch.setenv("RUNNERS_ENABLED", "1")
     monkeypatch.setattr("src.db.scheduler_settings.is_job_paused", lambda *a, **kw: False)
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
     monkeypatch.setattr(
         "src.db.scheduled_job_runs.create_run",
         lambda job_id, **kw: create_calls.append(job_id) or 1,

--- a/tests/test_scheduled_job_runs.py
+++ b/tests/test_scheduled_job_runs.py
@@ -189,6 +189,7 @@ def test_run_daily_delta_calls_create_and_finish_run(monkeypatch, tmp_path):
     )
     monkeypatch.setattr("src.db.scheduled_job_runs.create_run", _fake_create_run)
     monkeypatch.setattr("src.db.scheduled_job_runs.finish_run", _fake_finish_run)
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
 
     # Stub out the DB helpers that run_daily_delta also calls
     monkeypatch.setattr("src.scraper.runner._cleanup_disk_cache", lambda **_: 0)
@@ -229,6 +230,7 @@ def test_run_daily_delta_finishes_with_error_on_crash(monkeypatch, tmp_path):
     monkeypatch.setattr("src.scheduled_tasks._run_daily_delta_in_subprocess", _crash)
     monkeypatch.setattr("src.db.scheduled_job_runs.create_run", _fake_create_run)
     monkeypatch.setattr("src.db.scheduled_job_runs.finish_run", _fake_finish_run)
+    monkeypatch.setattr("src.db.scheduled_job_runs.count_active_scheduled_runs", lambda **kw: 0)
     monkeypatch.setattr("src.scraper.runner._cleanup_disk_cache", lambda **_: 0)
 
     try:


### PR DESCRIPTION
## Summary
- **#378** — adds `count_active_scheduled_runs()` to `scheduled_job_runs.py` (queries for any `status='running'` row started within 4 hours)
- Adds `_has_active_scheduled_run(job_name)` helper to `scheduled_tasks.py` — non-fatal if DB is unavailable
- Wires the guard into all four daily job handlers (`run_daily_delta`, `run_daily_insufficient_vitals`, `run_daily_gemini_research`, `run_daily_page_quality`) before `create_run()` is called

If another scheduled job is already running, the invoking job logs a warning and returns early. Re-entrancy safe: a job's own row doesn't exist yet at guard time.

## Test plan
- [ ] `test_count_active_*` (4 tests) — no rows, fresh running row counted, stale row ignored, completed row ignored
- [ ] `test_guard_skips_*_when_another_run_active` (4 tests) — one per job handler; verifies `create_run` is never called
- [ ] `test_guard_proceeds_daily_delta_when_no_active_run` — happy path proceeds normally
- [ ] `test_guard_db_error_does_not_block_job` — DB failure in guard is non-fatal
- [ ] All existing scheduled_tasks tests updated to patch new `count_active_scheduled_runs` call

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)