### PR TITLE
bug: strip Claude code-fenced JSON and fix is_valid=True parse fallback

### DIFF
--- a/src/services/claude_client.py
+++ b/src/services/claude_client.py
@@ -121,8 +121,13 @@ class ClaudeClient:
 
     def check_data_quality(
         self, prompt: str, context: dict, system_prompt: str | None = None
-    ) -> DataQualityResult:
-        """Assess data quality for a record or page. Returns structured result.
+    ) -> DataQualityResult | None:
+        """Assess data quality for a record or page. Returns structured result or None.
+
+        Returns None when the response cannot be parsed (e.g. Claude wraps JSON in
+        code fences and stripping still leaves unparseable text).  The caller
+        (_vote_claude in consensus_voter.py) treats None as provider unavailable and
+        excludes it from quorum rather than defaulting to is_valid=True.
 
         Args:
             system_prompt: Override the default individual-record system prompt.
@@ -134,7 +139,7 @@ class ClaudeClient:
             return self._call_claude(user_prompt, system_prompt=system_prompt or _SYSTEM_PROMPT)
         except Exception:
             logger.exception("Claude data quality check failed")
-            return DataQualityResult(is_valid=True, concerns=[], confidence="low")
+            return None
 
     def _build_prompt(self, prompt: str, context: dict) -> str:
         lines = [prompt]
@@ -146,10 +151,11 @@ class ClaudeClient:
 
     def _call_claude(
         self, user_prompt: str, system_prompt: str = _SYSTEM_PROMPT
-    ) -> DataQualityResult:
+    ) -> DataQualityResult | None:
         """Call Claude with exponential backoff on rate limit (HTTP 429).
 
         Retries up to 3 times, doubling the backoff delay each attempt (1 s → 2 s → 4 s).
+        Returns None when the response cannot be parsed (caller excludes from quorum).
         """
         import anthropic
 
@@ -181,14 +187,24 @@ class ClaudeClient:
                 backoff *= 2
         raise RuntimeError("unreachable")
 
-    def _parse_response(self, response) -> DataQualityResult:
-        """Parse Claude JSON response into DataQualityResult."""
+    def _parse_response(self, response) -> DataQualityResult | None:
+        """Parse Claude JSON response into DataQualityResult, or None on parse failure.
+
+        Claude sometimes wraps its JSON in markdown code fences (```json ... ```).
+        Strip them before parsing so the response is usable.  On any remaining
+        parse failure return None so the caller can exclude this provider from
+        quorum instead of defaulting to is_valid=True.
+        """
+        import re
+
         text = response.content[0].text if response.content else ""
+        # Strip optional markdown code fences: ```json ... ``` or ``` ... ```
+        stripped = re.sub(r"^```(?:json)?\s*|\s*```$", "", text.strip(), flags=re.MULTILINE)
         try:
-            data = json.loads(text)
+            data = json.loads(stripped)
         except json.JSONDecodeError:
             logger.warning("Claude returned non-JSON response: %s", text[:200])
-            return DataQualityResult(is_valid=True, concerns=[], confidence="low")
+            return None
 
         return DataQualityResult(
             is_valid=data.get("is_valid", True),

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -83,7 +83,9 @@ _SYSTEM_PROMPT = (
     "You are a data quality analyst for a political office holders database. "
     "Assess the provided record or page data and return JSON with these fields: "
     '{"is_valid": bool, "concerns": [str], "confidence": "high"|"medium"|"low"}. '
-    "is_valid is true if the data appears correct and accurate."
+    "is_valid is true if the data appears correct and accurate. "
+    "IMPORTANT: A record where full_name is a 4-digit year (e.g. '1999', '2006') "
+    "is NEVER a valid person name — always return is_valid=false with high confidence."
 )
 
 # ---------------------------------------------------------------------------
@@ -173,6 +175,8 @@ def _vote_claude(prompt: str, context: dict) -> AIVote:
             return AIVote(provider="claude", is_valid=None, error="client not configured")
 
         result = client.check_data_quality(prompt, context, system_prompt=_SYSTEM_PROMPT)
+        if result is None:
+            return AIVote(provider="claude", is_valid=None, error="parse error")
         return AIVote(
             provider="claude",
             is_valid=result.is_valid,

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -99,7 +99,11 @@ class TestClaudeStructuredOutput:
         """Claude sometimes wraps its JSON in ```json ... ``` — must be stripped."""
         from src.services.claude_client import ClaudeClient
 
-        fenced = "```json\n" + json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"}) + "\n```"
+        fenced = (
+            "```json\n"
+            + json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"})
+            + "\n```"
+        )
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text=fenced)]
 
@@ -118,7 +122,11 @@ class TestClaudeStructuredOutput:
         """Strip ``` fences with no language tag."""
         from src.services.claude_client import ClaudeClient
 
-        fenced = "```\n" + json.dumps({"is_valid": True, "concerns": [], "confidence": "medium"}) + "\n```"
+        fenced = (
+            "```\n"
+            + json.dumps({"is_valid": True, "concerns": [], "confidence": "medium"})
+            + "\n```"
+        )
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text=fenced)]
 

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -95,7 +95,44 @@ class TestClaudeStructuredOutput:
         assert "Birth date after death date" in result.concerns
         assert result.confidence == "high"
 
