### PR TITLE
security: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Description
+<!-- Clear, concise description of the bug -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+- OS:
+- Browser / runtime:
+- Version / branch:
+
+## Logs / screenshots
+<!-- Paste relevant logs or attach screenshots -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem statement
+<!-- What problem does this solve? Who is affected? -->
+
+## Proposed solution
+<!-- How would you solve it? -->
+
+## Alternatives considered
+<!-- What other approaches did you consider and why did you reject them? -->
+
+## Acceptance criteria
+- [ ]
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+<!-- What does this PR do? Focus on the why, not the how. -->
+-
+
+## Type of change
+- [ ] `feat` — new feature or behaviour
+- [ ] `fix` — bug fix
+- [ ] `chore` — tooling, deps, config
+- [ ] `test` — adding or updating tests
+- [ ] `docs` — documentation only
+- [ ] `refactor` — code change that is neither fix nor feature
+- [ ] `ci` — CI/CD changes
+- [ ] `a11y` — accessibility improvement
+- [ ] `security` — security hardening
+
+## Testing done
+<!-- What did you run? Any coverage delta? -->
+- [ ] All tests pass locally
+- [ ] No new lint errors
+
+## Security checklist
+- [ ] No secrets committed (gitleaks passes)
+- [ ] Dependencies reviewed if new ones added
+- [ ] OWASP considerations addressed if auth or data handling was touched
+
+## Accessibility checklist *(frontend PRs only)*
+- [ ] axe DevTools — no violations on affected pages
+- [ ] Keyboard navigation tested
+- [ ] Tested at 320px viewport width
+- [ ] Tested at 200% zoom

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+All active projects are maintained and receive security updates.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities privately via [GitHub's private vulnerability reporting](https://github.com/wcmchenry3-stack) or email directly.
+
+**What to include:**
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+**Response timeline:**
+- Acknowledgement within 48 hours
+- Initial assessment within 5 business days
+- Fix timeline communicated within 10 business days
+
+## Out of Scope
+
+- Vulnerabilities in third-party dependencies (report upstream)
+- Issues already reported
+- Theoretical vulnerabilities without a working proof-of-concept
+- Social engineering attacks


### PR DESCRIPTION
## Summary
Adds org-standard community health files so they remain in place if the org-level `.github` repo goes private (org-wide defaults only apply when `.github` is public).

## Files added
- `SECURITY.md` — vulnerability reporting policy and response timeline
- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist (type of change, testing, security, a11y)
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`

## Why now
This app is targeting App Store / Google Play submission. Having a security policy and structured issue reporting in place is expected by Apple/Google reviewers and required if any user-facing security contact is referenced.

## Test plan
- [ ] Open a new PR and confirm the template pre-populates
- [ ] Verify SECURITY.md appears in the Security tab (`github.com/wcmchenry3-stack/office_holder_cursor/security`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)