### PR TITLE
ci: opt into Node.js 24 for inline workflow actions (#410)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
   validate-fixtures:
     name: Validate parser fixtures
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -72,6 +74,8 @@ jobs:
   ui-tests:
     name: Playwright UI tests
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` to the `validate-fixtures` and `ui-tests` jobs in `ci.yml`
- Silences the Node.js 20 deprecation warnings for `actions/checkout@v4` and `actions/setup-python@v5` in those inline jobs
- Both `@v4` and `@v5` already support Node.js 24 — this env var explicitly opts in now rather than waiting for the forced migration

**Note:** The `gitleaks/gitleaks-action@v2` warning comes from the org-level `called-secret-scan.yml` reusable workflow in `wcmchenry3-stack/.github` (separate repo) and is not addressable from this workflow file.

Closes #410

## Test plan

- [ ] CI passes with no Node.js 20 deprecation warnings on the `Validate parser fixtures` and `Playwright UI tests` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)