### PR TITLE
feat: enrich suspect-record GH issues with source page URL and row data

### DIFF
--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -548,6 +548,8 @@ def _suspect_gate(
     wiki_url: str | None,
     office_id: int,
     conn,
+    source_page_url: str | None = None,
+    row_data: dict | None = None,
 ) -> tuple[bool, int | None]:
     """Thin wrapper around SuspectRecordFlagger.check_and_gate for the import loop.
 
@@ -560,6 +562,8 @@ def _suspect_gate(
         wiki_url=wiki_url,
         office_id=office_id,
         conn=conn,
+        source_page_url=source_page_url,
+        row_data=row_data,
     )
 
 
@@ -2567,6 +2571,7 @@ def run_with_db(
                 if wiki_link and wiki_link != "No link":
                     unique_wiki_urls.add(wiki_link)
                 row["_office_id"] = office_id
+                row["_source_page_url"] = office_row.get("url", "")
                 if office_row.get("office_details_id") is not None:
                     row["_office_details_id"] = office_row["office_details_id"]
                     row["_office_table_config_id"] = (
@@ -2683,6 +2688,8 @@ def run_with_db(
                         wiki_url=wiki_url,
                         office_id=office_id,
                         conn=conn,
+                        source_page_url=row.get("_source_page_url"),
+                        row_data={k: v for k, v in row.items() if not k.startswith("_")},
                     )
                     if not _should_insert:
                         continue

--- a/src/services/suspect_record_flagger.py
+++ b/src/services/suspect_record_flagger.py
@@ -105,6 +105,8 @@ def _create_gh_issue(
     flag_reasons: list[str],
     verdict_name: str,
     ai_votes_summary: str,
+    source_page_url: str | None = None,
+    row_data: dict | None = None,
 ) -> str | None:
     """Create a GitHub issue for manual review. Returns the issue URL or None."""
     try:
@@ -115,6 +117,21 @@ def _create_gh_issue(
             return None
 
         title = f"[Suspect record] {full_name or wiki_url or 'unknown'} (office {office_id})"
+
+        source_section = ""
+        if source_page_url or row_data:
+            source_section = "\n\n### Source\n"
+            if source_page_url:
+                source_section += f"**Page URL:** {source_page_url}\n"
+            if row_data:
+                import json as _json
+
+                source_section += (
+                    "**Parsed row data:**\n```json\n"
+                    + _json.dumps(row_data, default=str, indent=2)
+                    + "\n```"
+                )
+
         body = (
             f"## Suspect record flagged at parse time\n\n"
             f"**Verdict:** {verdict_name}\n"
@@ -123,8 +140,9 @@ def _create_gh_issue(
             f"**wiki_url:** `{wiki_url}`\n\n"
             f"### Pattern triggers\n"
             + "\n".join(f"- {r}" for r in flag_reasons)
-            + f"\n\n### AI votes\n{ai_votes_summary}\n\n"
-            f"This record was **not inserted** into the database. "
+            + f"\n\n### AI votes\n{ai_votes_summary}"
+            + source_section
+            + "\n\nThis record was **not inserted** into the database. "
             f"Please investigate and re-scrape the office if the record is legitimate."
         )
         result = gh.create_issue(title=title, body=body, labels=[_GH_LABEL])
@@ -144,6 +162,8 @@ def check_and_gate(
     wiki_url: str | None,
     office_id: int,
     conn=None,
+    source_page_url: str | None = None,
+    row_data: dict | None = None,
 ) -> tuple[bool, int | None]:
     """Run the suspect record gate for one parsed row.
 
