### PR TITLE
perf: add WIKI_TABLE_CACHE_ENABLED env var — all-or-nothing disk cache toggle

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -44,3 +44,5 @@ services:
         sync: false
       - key: DATA_QUALITY_ENABLED
         value: "0"
+      - key: WIKI_TABLE_CACHE_ENABLED
+        value: "0"

--- a/render.yaml
+++ b/render.yaml
@@ -44,5 +44,5 @@ services:
         sync: false
       - key: DATA_QUALITY_ENABLED
         value: "0"
-      - key: WIKI_TABLE_CACHE_ENABLED
+      - key: TABLE_HTML_CACHE_ENABLED
         value: "0"

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -10,7 +10,7 @@ Wikimedia API (via wiki_fetch.py):
   - Rate limiting: enforced by the global rate limiter in wiki_fetch.py (≤1 req/s).
   - This module never makes HTTP requests directly — all fetches go through
     _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate limiter.
-  - WIKI_TABLE_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
+  - TABLE_HTML_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
     is still enforced by wiki_fetch.py on every request.
   See: https://www.mediawiki.org/wiki/API:Etiquette
 """
@@ -159,7 +159,7 @@ def write_table_html_cache(
     Used by the AI office builder to prime the cache from already-fetched page HTML,
     so retry validations never re-fetch Wikipedia.
     """
-    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+    if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") == "0":
         return
     url = (url or "").strip()
     if not url or not html:
