### PR TITLE
bug: handle truncated JSON in Gemini check_data_quality

### DIFF
--- a/src/services/gemini_vitals_researcher.py
+++ b/src/services/gemini_vitals_researcher.py
@@ -318,14 +318,22 @@ class GeminiVitalsResearcher:
                     ],
                     config=types.GenerateContentConfig(
                         system_instruction=system_prompt or _default_instruction,
-                        max_output_tokens=512,
+                        max_output_tokens=1024,
                         response_mime_type="application/json",
                     ),
                 )
                 import json
 
                 text = response.text or ""
-                return json.loads(text)
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "check_data_quality: Gemini returned unparseable JSON (len=%d): %s",
+                        len(text),
+                        text[:120],
+                    )
+                    return None
             except errors.ClientError as exc:
                 if getattr(exc, "code", 0) == 429 or "RESOURCE_EXHAUSTED" in str(exc):
                     if attempt == 2:

--- a/tests/test_gemini_vitals_researcher.py
+++ b/tests/test_gemini_vitals_researcher.py
@@ -502,3 +502,65 @@ class TestPolicyCompliance:
         service_path = Path("src/services/gemini_vitals_researcher.py")
         content = service_path.read_text()
         assert "max_output_tokens" in content
+
+
+# ---------------------------------------------------------------------------
+# check_data_quality — truncated / unparseable JSON handling (#399)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDataQuality:
+    """check_data_quality must return None on JSONDecodeError rather than raising,
+    so _vote_gemini in consensus_voter.py treats Gemini as unavailable instead of
+    propagating an exception."""
+
+    def _make_researcher(self, response_text: str):
+        """Return a GeminiVitalsResearcher with a mocked Gemini client."""
+        from src.services.gemini_vitals_researcher import GeminiVitalsResearcher
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = response_text
+        mock_client.models.generate_content.return_value = mock_response
+
+        researcher = GeminiVitalsResearcher.__new__(GeminiVitalsResearcher)
+        researcher._client = mock_client
+        researcher._model = "gemini-test"
+        return researcher
+
+    def test_valid_json_returned(self):
+        researcher = self._make_researcher(
+            json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"})
+        )
+        result = researcher.check_data_quality("some prompt")
+        assert result is not None
+        assert result["is_valid"] is False
+        assert result["concerns"] == ["year as name"]
+
+    def test_truncated_json_returns_none(self):
+        """Gemini occasionally returns truncated JSON (e.g. cut off at 25 chars).
+        check_data_quality must return None rather than raising JSONDecodeError."""
+        researcher = self._make_researcher('{"is_val')
+        result = researcher.check_data_quality("some prompt")
+        assert result is None
+
+    def test_empty_response_returns_none(self):
+        researcher = self._make_researcher("")
+        result = researcher.check_data_quality("some prompt")
+        assert result is None
+
+    def test_max_output_tokens_1024_for_data_quality(self):
+        """data quality calls must use max_output_tokens=1024 (raised from 512)
+        to prevent truncation. Regression guard for Issue #399."""
+        researcher = self._make_researcher(
+            json.dumps({"is_valid": True, "concerns": [], "confidence": "low"})
+        )
+        researcher.check_data_quality("some prompt")
+        call_args = researcher._client.models.generate_content.call_args
+        config = call_args.kwargs.get("config") or (
+            call_args.args[1] if len(call_args.args) > 1 else None
+        )
+        assert config is not None
+        assert (
+            config.max_output_tokens == 1024
+        ), "max_output_tokens must be 1024 for data quality checks to avoid truncation"


### PR DESCRIPTION
## Summary
- Wraps `json.loads()` in `try/except JSONDecodeError` in `check_data_quality()` — returns `None` on parse failure so `_vote_gemini()` excludes Gemini from quorum rather than raising an unhandled exception
- Raises `max_output_tokens` from 512 → 1024 to reduce the likelihood of mid-response truncation
- Adds `TestCheckDataQuality` class (4 tests): valid JSON round-trip, truncated JSON → `None`, empty response → `None`, `max_output_tokens` value assertion

Closes #399

## Test plan
- [ ] `TestCheckDataQuality.test_truncated_json_returns_none` — `'{"is_val'` → `None` cleanly
- [ ] `TestCheckDataQuality.test_valid_json_returned` — valid JSON parsed correctly
- [ ] `TestCheckDataQuality.test_empty_response_returns_none` — empty string → `None`
- [ ] `TestCheckDataQuality.test_max_output_tokens_1024_for_data_quality` — token budget assertion
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)