@@ -217,6 +237,8 @@ def check_and_gate(
                 flag_reasons=reasons,
                 verdict_name=verdict.value,
                 ai_votes_summary=ai_votes_summary,
+                source_page_url=source_page_url,
+                row_data=row_data,
             )
 
         flag_id = db_flags.insert_flag(

--- a/src/services/suspect_record_flagger.py
+++ b/src/services/suspect_record_flagger.py
@@ -143,7 +143,7 @@ def _create_gh_issue(
             + f"\n\n### AI votes\n{ai_votes_summary}"
             + source_section
             + "\n\nThis record was **not inserted** into the database. "
-            f"Please investigate and re-scrape the office if the record is legitimate."
+            "Please investigate and re-scrape the office if the record is legitimate."
         )
         result = gh.create_issue(title=title, body=body, labels=[_GH_LABEL])
         return result.get("html_url")

--- a/tests/test_suspect_record_flagger.py
+++ b/tests/test_suspect_record_flagger.py
@@ -295,3 +295,83 @@ class TestCheckAndGateErrorHandling:
             should_insert, flag_id = check_and_gate("1978", "", 94, conn)
         assert should_insert is True
         assert flag_id is None
+
+
+# ---------------------------------------------------------------------------
+# GH issue enrichment: source_page_url + row_data (#400)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGhIssueEnrichment:
+    """_create_gh_issue includes source_page_url and row_data in the issue body."""
+
+    def _call(self, source_page_url=None, row_data=None):
+        from src.services.suspect_record_flagger import _create_gh_issue
+
+        captured = {}
+
+        def fake_create_issue(title, body, labels):
+            captured["body"] = body
+            return {"html_url": "https://github.com/org/repo/issues/1"}
+
+        mock_gh = MagicMock()
+        mock_gh.create_issue.side_effect = fake_create_issue
+
+        with patch("src.services.github_client.get_github_client", return_value=mock_gh):
+            _create_gh_issue(
+                full_name="1999",
+                wiki_url="No link:42:1999",
+                office_id=42,
+                flag_reasons=["full_name is a 4-digit year: '1999'"],
+                verdict_name="disagreement",
+                ai_votes_summary="- **claude**: invalid",
+                source_page_url=source_page_url,
+                row_data=row_data,
+            )
+        return captured.get("body", "")
+
+    def test_source_page_url_appears_in_body(self):
+        body = self._call(source_page_url="https://en.wikipedia.org/wiki/Some_Office")
+        assert "### Source" in body
+        assert "https://en.wikipedia.org/wiki/Some_Office" in body
+
+    def test_row_data_appears_as_json_block(self):
+        row_data = {"Name": "1999", "Term start": "1999", "Term end": "2000"}
+        body = self._call(row_data=row_data)
+        assert "### Source" in body
+        assert "```json" in body
+        assert '"Name": "1999"' in body
+
+    def test_no_source_section_when_both_none(self):
+        body = self._call()
+        assert "### Source" not in body
+
+    def test_check_and_gate_passes_source_url_to_gh_issue(self, tmp_path):
+        """check_and_gate forwards source_page_url to _create_gh_issue."""
+        conn = _conn(tmp_path)
+        mock_voter = MagicMock()
+        mock_voter.vote.return_value = _make_verdict(Verdict.DISAGREEMENT)
+        captured = {}
+
+        def fake_gh_issue(**kwargs):
+            captured.update(kwargs)
+            return "https://github.com/org/repo/issues/2"
+
+        with (
+            patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter),
+            patch(
+                "src.services.suspect_record_flagger._create_gh_issue",
+                side_effect=fake_gh_issue,
+            ),
+        ):
+            check_and_gate(
+                full_name="1978",
+                wiki_url="No link:94:1978",
+                office_id=94,
+                conn=conn,
+                source_page_url="https://en.wikipedia.org/wiki/Test_Office",
+                row_data={"Name": "1978"},
+            )
+
+        assert captured.get("source_page_url") == "https://en.wikipedia.org/wiki/Test_Office"
+        assert captured.get("row_data") == {"Name": "1978"}


### PR DESCRIPTION
## Summary
- `check_and_gate()` and `_create_gh_issue()` accept two new optional params: `source_page_url` and `row_data`
- When present, a `### Source` section is appended to the issue body containing the Wikipedia page URL and a JSON code block of the parsed row fields (non-`_` keys only)
- `runner.py` stores `_source_page_url` (from `office_row["url"]`) in each row dict during accumulation, then passes it + cleaned row dict to `_suspect_gate()` → `check_and_gate()`
- No behavior change when both params are `None` (existing calls unaffected)

Closes #400

## Test plan
- [ ] `test_source_page_url_appears_in_body` — URL appears in `### Source` section
- [ ] `test_row_data_appears_as_json_block` — row dict serialized as ` ```json ``` ` block
- [ ] `test_no_source_section_when_both_none` — no `### Source` when both params omitted
- [ ] `test_check_and_gate_passes_source_url_to_gh_issue` — end-to-end forwarding verified
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)