### PR TITLE
fix: remove service-id input from deploy and hardcode ZAP URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,5 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-deploy-render.yml@main
     with:
       service-name: 'office-holder-cursor'
-      service-id: 'srv-d6ubbu24d50c73cpmgkg'
       zap-target-url: 'https://rulersai.buffingchi.com'
     secrets: inherit

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -10,6 +10,6 @@ jobs:
   zap-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
     with:
-      target-url: ${{ secrets.SITE_URL }}
+      target-url: 'https://rulersai.buffingchi.com'
       artifact-name: 'zap-weekly-office-holder'
     secrets: inherit


### PR DESCRIPTION
## Summary
- `deploy.yml` was still passing `service-id` as a `with:` input after wcmchenry3-stack/.github#54 moved it to a secret in the called workflow. GitHub rejects unknown inputs → "workflow file issue" on every deploy trigger.
  - Fix: remove `service-id` from `with:` block. The called workflow now reads from the `RENDER_SERVICE_ID` repo secret (must be set — see note below).
- `zap-scan.yml` was using `${{ secrets.SITE_URL }}` as the `target-url` input. Secrets can't be evaluated in `with:` for reusable workflow calls → empty string fails required input validation on every push.
  - Fix: hardcode the known URL (`https://rulersai.buffingchi.com`).

## Action required
Set the `RENDER_SERVICE_ID` repository secret to `srv-d6ubbu24d50c73cpmgkg` if not already set.

## Test plan
- [ ] `RENDER_SERVICE_ID` secret is set in this repo
- [ ] Deploy workflow runs successfully on next push to `main`
- [ ] No ZAP scan file validation failures on next push

Closes wcmchenry3-stack/.github#55

🤖 Generated with [Claude Code](https://claude.com/claude-code)