-    def test_non_json_response_returns_default(self):
+    def test_code_fenced_json_is_parsed_correctly(self):
+        """Claude sometimes wraps its JSON in ```json ... ``` — must be stripped."""
+        from src.services.claude_client import ClaudeClient
+
+        fenced = "```json\n" + json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"}) + "\n```"
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=fenced)]
+
+        with patch("anthropic.Anthropic") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.messages.create.return_value = mock_response
+            client = ClaudeClient(api_key="test")
+            result = client.check_data_quality("Check this record", {})
+
+        assert result is not None
+        assert result.is_valid is False
+        assert result.concerns == ["year as name"]
+        assert result.confidence == "high"
+
+    def test_code_fenced_json_no_language_tag(self):
+        """Strip ``` fences with no language tag."""
+        from src.services.claude_client import ClaudeClient
+
+        fenced = "```\n" + json.dumps({"is_valid": True, "concerns": [], "confidence": "medium"}) + "\n```"
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=fenced)]
+
+        with patch("anthropic.Anthropic") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.messages.create.return_value = mock_response
+            client = ClaudeClient(api_key="test")
+            result = client.check_data_quality("Check this record", {})
+
+        assert result is not None
+        assert result.is_valid is True
+
+    def test_non_json_response_returns_none(self):
+        """Unparseable response returns None so caller excludes provider from quorum."""
         from src.services.claude_client import ClaudeClient
 
         mock_response = MagicMock()
@@ -107,9 +144,7 @@ class TestClaudeStructuredOutput:
             client = ClaudeClient(api_key="test")
             result = client.check_data_quality("Check this record", {})
 
-        assert result.is_valid is True
-        assert result.concerns == []
-        assert result.confidence == "low"
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -439,6 +439,23 @@ class TestVoteClaude:
         assert vote.is_valid is False
         assert "suspicious" in vote.concerns
 
+    def test_none_result_returns_parse_error_unavailable(self):
+        """When check_data_quality returns None (e.g. code-fenced JSON that still
+        fails to parse), _vote_claude must return is_valid=None so the provider
+        is excluded from quorum rather than voting 'valid'."""
+        from src.services.consensus_voter import _vote_claude
+
+        mock_client = MagicMock()
+        mock_client.check_data_quality.return_value = None
+        with patch(
+            "src.services.claude_client.get_claude_client",
+            return_value=mock_client,
+        ):
+            vote = _vote_claude("prompt", {})
+        assert vote.provider == "claude"
+        assert vote.is_valid is None
+        assert vote.error == "parse error"
+
 
 # ---------------------------------------------------------------------------
 # Vote ordering is deterministic
@@ -470,6 +487,20 @@ class TestVoteOrdering:
 # ---------------------------------------------------------------------------
 # System prompt alignment — Claude and Gemini must receive _SYSTEM_PROMPT
 # ---------------------------------------------------------------------------
+
+
+class TestSystemPromptContent:
+    def test_system_prompt_contains_year_as_name_directive(self):
+        """_SYSTEM_PROMPT must explicitly instruct providers to reject year-as-name
+        records. Regression guard for Issue #398."""
+        from src.services.consensus_voter import _SYSTEM_PROMPT
+
+        assert "4-digit year" in _SYSTEM_PROMPT, (
+            "_SYSTEM_PROMPT must contain explicit year-as-name rejection rule"
+        )
+        assert "is_valid=false" in _SYSTEM_PROMPT, (
+            "_SYSTEM_PROMPT must explicitly say to return is_valid=false for year-as-name"
+        )
 
 
 class TestSystemPromptAlignment:

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -495,12 +495,12 @@ class TestSystemPromptContent:
         records. Regression guard for Issue #398."""
         from src.services.consensus_voter import _SYSTEM_PROMPT
 
-        assert "4-digit year" in _SYSTEM_PROMPT, (
-            "_SYSTEM_PROMPT must contain explicit year-as-name rejection rule"
-        )
-        assert "is_valid=false" in _SYSTEM_PROMPT, (
-            "_SYSTEM_PROMPT must explicitly say to return is_valid=false for year-as-name"
-        )
+        assert (
+            "4-digit year" in _SYSTEM_PROMPT
+        ), "_SYSTEM_PROMPT must contain explicit year-as-name rejection rule"
+        assert (
+            "is_valid=false" in _SYSTEM_PROMPT
+        ), "_SYSTEM_PROMPT must explicitly say to return is_valid=false for year-as-name"
 
 
 class TestSystemPromptAlignment:


### PR DESCRIPTION
## Summary

Closes #398.

Claude frequently wraps its JSON in ` ```json ... ``` ` markdown fences. `json.loads()` failed on these, and the fallback at `claude_client.py:_parse_response()` returned `DataQualityResult(is_valid=True)` — making Claude vote **"valid"** on every suspect record where this happened. This caused false `DISAGREEMENT` verdicts against Gemini and OpenAI, which correctly identified year-as-name records (e.g. `'1999'`, `'2006'`) as invalid, triggering spurious GitHub issues #388–#395.

- **Strip code fences** before `json.loads()` in `_parse_response()`
- **Return `None` on parse failure** (instead of `is_valid=True`) so `_vote_claude()` returns `AIVote(is_valid=None, error="parse error")` — provider excluded from quorum, not injecting a wrong vote
- **Propagate `None`** through `_call_claude()` and `check_data_quality()`
- **Update `_SYSTEM_PROMPT`** with explicit directive: a 4-digit year as `full_name` is NEVER valid

## Test plan

- [ ] `tests/test_claude_client.py` — code-fenced JSON parsed correctly; non-JSON returns `None`
- [ ] `tests/test_consensus_voter.py` — `_vote_claude` with `None` result returns `AIVote(is_valid=None, error="parse error")`; system prompt asserted to contain year directive
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)