@@ -196,7 +196,7 @@ def get_table_html_cached(
     Returns {"table_no", "num_tables", "html": "<table>...</table>"} or {"error": "..."}.
     """
 
-    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+    if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") == "0":
         return _fetch_table_from_url(url, table_no, use_full_page, run_cache=None)
 
     url = (url or "").strip()

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -7,10 +7,10 @@ Preview / test / run use cache by default; use Refresh to refetch from Wikipedia
 
 Wikimedia API (via wiki_fetch.py):
   - User-Agent: set on every HTTP request via WIKIPEDIA_REQUEST_HEADERS in wiki_fetch.py.
-  - Rate limiting: enforced by the global rate limiter in wiki_fetch.py (≤1 req/s).
+  - rate_limit / retry: enforced by wiki_session() in wiki_fetch.py (≤1 req/s, backoff on 429).
   - This module never makes HTTP requests directly — all fetches go through
-    _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate limiter.
-  - TABLE_HTML_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
+    _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate_limit.
+  - TABLE_HTML_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate_limit)
     is still enforced by wiki_fetch.py on every request.
   See: https://www.mediawiki.org/wiki/API:Etiquette
 """

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -2,6 +2,17 @@
 """
 Local cache for Wikipedia table HTML. One file per (url, table_no); raw HTML stored in gzipped JSON.
 Preview / test / run use cache by default; use Refresh to refetch from Wikipedia.
+
+--- Policy compliance ---
+
+Wikimedia API (via wiki_fetch.py):
+  - User-Agent: set on every HTTP request via WIKIPEDIA_REQUEST_HEADERS in wiki_fetch.py.
+  - Rate limiting: enforced by the global rate limiter in wiki_fetch.py (≤1 req/s).
+  - This module never makes HTTP requests directly — all fetches go through
+    _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate limiter.
+  - WIKI_TABLE_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
+    is still enforced by wiki_fetch.py on every request.
+  See: https://www.mediawiki.org/wiki/API:Etiquette
 """
 
 import gzip

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import json
 import logging
+import os
 import time
 import threading
 import weakref
@@ -147,6 +148,8 @@ def write_table_html_cache(
     Used by the AI office builder to prime the cache from already-fetched page HTML,
     so retry validations never re-fetch Wikipedia.
     """
+    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+        return
     url = (url or "").strip()
     if not url or not html:
         return
@@ -181,6 +184,9 @@ def get_table_html_cached(
     and re-fetch. Prevents stale cached pages from masking Wikipedia changes across runs.
     Returns {"table_no", "num_tables", "html": "<table>...</table>"} or {"error": "..."}.
     """
+
+    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+        return _fetch_table_from_url(url, table_no, use_full_page, run_cache=None)
 
     url = (url or "").strip()
     if not url:

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -12,7 +12,7 @@ Tests cover:
 - Dict shrinks after references are released (GC frees the lock)
 - Concurrent access from multiple threads does not corrupt the dict
   and each thread gets a usable lock
-- WIKI_TABLE_CACHE_ENABLED=0 bypasses disk I/O and calls _fetch_table_from_url directly
+- TABLE_HTML_CACHE_ENABLED=0 bypasses disk I/O and calls _fetch_table_from_url directly
 """
 
 from __future__ import annotations
@@ -167,18 +167,18 @@ class TestThreadSafety:
 
 
 # ---------------------------------------------------------------------------
-# WIKI_TABLE_CACHE_ENABLED toggle (#396)
+# TABLE_HTML_CACHE_ENABLED toggle (#396)
 # ---------------------------------------------------------------------------
 
 
 class TestCacheToggle:
     def test_disabled_bypasses_disk_and_calls_fetch_directly(self):
-        """When WIKI_TABLE_CACHE_ENABLED=0, get_table_html_cached calls _fetch_table_from_url
+        """When TABLE_HTML_CACHE_ENABLED=0, get_table_html_cached calls _fetch_table_from_url
         directly with run_cache=None and skips all disk I/O."""
         from src.scraper import table_cache
 
         fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
-        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+        with patch.dict("os.environ", {"TABLE_HTML_CACHE_ENABLED": "0"}):
             with patch.object(
                 table_cache, "_fetch_table_from_url", return_value=fake_result
             ) as mock_fetch:
@@ -192,10 +192,10 @@ class TestCacheToggle:
         assert result == fake_result
 
     def test_disabled_write_is_noop(self, tmp_path):
-        """When WIKI_TABLE_CACHE_ENABLED=0, write_table_html_cache writes no files."""
+        """When TABLE_HTML_CACHE_ENABLED=0, write_table_html_cache writes no files."""
         from src.scraper import table_cache
 
-        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+        with patch.dict("os.environ", {"TABLE_HTML_CACHE_ENABLED": "0"}):
             with patch.object(table_cache, "_cache_dir", return_value=tmp_path):
                 table_cache.write_table_html_cache(
                     url="https://en.wikipedia.org/wiki/Test",
@@ -207,7 +207,7 @@ class TestCacheToggle:
         assert list(tmp_path.iterdir()) == []
 
     def test_enabled_by_default(self):
-        """Without WIKI_TABLE_CACHE_ENABLED set, normal disk-cache path is used."""
+        """Without TABLE_HTML_CACHE_ENABLED set, normal disk-cache path is used."""
         from src.scraper import table_cache
 
         fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
@@ -215,7 +215,7 @@ class TestCacheToggle:
             # Remove key if present to test default
             import os
 
-            os.environ.pop("WIKI_TABLE_CACHE_ENABLED", None)
+            os.environ.pop("TABLE_HTML_CACHE_ENABLED", None)
             with patch.object(
                 table_cache, "_fetch_table_from_url", return_value=fake_result
             ) as mock_fetch:
@@ -231,11 +231,11 @@ class TestCacheToggle:
         mock_fetch.assert_called_once()
 
     def test_explicit_enabled_uses_normal_path(self):
-        """WIKI_TABLE_CACHE_ENABLED=1 uses the normal disk-cache path."""
+        """TABLE_HTML_CACHE_ENABLED=1 uses the normal disk-cache path."""
         from src.scraper import table_cache
 
         fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
-        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "1"}):
+        with patch.dict("os.environ", {"TABLE_HTML_CACHE_ENABLED": "1"}):
             with patch.object(
                 table_cache, "_fetch_table_from_url", return_value=fake_result
             ) as mock_fetch:

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Tests for the _key_locks memory-leak fix in table_cache.py (Issue #224).
+"""Tests for the _key_locks memory-leak fix and cache toggle in table_cache.py.
 
-The original implementation used a plain dict[str, threading.Lock] that
-grew forever. The fix uses weakref.WeakValueDictionary so entries are
-automatically removed once no thread holds a reference to the lock.
+table_cache.py never makes HTTP requests directly — all Wikipedia fetches go
+through _fetch_table_from_url() → wiki_session(), which enforces the
+User-Agent header and rate limiting per Wikimedia policy (wiki_fetch.py).
 
 Tests cover:
 - _key_lock returns a _KeyLock with working __enter__/__exit__
@@ -12,6 +12,7 @@ Tests cover:
 - Dict shrinks after references are released (GC frees the lock)
 - Concurrent access from multiple threads does not corrupt the dict
   and each thread gets a usable lock
+- WIKI_TABLE_CACHE_ENABLED=0 bypasses disk I/O and calls _fetch_table_from_url directly
 """
 
 from __future__ import annotations

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import gc
 import threading
 import weakref
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -162,3 +163,87 @@ class TestThreadSafety:
 
         gc.collect()
         assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# WIKI_TABLE_CACHE_ENABLED toggle (#396)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheToggle:
+    def test_disabled_bypasses_disk_and_calls_fetch_directly(self):
+        """When WIKI_TABLE_CACHE_ENABLED=0, get_table_html_cached calls _fetch_table_from_url
+        directly with run_cache=None and skips all disk I/O."""
+        from src.scraper import table_cache
+
+        fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
+        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+            with patch.object(
+                table_cache, "_fetch_table_from_url", return_value=fake_result
+            ) as mock_fetch:
+                result = table_cache.get_table_html_cached(
+                    "https://en.wikipedia.org/wiki/Test", table_no=1
+                )
+
+        mock_fetch.assert_called_once_with(
+            "https://en.wikipedia.org/wiki/Test", 1, False, run_cache=None
+        )
+        assert result == fake_result
+
+    def test_disabled_write_is_noop(self, tmp_path):
+        """When WIKI_TABLE_CACHE_ENABLED=0, write_table_html_cache writes no files."""
+        from src.scraper import table_cache
+
+        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+            with patch.object(table_cache, "_cache_dir", return_value=tmp_path):
+                table_cache.write_table_html_cache(
+                    url="https://en.wikipedia.org/wiki/Test",
+                    table_no=1,
+                    html="<table></table>",
+                    num_tables=1,
+                )
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_enabled_by_default(self):
+        """Without WIKI_TABLE_CACHE_ENABLED set, normal disk-cache path is used."""
+        from src.scraper import table_cache
+
+        fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove key if present to test default
+            import os
+
+            os.environ.pop("WIKI_TABLE_CACHE_ENABLED", None)
+            with patch.object(
+                table_cache, "_fetch_table_from_url", return_value=fake_result
+            ) as mock_fetch:
+                with patch.object(table_cache, "_cache_dir") as mock_dir:
+                    mock_path = MagicMock()
+                    mock_path.__truediv__ = MagicMock(return_value=MagicMock(exists=lambda: False))
+                    mock_dir.return_value = mock_path
+                    table_cache.get_table_html_cached(
+                        "https://en.wikipedia.org/wiki/Test2", table_no=1
+                    )
+
+        # Normal path calls _fetch_table_from_url but NOT with run_cache=None forced
+        mock_fetch.assert_called_once()
+
+    def test_explicit_enabled_uses_normal_path(self):
+        """WIKI_TABLE_CACHE_ENABLED=1 uses the normal disk-cache path."""
+        from src.scraper import table_cache
+
+        fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
+        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "1"}):
+            with patch.object(
+                table_cache, "_fetch_table_from_url", return_value=fake_result
+            ) as mock_fetch:
+                with patch.object(table_cache, "_cache_dir") as mock_dir:
+                    mock_path = MagicMock()
+                    mock_path.__truediv__ = MagicMock(return_value=MagicMock(exists=lambda: False))
+                    mock_dir.return_value = mock_path
+                    table_cache.get_table_html_cached(
+                        "https://en.wikipedia.org/wiki/Test3", table_no=1
+                    )
+
+        mock_fetch.assert_called_once()

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -3,7 +3,7 @@
 
 table_cache.py never makes HTTP requests directly — all Wikipedia fetches go
 through _fetch_table_from_url() → wiki_session(), which enforces the
