### PR TITLE
feat: force-run specific offices via POST /api/run (#397)

### DIFF
--- a/src/routers/run_scraper.py
+++ b/src/routers/run_scraper.py
@@ -283,6 +283,7 @@ async def api_run(
     force_overwrite: str = Form(""),
     living_only: str = Form(""),
     valid_page_paths_only: str = Form(""),
+    forced_office_ids: str = Form(""),
 ):
     if run_mode == "single_bio" and not individual_ref.strip():
         raise HTTPException(
@@ -292,6 +293,13 @@ async def api_run(
     office_category_id_int = _parse_optional_int(office_category_id)
     living_only_bool = str(living_only).strip().lower() in ("1", "true", "yes")
     valid_page_paths_only_bool = str(valid_page_paths_only).strip().lower() in ("1", "true", "yes")
+
+    # forced_office_ids: comma-separated int IDs → run only those offices with refresh=True
+    forced_ids: list[int] = []
+    for tok in forced_office_ids.replace(";", ",").split(","):
+        tok = tok.strip()
+        if tok.isdigit():
+            forced_ids.append(int(tok))
     run_bio = run_mode == "delta_live"
     run_office_bio = run_mode not in (
         "full_no_bio",
@@ -354,6 +362,12 @@ async def api_run(
         run_bio = False
         run_office_bio = False
         refresh_table_cache = False
+    if forced_ids:
+        office_id_list = forced_ids
+        refresh_table_cache = True
+        mode = "delta"
+        run_bio = False
+        run_office_bio = False
     if not _is_runners_enabled():
         return JSONResponse(
             {"error": "Runner jobs are globally disabled (RUNNERS_ENABLED=false)"},

--- a/src/templates/run.html
+++ b/src/templates/run.html
@@ -50,6 +50,16 @@
   </div>
 </form>
 
+<hr>
+<h2>Force-run specific offices</h2>
+<p class="muted">Immediately re-scrape one or more offices regardless of their scheduled batch day. Always fetches fresh HTML from Wikipedia (bypasses cache).</p>
+<div class="form-group">
+  <label for="forceRunIds">Office ID(s) <span class="muted">(comma-separated)</span></label>
+  <input type="text" id="forceRunIds" placeholder="e.g. 220, 314" style="width:220px;">
+  <button type="button" class="btn" id="forceRunBtn" style="margin-left:8px;">Force run</button>
+</div>
+<div id="forceRunError" class="alert alert-error" style="display:none;"></div>
+
 <div id="runningPanel" class="running-panel" style="display:none;">
   <div class="running-header">
     <span class="spinner" aria-hidden="true"></span>
@@ -358,6 +368,39 @@ if (_stopBtn) {
     } catch (_) {}
   });
 }
+
+// Force-run button
+document.getElementById('forceRunBtn').addEventListener('click', async () => {
+  const ids = document.getElementById('forceRunIds').value.trim();
+  const errEl = document.getElementById('forceRunError');
+  errEl.style.display = 'none';
+  if (!ids) {
+    errEl.textContent = 'Enter at least one office ID.';
+    errEl.style.display = 'block';
+    return;
+  }
+  const formData = new FormData();
+  formData.append('run_mode', 'delta');
+  formData.append('forced_office_ids', ids);
+  let jobId = null;
+  try {
+    const r = await fetch('/api/run', { method: 'POST', body: formData });
+    const data = await r.json();
+    if (r.status !== 202 || !data.job_id) {
+      throw new Error(data.detail || data.error || 'Failed to start job');
+    }
+    jobId = data.job_id;
+  } catch (err) {
+    errEl.textContent = 'Error: ' + err.message;
+    errEl.style.display = 'block';
+    return;
+  }
+  _resultEl.style.display = 'none';
+  _progressMessage.textContent = 'Starting force run…';
+  _resetProgressGroups();
+  _progressDetail.textContent = '';
+  _startPolling(jobId);
+});
 
 // Form submit
 document.getElementById('runForm').addEventListener('submit', async (e) => {

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -191,6 +191,7 @@ def _run_api_run_in_thread(rs, **kwargs):
         force_overwrite="",
         living_only="",
         valid_page_paths_only="",
+        forced_office_ids="",
     )
     defaults.update(kwargs)
 

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -245,3 +245,87 @@ def test_job_store_eviction_removes_old_completed_jobs(client, monkeypatch):
     status_resp = client.get(f"/api/run/status/{job_id}")
     assert status_resp.status_code == 200
     assert status_resp.json()["status"] == "complete"
+
+
+# ---------------------------------------------------------------------------
+# Force-run specific offices (#397)
+# ---------------------------------------------------------------------------
+
+
+def test_forced_office_ids_sets_office_id_list_and_refresh(client, monkeypatch):
+    """POST /api/run with forced_office_ids passes office_id_list and refresh_table_cache=True."""
+    import src.routers.run_scraper as rs
+
+    captured = {}
+
+    def _capture_run(**kwargs):
+        captured.update(kwargs)
+        return {"cancelled": False, "terms": 0}
+
+    monkeypatch.setattr(rs, "run_with_db", _capture_run)
+
+    resp = client.post("/api/run", data={"forced_office_ids": "220, 314"})
+    assert resp.status_code == 202
+
+    # Wait for the job to finish so captured is populated
+    job_id = resp.json()["job_id"]
+    for _ in range(40):
+        status = client.get(f"/api/run/status/{job_id}").json()
+        if status.get("status") != "running":
+            break
+        time.sleep(0.05)
+
+    assert set(captured.get("office_ids", [])) == {220, 314}
+    assert captured.get("refresh_table_cache") is True
+
+
+def test_forced_office_ids_ignores_non_numeric_tokens(client, monkeypatch):
+    """Non-numeric tokens in forced_office_ids are silently ignored."""
+    import src.routers.run_scraper as rs
+
+    captured = {}
+
+    def _capture_run(**kwargs):
+        captured.update(kwargs)
+        return {"cancelled": False, "terms": 0}
+
+    monkeypatch.setattr(rs, "run_with_db", _capture_run)
+
+    resp = client.post("/api/run", data={"forced_office_ids": "42, abc, , 99"})
+    assert resp.status_code == 202
+
+    job_id = resp.json()["job_id"]
+    for _ in range(40):
+        status = client.get(f"/api/run/status/{job_id}").json()
+        if status.get("status") != "running":
+            break
+        time.sleep(0.05)
+
+    assert set(captured.get("office_ids", [])) == {42, 99}
+
+
+def test_forced_office_ids_empty_string_does_not_override(client, monkeypatch):
+    """Empty forced_office_ids leaves office_ids and refresh_table_cache unchanged."""
+    import src.routers.run_scraper as rs
+
+    captured = {}
+
+    def _capture_run(**kwargs):
+        captured.update(kwargs)
+        return {"cancelled": False, "terms": 0}
+
+    monkeypatch.setattr(rs, "run_with_db", _capture_run)
+
+    resp = client.post("/api/run", data={"run_mode": "delta", "forced_office_ids": ""})
+    assert resp.status_code == 202
+
+    job_id = resp.json()["job_id"]
+    for _ in range(40):
+        status = client.get(f"/api/run/status/{job_id}").json()
+        if status.get("status") != "running":
+            break
+        time.sleep(0.05)
+
+    # No office_ids filter and no forced refresh
+    assert captured.get("office_ids") is None
+    assert captured.get("refresh_table_cache") is False


### PR DESCRIPTION
## Summary
- Adds `forced_office_ids` form field to `POST /api/run` — accepts comma-separated integer office IDs
- When supplied, bypasses 7-day batch scheduling and sets `refresh_table_cache=True` so those offices always fetch fresh from Wikipedia
- Non-numeric tokens silently ignored; empty value leaves existing behaviour unchanged
- UI: adds "Force-run specific offices" section on the run page with input and button

## Test plan
- [x] `test_forced_office_ids_sets_office_id_list_and_refresh` — verifies `office_ids={220,314}` and `refresh_table_cache=True`
- [x] `test_forced_office_ids_ignores_non_numeric_tokens` — `"42, abc, , 99"` → `{42, 99}`
- [x] `test_forced_office_ids_empty_string_does_not_override` — empty string leaves `office_ids=None`, `refresh_table_cache=False`

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)