-User-Agent header and rate limiting per Wikimedia policy (wiki_fetch.py).
+User-Agent header, rate_limit, and backoff/retry per Wikimedia policy (wiki_fetch.py).
 
 Tests cover:
 - _key_lock returns a _KeyLock with working __enter__/__exit__


### PR DESCRIPTION
## Summary
- Adds `WIKI_TABLE_CACHE_ENABLED` env var (default `"1"`); set to `"0"` in `render.yaml` (prod default OFF)
- When `"0"`: `get_table_html_cached()` bypasses all disk read/write and calls `_fetch_table_from_url()` directly with `run_cache=None`; `write_table_html_cache()` is a no-op
- Hash-based HTML skip (`last_html_hash` in DB) is unaffected — still deduplicates unchanged tables
- 7-day batch scheduling logic is unchanged

Closes #396

## Test plan
- [ ] `TestCacheToggle.test_disabled_bypasses_disk_and_calls_fetch_directly` — confirms `_fetch_table_from_url` called with `run_cache=None`, no disk I/O
- [ ] `TestCacheToggle.test_disabled_write_is_noop` — confirms no `.json.gz` files written when disabled
- [ ] `TestCacheToggle.test_enabled_by_default` — normal path when env var absent
- [ ] `TestCacheToggle.test_explicit_enabled_uses_normal_path` — normal path when `WIKI_TABLE_CACHE_ENABLED=1`
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)