### PR TITLE
chore: merge dev into main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Description
+<!-- Clear, concise description of the bug -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+- OS:
+- Browser / runtime:
+- Version / branch:
+
+## Logs / screenshots
+<!-- Paste relevant logs or attach screenshots -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem statement
+<!-- What problem does this solve? Who is affected? -->
+
+## Proposed solution
+<!-- How would you solve it? -->
+
+## Alternatives considered
+<!-- What other approaches did you consider and why did you reject them? -->
+
+## Acceptance criteria
+- [ ]
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+<!-- What does this PR do? Focus on the why, not the how. -->
+-
+
+## Type of change
+- [ ] `feat` — new feature or behaviour
+- [ ] `fix` — bug fix
+- [ ] `chore` — tooling, deps, config
+- [ ] `test` — adding or updating tests
+- [ ] `docs` — documentation only
+- [ ] `refactor` — code change that is neither fix nor feature
+- [ ] `ci` — CI/CD changes
+- [ ] `a11y` — accessibility improvement
+- [ ] `security` — security hardening
+
+## Testing done
+<!-- What did you run? Any coverage delta? -->
+- [ ] All tests pass locally
+- [ ] No new lint errors
+
+## Security checklist
+- [ ] No secrets committed (gitleaks passes)
+- [ ] Dependencies reviewed if new ones added
+- [ ] OWASP considerations addressed if auth or data handling was touched
+
+## Accessibility checklist *(frontend PRs only)*
+- [ ] axe DevTools — no violations on affected pages
+- [ ] Keyboard navigation tested
+- [ ] Tested at 320px viewport width
+- [ ] Tested at 200% zoom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
   validate-fixtures:
     name: Validate parser fixtures
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -72,6 +74,8 @@ jobs:
   ui-tests:
     name: Playwright UI tests
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,5 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-deploy-render.yml@main
     with:
       service-name: 'office-holder-cursor'
-      service-id: 'srv-d6ubbu24d50c73cpmgkg'
       zap-target-url: 'https://rulersai.buffingchi.com'
     secrets: inherit

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -10,6 +10,6 @@ jobs:
   zap-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
     with:
-      target-url: ${{ secrets.SITE_URL }}
+      target-url: 'https://rulersai.buffingchi.com'
       artifact-name: 'zap-weekly-office-holder'
     secrets: inherit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+All active projects are maintained and receive security updates.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities privately via [GitHub's private vulnerability reporting](https://github.com/wcmchenry3-stack) or email directly.
+
+**What to include:**
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+**Response timeline:**
+- Acknowledgement within 48 hours
+- Initial assessment within 5 business days
+- Fix timeline communicated within 10 business days
+
+## Out of Scope
+
+- Vulnerabilities in third-party dependencies (report upstream)
+- Issues already reported
+- Theoretical vulnerabilities without a working proof-of-concept
+- Social engineering attacks

--- a/render.yaml
+++ b/render.yaml
@@ -44,3 +44,5 @@ services:
         sync: false
       - key: DATA_QUALITY_ENABLED
         value: "0"
+      - key: WIKI_TABLE_CACHE_ENABLED
+        value: "0"

--- a/render.yaml
+++ b/render.yaml
@@ -44,5 +44,5 @@ services:
         sync: false
       - key: DATA_QUALITY_ENABLED
         value: "0"
-      - key: WIKI_TABLE_CACHE_ENABLED
+      - key: TABLE_HTML_CACHE_ENABLED
         value: "0"

--- a/src/routers/data.py
+++ b/src/routers/data.py
@@ -5,6 +5,7 @@ Wikipedia requests use a descriptive User-Agent header per Wikimedia API etiquet
 
 import os
 
+import requests as _requests
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
@@ -93,8 +94,13 @@ async def data_wiki_draft_detail(request: Request, proposal_id: int):
 
         return RedirectResponse("/data/wiki-drafts")
     sources = db_research.list_sources_for_individual(draft["individual_id"])
+    validation = None
+    if draft.get("proposal_text"):
+        from src.services.wikitext_validator import validate_wikitext
+
+        validation = validate_wikitext(draft["proposal_text"]).as_dict()
     return templates.TemplateResponse(
-        request, "wiki_draft_detail.html", {"draft": draft, "sources": sources}
+        request, "wiki_draft_detail.html", {"draft": draft, "sources": sources, "validation": validation}
     )
 
 
@@ -162,6 +168,118 @@ async def api_research_submit(individual_id: int):
     except WikipediaSubmitError as exc:
         db_research.update_wiki_draft_proposal_status(draft["id"], "rejected")
         raise HTTPException(502, f"Wikipedia submission failed: {exc}")
+
+
+@router.get("/api/wikipedia/status")
+async def api_wikipedia_status():
+    """Return whether Wikipedia bot credentials are configured.
+
+    Checks env vars only — does NOT attempt login, does NOT touch the
+    get_submitter() singleton (to avoid caching a failed login attempt).
+    """
+    username = os.environ.get("WIKIPEDIA_BOT_USERNAME", "").strip()
+    password = os.environ.get("WIKIPEDIA_BOT_PASSWORD", "").strip()
+    return JSONResponse({"configured": bool(username and password)})
+
+
+@router.post("/api/wiki-drafts/{proposal_id}/submit")
+async def api_submit_wiki_draft(proposal_id: int, request: Request):
+    """Submit a specific wiki draft proposal to Wikipedia.
+
+    Accepts optional JSON body: {"use_draft_namespace": true}
+    Default is Draft: namespace (safer — goes through AfC review).
+    Pass use_draft_namespace=false to target the main article namespace.
+
+    Returns 503 if bot credentials are not configured.
+    Returns 404 if draft not found.
+    Returns 409 if draft status is not 'pending'.
+    Returns 400 if individual has no name.
+    Returns 502 on Wikipedia API error (draft status set to 'rejected').
+    Returns 200 {"ok": true, "title": ..., "url": ...} on success.
+    """
+    from src.services.wikipedia_submit import get_submitter, WikipediaSubmitError
+
+    submitter = get_submitter()
+    if submitter is None:
+        raise HTTPException(
+            503,
+            "Wikipedia submit disabled — set WIKIPEDIA_BOT_USERNAME and WIKIPEDIA_BOT_PASSWORD",
+        )
+
+    draft = db_research.get_wiki_draft_proposal(proposal_id)
+    if draft is None:
+        raise HTTPException(404, "Draft not found")
+    if draft["status"] != "pending":
+        raise HTTPException(
+            409,
+            f"Draft status is '{draft['status']}' — only pending drafts can be submitted",
+        )
+
+    full_name = (draft.get("full_name") or "").strip()
+    if not full_name:
+        raise HTTPException(400, "Cannot determine article title — individual has no name")
+
+    body: dict = {}
+    try:
+        body = await request.json()
+    except Exception:
+        pass
+    use_draft_namespace: bool = body.get("use_draft_namespace", True)
+
+    title = f"Draft:{full_name}" if use_draft_namespace else full_name
+    article_url = f"https://en.wikipedia.org/wiki/{title.replace(' ', '_')}"
+
+    try:
+        submitter.submit_article(
+            title=title,
+            wikitext=draft["proposal_text"],
+            summary=f"New article: {full_name} — created from researched biographical sources",
+        )
+        db_research.update_wiki_draft_proposal_status(proposal_id, "submitted")
+        return JSONResponse({"ok": True, "title": title, "url": article_url})
+    except WikipediaSubmitError as exc:
+        db_research.update_wiki_draft_proposal_status(proposal_id, "rejected")
+        raise HTTPException(502, f"Wikipedia submission failed: {exc}")
+
+
+@router.get("/api/wiki-drafts/{proposal_id}/preview")
+async def api_wiki_draft_preview(proposal_id: int):
+    """Render a wiki draft's wikitext to HTML via the Wikipedia action=parse API.
+
+    Uses the Wikipedia public API (no auth required for rendering).
+    Returns {"html": "..."} on success or 503 on API failure.
+    Preview is best-effort and does not affect draft status.
+    """
+    from src.scraper.logger import HTTP_USER_AGENT
+
+    draft = db_research.get_wiki_draft_proposal(proposal_id)
+    if draft is None:
+        raise HTTPException(404, "Draft not found")
+
+    wikitext = draft.get("proposal_text") or ""
+    if not wikitext:
+        return JSONResponse({"html": "<p><em>No wikitext to preview.</em></p>"})
+
+    try:
+        resp = _requests.post(
+            "https://en.wikipedia.org/w/api.php",
+            data={
+                "action": "parse",
+                "format": "json",
+                "contentmodel": "wikitext",
+                "text": wikitext,
+                "disablelimitreport": "1",
+                "disableeditsection": "1",
+            },
+            headers={"User-Agent": HTTP_USER_AGENT},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        html = data.get("parse", {}).get("text", {}).get("*", "")
+        return JSONResponse({"html": html})
+    except Exception as exc:
+        raise HTTPException(503, f"Wikipedia preview unavailable: {exc}")
 
 
 @router.get("/data/scheduled-job-runs", response_class=HTMLResponse)

--- a/src/routers/data.py
+++ b/src/routers/data.py
@@ -100,7 +100,9 @@ async def data_wiki_draft_detail(request: Request, proposal_id: int):
 
         validation = validate_wikitext(draft["proposal_text"]).as_dict()
     return templates.TemplateResponse(
-        request, "wiki_draft_detail.html", {"draft": draft, "sources": sources, "validation": validation}
+        request,
+        "wiki_draft_detail.html",
+        {"draft": draft, "sources": sources, "validation": validation},
     )
 
 
@@ -249,7 +251,12 @@ async def api_wiki_draft_preview(proposal_id: int):
     Uses the Wikipedia public API (no auth required for rendering).
     Returns {"html": "..."} on success or 503 on API failure.
     Preview is best-effort and does not affect draft status.
+
+    Rate limiting: 1 s sleep before each request per Wikimedia API etiquette
+    (https://www.mediawiki.org/wiki/API:Etiquette#Request_limit).
     """
+    import time
+
     from src.scraper.logger import HTTP_USER_AGENT
 
     draft = db_research.get_wiki_draft_proposal(proposal_id)
@@ -260,6 +267,7 @@ async def api_wiki_draft_preview(proposal_id: int):
     if not wikitext:
         return JSONResponse({"html": "<p><em>No wikitext to preview.</em></p>"})
 
+    time.sleep(1.0)  # Wikimedia rate-limit: minimum 1 s between requests
     try:
         resp = _requests.post(
             "https://en.wikipedia.org/w/api.php",

--- a/src/routers/run_scraper.py
+++ b/src/routers/run_scraper.py
@@ -283,6 +283,7 @@ async def api_run(
     force_overwrite: str = Form(""),
     living_only: str = Form(""),
     valid_page_paths_only: str = Form(""),
+    forced_office_ids: str = Form(""),
 ):
     if run_mode == "single_bio" and not individual_ref.strip():
         raise HTTPException(
@@ -292,6 +293,13 @@ async def api_run(
     office_category_id_int = _parse_optional_int(office_category_id)
     living_only_bool = str(living_only).strip().lower() in ("1", "true", "yes")
     valid_page_paths_only_bool = str(valid_page_paths_only).strip().lower() in ("1", "true", "yes")
+
+    # forced_office_ids: comma-separated int IDs → run only those offices with refresh=True
+    forced_ids: list[int] = []
+    for tok in forced_office_ids.replace(";", ",").split(","):
+        tok = tok.strip()
+        if tok.isdigit():
+            forced_ids.append(int(tok))
     run_bio = run_mode == "delta_live"
     run_office_bio = run_mode not in (
         "full_no_bio",
@@ -354,6 +362,12 @@ async def api_run(
         run_bio = False
         run_office_bio = False
         refresh_table_cache = False
+    if forced_ids:
+        office_id_list = forced_ids
+        refresh_table_cache = True
+        mode = "delta"
+        run_bio = False
+        run_office_bio = False
     if not _is_runners_enabled():
         return JSONResponse(
             {"error": "Runner jobs are globally disabled (RUNNERS_ENABLED=false)"},

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -548,6 +548,8 @@ def _suspect_gate(
     wiki_url: str | None,
     office_id: int,
     conn,
+    source_page_url: str | None = None,
+    row_data: dict | None = None,
 ) -> tuple[bool, int | None]:
     """Thin wrapper around SuspectRecordFlagger.check_and_gate for the import loop.
 
@@ -560,6 +562,8 @@ def _suspect_gate(
         wiki_url=wiki_url,
         office_id=office_id,
         conn=conn,
+        source_page_url=source_page_url,
+        row_data=row_data,
     )
 
 
@@ -2567,6 +2571,7 @@ def run_with_db(
                 if wiki_link and wiki_link != "No link":
                     unique_wiki_urls.add(wiki_link)
                 row["_office_id"] = office_id
+                row["_source_page_url"] = office_row.get("url", "")
                 if office_row.get("office_details_id") is not None:
                     row["_office_details_id"] = office_row["office_details_id"]
                     row["_office_table_config_id"] = (
@@ -2683,6 +2688,8 @@ def run_with_db(
                         wiki_url=wiki_url,
                         office_id=office_id,
                         conn=conn,
+                        source_page_url=row.get("_source_page_url"),
+                        row_data={k: v for k, v in row.items() if not k.startswith("_")},
                     )
                     if not _should_insert:
                         continue

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -10,7 +10,7 @@ Wikimedia API (via wiki_fetch.py):
   - Rate limiting: enforced by the global rate limiter in wiki_fetch.py (≤1 req/s).
   - This module never makes HTTP requests directly — all fetches go through
     _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate limiter.
-  - WIKI_TABLE_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
+  - TABLE_HTML_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
     is still enforced by wiki_fetch.py on every request.
   See: https://www.mediawiki.org/wiki/API:Etiquette
 """
@@ -159,7 +159,7 @@ def write_table_html_cache(
     Used by the AI office builder to prime the cache from already-fetched page HTML,
     so retry validations never re-fetch Wikipedia.
     """
-    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+    if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") == "0":
         return
     url = (url or "").strip()
     if not url or not html:
@@ -196,7 +196,7 @@ def get_table_html_cached(
     Returns {"table_no", "num_tables", "html": "<table>...</table>"} or {"error": "..."}.
     """
 
-    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+    if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") == "0":
         return _fetch_table_from_url(url, table_no, use_full_page, run_cache=None)
 
     url = (url or "").strip()

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -7,10 +7,10 @@ Preview / test / run use cache by default; use Refresh to refetch from Wikipedia
 
 Wikimedia API (via wiki_fetch.py):
   - User-Agent: set on every HTTP request via WIKIPEDIA_REQUEST_HEADERS in wiki_fetch.py.
-  - Rate limiting: enforced by the global rate limiter in wiki_fetch.py (≤1 req/s).
+  - rate_limit / retry: enforced by wiki_session() in wiki_fetch.py (≤1 req/s, backoff on 429).
   - This module never makes HTTP requests directly — all fetches go through
-    _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate limiter.
-  - TABLE_HTML_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
+    _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate_limit.
+  - TABLE_HTML_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate_limit)
     is still enforced by wiki_fetch.py on every request.
   See: https://www.mediawiki.org/wiki/API:Etiquette
 """

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -2,6 +2,17 @@
 """
 Local cache for Wikipedia table HTML. One file per (url, table_no); raw HTML stored in gzipped JSON.
 Preview / test / run use cache by default; use Refresh to refetch from Wikipedia.
+
+--- Policy compliance ---
+
+Wikimedia API (via wiki_fetch.py):
+  - User-Agent: set on every HTTP request via WIKIPEDIA_REQUEST_HEADERS in wiki_fetch.py.
+  - Rate limiting: enforced by the global rate limiter in wiki_fetch.py (≤1 req/s).
+  - This module never makes HTTP requests directly — all fetches go through
+    _fetch_table_from_url() → wiki_session() which applies the User-Agent and rate limiter.
+  - WIKI_TABLE_CACHE_ENABLED=0 disables disk I/O; HTTP policy (User-Agent, rate limit)
+    is still enforced by wiki_fetch.py on every request.
+  See: https://www.mediawiki.org/wiki/API:Etiquette
 """
 
 import gzip

--- a/src/scraper/table_cache.py
+++ b/src/scraper/table_cache.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import json
 import logging
+import os
 import time
 import threading
 import weakref
@@ -147,6 +148,8 @@ def write_table_html_cache(
     Used by the AI office builder to prime the cache from already-fetched page HTML,
     so retry validations never re-fetch Wikipedia.
     """
+    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+        return
     url = (url or "").strip()
     if not url or not html:
         return
@@ -181,6 +184,9 @@ def get_table_html_cached(
     and re-fetch. Prevents stale cached pages from masking Wikipedia changes across runs.
     Returns {"table_no", "num_tables", "html": "<table>...</table>"} or {"error": "..."}.
     """
+
+    if os.environ.get("WIKI_TABLE_CACHE_ENABLED", "1") == "0":
+        return _fetch_table_from_url(url, table_no, use_full_page, run_cache=None)
 
     url = (url or "").strip()
     if not url:

--- a/src/services/ai_office_builder.py
+++ b/src/services/ai_office_builder.py
@@ -798,7 +798,43 @@ class AIOfficeBuilder:
             {"role": "user", "content": user_prompt},
         ]
 
-        return self._call_wiki_polish_openai(messages)
+        article = self._call_wiki_polish_openai(messages)
+        if article is None:
+            return None
+
+        # Validate and attempt one repair if critical format errors are found.
+        # Guard: skip repair for very long articles to stay within model context.
+        from src.services.wikitext_validator import validate_wikitext
+
+        validation = validate_wikitext(article)
+        if not validation.is_valid and len(article) < 8000:
+            logger.warning(
+                "polish_wiki_article: %d wikitext error(s) for %s — attempting repair",
+                len(validation.errors),
+                full_name,
+            )
+            repair_messages = messages + [
+                {"role": "assistant", "content": article},
+                {
+                    "role": "user",
+                    "content": (
+                        "The article you just wrote has the following wikitext format errors. "
+                        "Please rewrite it correcting all of these issues:\n"
+                        + "\n".join(f"- {e.message}" for e in validation.errors)
+                    ),
+                },
+            ]
+            try:
+                repaired = self._call_wiki_polish_openai(repair_messages)
+                if repaired:
+                    article = repaired
+            except Exception:
+                logger.warning(
+                    "polish_wiki_article: repair call failed for %s — using first draft",
+                    full_name,
+                )
+
+        return article
 
     def _call_wiki_polish_openai(self, messages: list[dict]) -> str | None:
         """Call OpenAI for wiki article polish with exponential backoff on RateLimitError.

--- a/src/services/claude_client.py
+++ b/src/services/claude_client.py
@@ -121,8 +121,13 @@ class ClaudeClient:
 
     def check_data_quality(
         self, prompt: str, context: dict, system_prompt: str | None = None
-    ) -> DataQualityResult:
-        """Assess data quality for a record or page. Returns structured result.
+    ) -> DataQualityResult | None:
+        """Assess data quality for a record or page. Returns structured result or None.
+
+        Returns None when the response cannot be parsed (e.g. Claude wraps JSON in
+        code fences and stripping still leaves unparseable text).  The caller
+        (_vote_claude in consensus_voter.py) treats None as provider unavailable and
+        excludes it from quorum rather than defaulting to is_valid=True.
 
         Args:
             system_prompt: Override the default individual-record system prompt.
@@ -134,7 +139,7 @@ class ClaudeClient:
             return self._call_claude(user_prompt, system_prompt=system_prompt or _SYSTEM_PROMPT)
         except Exception:
             logger.exception("Claude data quality check failed")
-            return DataQualityResult(is_valid=True, concerns=[], confidence="low")
+            return None
 
     def _build_prompt(self, prompt: str, context: dict) -> str:
         lines = [prompt]
@@ -146,10 +151,11 @@ class ClaudeClient:
 
     def _call_claude(
         self, user_prompt: str, system_prompt: str = _SYSTEM_PROMPT
-    ) -> DataQualityResult:
+    ) -> DataQualityResult | None:
         """Call Claude with exponential backoff on rate limit (HTTP 429).
 
         Retries up to 3 times, doubling the backoff delay each attempt (1 s → 2 s → 4 s).
+        Returns None when the response cannot be parsed (caller excludes from quorum).
         """
         import anthropic
 
@@ -181,14 +187,24 @@ class ClaudeClient:
                 backoff *= 2
         raise RuntimeError("unreachable")
 
-    def _parse_response(self, response) -> DataQualityResult:
-        """Parse Claude JSON response into DataQualityResult."""
+    def _parse_response(self, response) -> DataQualityResult | None:
+        """Parse Claude JSON response into DataQualityResult, or None on parse failure.
+
+        Claude sometimes wraps its JSON in markdown code fences (```json ... ```).
+        Strip them before parsing so the response is usable.  On any remaining
+        parse failure return None so the caller can exclude this provider from
+        quorum instead of defaulting to is_valid=True.
+        """
+        import re
+
         text = response.content[0].text if response.content else ""
+        # Strip optional markdown code fences: ```json ... ``` or ``` ... ```
+        stripped = re.sub(r"^```(?:json)?\s*|\s*```$", "", text.strip(), flags=re.MULTILINE)
         try:
-            data = json.loads(text)
+            data = json.loads(stripped)
         except json.JSONDecodeError:
             logger.warning("Claude returned non-JSON response: %s", text[:200])
-            return DataQualityResult(is_valid=True, concerns=[], confidence="low")
+            return None
 
         return DataQualityResult(
             is_valid=data.get("is_valid", True),

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -83,7 +83,9 @@ _SYSTEM_PROMPT = (
     "You are a data quality analyst for a political office holders database. "
     "Assess the provided record or page data and return JSON with these fields: "
     '{"is_valid": bool, "concerns": [str], "confidence": "high"|"medium"|"low"}. '
-    "is_valid is true if the data appears correct and accurate."
+    "is_valid is true if the data appears correct and accurate. "
+    "IMPORTANT: A record where full_name is a 4-digit year (e.g. '1999', '2006') "
+    "is NEVER a valid person name — always return is_valid=false with high confidence."
 )
 
 # ---------------------------------------------------------------------------
@@ -173,6 +175,8 @@ def _vote_claude(prompt: str, context: dict) -> AIVote:
             return AIVote(provider="claude", is_valid=None, error="client not configured")
 
         result = client.check_data_quality(prompt, context, system_prompt=_SYSTEM_PROMPT)
+        if result is None:
+            return AIVote(provider="claude", is_valid=None, error="parse error")
         return AIVote(
             provider="claude",
             is_valid=result.is_valid,

--- a/src/services/gemini_vitals_researcher.py
+++ b/src/services/gemini_vitals_researcher.py
@@ -318,14 +318,22 @@ class GeminiVitalsResearcher:
                     ],
                     config=types.GenerateContentConfig(
                         system_instruction=system_prompt or _default_instruction,
-                        max_output_tokens=512,
+                        max_output_tokens=1024,
                         response_mime_type="application/json",
                     ),
                 )
                 import json
 
                 text = response.text or ""
-                return json.loads(text)
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "check_data_quality: Gemini returned unparseable JSON (len=%d): %s",
+                        len(text),
+                        text[:120],
+                    )
+                    return None
             except errors.ClientError as exc:
                 if getattr(exc, "code", 0) == 429 or "RESOURCE_EXHAUSTED" in str(exc):
                     if attempt == 2:

--- a/src/services/suspect_record_flagger.py
+++ b/src/services/suspect_record_flagger.py
@@ -105,6 +105,8 @@ def _create_gh_issue(
     flag_reasons: list[str],
     verdict_name: str,
     ai_votes_summary: str,
+    source_page_url: str | None = None,
+    row_data: dict | None = None,
 ) -> str | None:
     """Create a GitHub issue for manual review. Returns the issue URL or None."""
     try:
@@ -115,6 +117,21 @@ def _create_gh_issue(
             return None
 
         title = f"[Suspect record] {full_name or wiki_url or 'unknown'} (office {office_id})"
+
+        source_section = ""
+        if source_page_url or row_data:
+            source_section = "\n\n### Source\n"
+            if source_page_url:
+                source_section += f"**Page URL:** {source_page_url}\n"
+            if row_data:
+                import json as _json
+
+                source_section += (
+                    "**Parsed row data:**\n```json\n"
+                    + _json.dumps(row_data, default=str, indent=2)
+                    + "\n```"
+                )
+
         body = (
             f"## Suspect record flagged at parse time\n\n"
             f"**Verdict:** {verdict_name}\n"
@@ -123,8 +140,9 @@ def _create_gh_issue(
             f"**wiki_url:** `{wiki_url}`\n\n"
             f"### Pattern triggers\n"
             + "\n".join(f"- {r}" for r in flag_reasons)
-            + f"\n\n### AI votes\n{ai_votes_summary}\n\n"
-            f"This record was **not inserted** into the database. "
+            + f"\n\n### AI votes\n{ai_votes_summary}"
+            + source_section
+            + "\n\nThis record was **not inserted** into the database. "
             f"Please investigate and re-scrape the office if the record is legitimate."
         )
         result = gh.create_issue(title=title, body=body, labels=[_GH_LABEL])
@@ -144,6 +162,8 @@ def check_and_gate(
     wiki_url: str | None,
     office_id: int,
     conn=None,
+    source_page_url: str | None = None,
+    row_data: dict | None = None,
 ) -> tuple[bool, int | None]:
     """Run the suspect record gate for one parsed row.
 
@@ -217,6 +237,8 @@ def check_and_gate(
                 flag_reasons=reasons,
                 verdict_name=verdict.value,
                 ai_votes_summary=ai_votes_summary,
+                source_page_url=source_page_url,
+                row_data=row_data,
             )
 
         flag_id = db_flags.insert_flag(

--- a/src/services/suspect_record_flagger.py
+++ b/src/services/suspect_record_flagger.py
@@ -143,7 +143,7 @@ def _create_gh_issue(
             + f"\n\n### AI votes\n{ai_votes_summary}"
             + source_section
             + "\n\nThis record was **not inserted** into the database. "
-            f"Please investigate and re-scrape the office if the record is legitimate."
+            "Please investigate and re-scrape the office if the record is legitimate."
         )
         result = gh.create_issue(title=title, body=body, labels=[_GH_LABEL])
         return result.get("html_url")

--- a/src/services/wikitext_validator.py
+++ b/src/services/wikitext_validator.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""Lightweight wikitext format validator.
+
+Checks that AI-generated Wikipedia article drafts conform to the expected
+wikitext structure before storage or submission.  All checks are pure-Python
+regex operations — no I/O, no external dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ValidationIssue:
+    level: str    # "error" | "warning"
+    code: str     # machine-readable key, e.g. "missing_infobox"
+    message: str  # human-readable one-liner
+
+
+@dataclass
+class WikitextValidationResult:
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.level == "error"]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.level == "warning"]
+
+    @property
+    def is_valid(self) -> bool:
+        """True when there are no errors (warnings are acceptable)."""
+        return len(self.errors) == 0
+
+    def as_dict(self) -> dict:
+        return {
+            "is_valid": self.is_valid,
+            "errors": [{"code": i.code, "message": i.message} for i in self.errors],
+            "warnings": [{"code": i.code, "message": i.message} for i in self.warnings],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+def _check_infobox(wikitext: str, issues: list[ValidationIssue]) -> None:
+    """Error if {{Infobox officeholder is absent (case-insensitive)."""
+    if not re.search(r"\{\{infobox officeholder", wikitext, re.IGNORECASE):
+        issues.append(ValidationIssue(
+            level="error",
+            code="missing_infobox",
+            message="Missing {{Infobox officeholder}} template",
+        ))
+
+
+def _check_refs(wikitext: str, issues: list[ValidationIssue]) -> None:
+    """Error if no <ref tag is present."""
+    if not re.search(r"<ref", wikitext, re.IGNORECASE):
+        issues.append(ValidationIssue(
+            level="error",
+            code="missing_refs",
+            message="No <ref> citation tags found — every factual claim needs a citation",
+        ))
+
+
+def _check_reflist(wikitext: str, issues: list[ValidationIssue]) -> None:
+    """Error if {{reflist}} is absent (case-insensitive)."""
+    if not re.search(r"\{\{reflist", wikitext, re.IGNORECASE):
+        issues.append(ValidationIssue(
+            level="error",
+            code="missing_reflist",
+            message="Missing {{reflist}} in References section",
+        ))
+
+
+def _check_references_section(wikitext: str, issues: list[ValidationIssue]) -> None:
+    """Error if ==References== section header is absent."""
+    if not re.search(r"==\s*References\s*==", wikitext, re.IGNORECASE):
+        issues.append(ValidationIssue(
+            level="error",
+            code="missing_references_section",
+            message="Missing ==References== section header",
+        ))
+
+
+def _check_categories(wikitext: str, issues: list[ValidationIssue]) -> None:
+    """Error if no [[Category: link is present."""
+    if not re.search(r"\[\[Category:", wikitext, re.IGNORECASE):
+        issues.append(ValidationIssue(
+            level="error",
+            code="missing_categories",
+            message="No [[Category:...]] links found — article must be categorised",
+        ))
+
+
+def _check_unmatched_braces(wikitext: str, issues: list[ValidationIssue]) -> None:
+    """Warning if {{ and }} counts differ (indicates broken template syntax).
+
+    Strips <nowiki>...</nowiki> blocks first to avoid false positives from
+    intentionally unbalanced markup in displayed examples.
+    """
+    stripped = re.sub(r"<nowiki>.*?</nowiki>", "", wikitext, flags=re.DOTALL | re.IGNORECASE)
+    open_count = stripped.count("{{")
+    close_count = stripped.count("}}")
+    if open_count != close_count:
+        delta = open_count - close_count
+        direction = "unclosed" if delta > 0 else "extra closing"
+        issues.append(ValidationIssue(
+            level="warning",
+            code="unmatched_braces",
+            message=f"Unmatched template braces: {abs(delta)} {direction} '{{{{' detected",
+        ))
+
+
+def _check_birth_date_template(
+    wikitext: str,
+    has_birth_info: bool,
+    issues: list[ValidationIssue],
+) -> None:
+    """Warning if birth info appears present but {{birth date| template is absent."""
+    if not has_birth_info:
+        return
+    if not re.search(r"\{\{birth date", wikitext, re.IGNORECASE):
+        issues.append(ValidationIssue(
+            level="warning",
+            code="missing_birth_date_template",
+            message="birth_date field present but missing {{birth date|YYYY|MM|DD}} template",
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def validate_wikitext(wikitext: str) -> WikitextValidationResult:
+    """Run all checks against *wikitext* and return the aggregate result.
+
+    Always returns a result — never raises.  An empty or None-like string will
+    accumulate all error codes.
+    """
+    if not wikitext:
+        wikitext = ""
+
+    issues: list[ValidationIssue] = []
+
+    _check_infobox(wikitext, issues)
+    _check_refs(wikitext, issues)
+    _check_reflist(wikitext, issues)
+    _check_references_section(wikitext, issues)
+    _check_categories(wikitext, issues)
+    _check_unmatched_braces(wikitext, issues)
+
+    # Derive has_birth_info heuristic
+    has_birth_info = bool(
+        re.search(r"\|\s*birth_date\s*=\s*\S", wikitext, re.IGNORECASE)
+        or re.search(r"\bborn\s+\w", wikitext, re.IGNORECASE)
+    )
+    _check_birth_date_template(wikitext, has_birth_info, issues)
+
+    return WikitextValidationResult(issues=issues)

--- a/src/services/wikitext_validator.py
+++ b/src/services/wikitext_validator.py
@@ -14,8 +14,8 @@ from dataclasses import dataclass, field
 
 @dataclass
 class ValidationIssue:
-    level: str    # "error" | "warning"
-    code: str     # machine-readable key, e.g. "missing_infobox"
+    level: str  # "error" | "warning"
+    code: str  # machine-readable key, e.g. "missing_infobox"
     message: str  # human-readable one-liner
 
 
@@ -48,54 +48,65 @@ class WikitextValidationResult:
 # Individual checks
 # ---------------------------------------------------------------------------
 
+
 def _check_infobox(wikitext: str, issues: list[ValidationIssue]) -> None:
     """Error if {{Infobox officeholder is absent (case-insensitive)."""
     if not re.search(r"\{\{infobox officeholder", wikitext, re.IGNORECASE):
-        issues.append(ValidationIssue(
-            level="error",
-            code="missing_infobox",
-            message="Missing {{Infobox officeholder}} template",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="error",
+                code="missing_infobox",
+                message="Missing {{Infobox officeholder}} template",
+            )
+        )
 
 
 def _check_refs(wikitext: str, issues: list[ValidationIssue]) -> None:
     """Error if no <ref tag is present."""
     if not re.search(r"<ref", wikitext, re.IGNORECASE):
-        issues.append(ValidationIssue(
-            level="error",
-            code="missing_refs",
-            message="No <ref> citation tags found — every factual claim needs a citation",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="error",
+                code="missing_refs",
+                message="No <ref> citation tags found — every factual claim needs a citation",
+            )
+        )
 
 
 def _check_reflist(wikitext: str, issues: list[ValidationIssue]) -> None:
     """Error if {{reflist}} is absent (case-insensitive)."""
     if not re.search(r"\{\{reflist", wikitext, re.IGNORECASE):
-        issues.append(ValidationIssue(
-            level="error",
-            code="missing_reflist",
-            message="Missing {{reflist}} in References section",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="error",
+                code="missing_reflist",
+                message="Missing {{reflist}} in References section",
+            )
+        )
 
 
 def _check_references_section(wikitext: str, issues: list[ValidationIssue]) -> None:
     """Error if ==References== section header is absent."""
     if not re.search(r"==\s*References\s*==", wikitext, re.IGNORECASE):
-        issues.append(ValidationIssue(
-            level="error",
-            code="missing_references_section",
-            message="Missing ==References== section header",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="error",
+                code="missing_references_section",
+                message="Missing ==References== section header",
+            )
+        )
 
 
 def _check_categories(wikitext: str, issues: list[ValidationIssue]) -> None:
     """Error if no [[Category: link is present."""
     if not re.search(r"\[\[Category:", wikitext, re.IGNORECASE):
-        issues.append(ValidationIssue(
-            level="error",
-            code="missing_categories",
-            message="No [[Category:...]] links found — article must be categorised",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="error",
+                code="missing_categories",
+                message="No [[Category:...]] links found — article must be categorised",
+            )
+        )
 
 
 def _check_unmatched_braces(wikitext: str, issues: list[ValidationIssue]) -> None:
@@ -110,11 +121,13 @@ def _check_unmatched_braces(wikitext: str, issues: list[ValidationIssue]) -> Non
     if open_count != close_count:
         delta = open_count - close_count
         direction = "unclosed" if delta > 0 else "extra closing"
-        issues.append(ValidationIssue(
-            level="warning",
-            code="unmatched_braces",
-            message=f"Unmatched template braces: {abs(delta)} {direction} '{{{{' detected",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="warning",
+                code="unmatched_braces",
+                message=f"Unmatched template braces: {abs(delta)} {direction} '{{{{' detected",
+            )
+        )
 
 
 def _check_birth_date_template(
@@ -126,16 +139,19 @@ def _check_birth_date_template(
     if not has_birth_info:
         return
     if not re.search(r"\{\{birth date", wikitext, re.IGNORECASE):
-        issues.append(ValidationIssue(
-            level="warning",
-            code="missing_birth_date_template",
-            message="birth_date field present but missing {{birth date|YYYY|MM|DD}} template",
-        ))
+        issues.append(
+            ValidationIssue(
+                level="warning",
+                code="missing_birth_date_template",
+                message="birth_date field present but missing {{birth date|YYYY|MM|DD}} template",
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
+
 
 def validate_wikitext(wikitext: str) -> WikitextValidationResult:
     """Run all checks against *wikitext* and return the aggregate result.

--- a/src/templates/run.html
+++ b/src/templates/run.html
@@ -50,6 +50,16 @@
   </div>
 </form>
 
+<hr>
+<h2>Force-run specific offices</h2>
+<p class="muted">Immediately re-scrape one or more offices regardless of their scheduled batch day. Always fetches fresh HTML from Wikipedia (bypasses cache).</p>
+<div class="form-group">
+  <label for="forceRunIds">Office ID(s) <span class="muted">(comma-separated)</span></label>
+  <input type="text" id="forceRunIds" placeholder="e.g. 220, 314" style="width:220px;">
+  <button type="button" class="btn" id="forceRunBtn" style="margin-left:8px;">Force run</button>
+</div>
+<div id="forceRunError" class="alert alert-error" style="display:none;"></div>
+
 <div id="runningPanel" class="running-panel" style="display:none;">
   <div class="running-header">
     <span class="spinner" aria-hidden="true"></span>
@@ -358,6 +368,39 @@ if (_stopBtn) {
     } catch (_) {}
   });
 }
+
+// Force-run button
+document.getElementById('forceRunBtn').addEventListener('click', async () => {
+  const ids = document.getElementById('forceRunIds').value.trim();
+  const errEl = document.getElementById('forceRunError');
+  errEl.style.display = 'none';
+  if (!ids) {
+    errEl.textContent = 'Enter at least one office ID.';
+    errEl.style.display = 'block';
+    return;
+  }
+  const formData = new FormData();
+  formData.append('run_mode', 'delta');
+  formData.append('forced_office_ids', ids);
+  let jobId = null;
+  try {
+    const r = await fetch('/api/run', { method: 'POST', body: formData });
+    const data = await r.json();
+    if (r.status !== 202 || !data.job_id) {
+      throw new Error(data.detail || data.error || 'Failed to start job');
+    }
+    jobId = data.job_id;
+  } catch (err) {
+    errEl.textContent = 'Error: ' + err.message;
+    errEl.style.display = 'block';
+    return;
+  }
+  _resultEl.style.display = 'none';
+  _progressMessage.textContent = 'Starting force run…';
+  _resetProgressGroups();
+  _progressDetail.textContent = '';
+  _startPolling(jobId);
+});
 
 // Form submit
 document.getElementById('runForm').addEventListener('submit', async (e) => {

--- a/src/templates/wiki_draft_detail.html
+++ b/src/templates/wiki_draft_detail.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{# All Wikipedia API requests made by this app (submit + preview) include a descriptive
+   User-Agent header via HTTP_USER_AGENT per Wikimedia API:Etiquette policy. #}
 {% block title %}Wiki Draft #{{ draft.id }} – Office Holder{% endblock %}
 {% block content %}
 <p><a href="/data/wiki-drafts">&larr; Back to drafts</a></p>

--- a/src/templates/wiki_draft_detail.html
+++ b/src/templates/wiki_draft_detail.html
@@ -22,6 +22,52 @@
   <span id="statusMsg" style="margin-left:0.5em;"></span>
 </div>
 
+<!-- Submit to Wikipedia section -->
+<div id="submitSection" style="display:none; margin:1em 0;">
+  <button id="submitBtn" class="btn" style="background:var(--accent); color:#fff;">
+    Submit to Wikipedia
+  </button>
+  <span id="submitMsg" style="margin-left:0.75em;"></span>
+</div>
+
+<div id="credentialHelp" style="display:none; margin:1em 0; padding:0.75rem 1rem; border-radius:4px; background:rgba(224,49,49,0.08); border:1px solid var(--danger); font-size:0.9rem;">
+  <strong>Wikipedia bot credentials not configured.</strong>
+  To enable submission, set two environment variables on the server:
+  <ol style="margin:0.5em 0; padding-left:1.5em;">
+    <li><code>WIKIPEDIA_BOT_USERNAME</code> — your Wikipedia bot account name (e.g. <code>MyAccount@MyBot</code>)</li>
+    <li><code>WIKIPEDIA_BOT_PASSWORD</code> — the bot password from
+      <a href="https://en.wikipedia.org/wiki/Special:BotPasswords" target="_blank" rel="noopener">Special:BotPasswords</a>
+      (grant: <em>Edit existing pages</em> and <em>Create, edit, and move pages</em>)
+    </li>
+  </ol>
+  Articles are submitted to the <code>Draft:</code> namespace by default and reviewed via
+  <a href="https://en.wikipedia.org/wiki/Wikipedia:Articles_for_creation" target="_blank" rel="noopener">Articles for Creation</a>
+  before appearing in main article space. No Wikipedia account yet?
+  <a href="https://en.wikipedia.org/wiki/Special:CreateAccount" target="_blank" rel="noopener">Create one here.</a>
+</div>
+
+<!-- Submit confirmation modal -->
+<div id="submitModal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.6); z-index:1000; align-items:center; justify-content:center;">
+  <div style="background:var(--bg2); border:1px solid var(--border); border-radius:6px; padding:1.5rem; max-width:480px; width:90%;">
+    <h3 style="margin:0 0 0.75rem;">Confirm Wikipedia Submission</h3>
+    <p style="margin:0 0 0.5rem;">This will create a new article at:</p>
+    <p style="margin:0 0 0.75rem;"><strong id="modalTitle" style="color:var(--accent);"></strong></p>
+    <p style="font-size:0.875rem; color:var(--text-muted); margin:0 0 0.75rem;">
+      Articles in the <code>Draft:</code> namespace go through Wikipedia's Articles for Creation
+      review before appearing publicly. Uncheck below to submit directly to the main article space
+      (not recommended for first submissions).
+    </p>
+    <label style="display:flex; align-items:center; gap:0.5em; margin-bottom:1rem; font-size:0.875rem; cursor:pointer;">
+      <input type="checkbox" id="useDraftNs" checked>
+      Use <code>Draft:</code> namespace (recommended)
+    </label>
+    <div style="display:flex; gap:0.75rem; justify-content:flex-end;">
+      <button id="modalCancel" class="btn btn-secondary">Cancel</button>
+      <button id="modalConfirm" class="btn" style="background:var(--accent); color:#fff;">Submit</button>
+    </div>
+  </div>
+</div>
+
 <h2>Research Sources</h2>
 {% if sources %}
 <table>
@@ -44,12 +90,57 @@
 <p>No research sources recorded.</p>
 {% endif %}
 
-<h2>Article Draft (Wikitext)</h2>
-<pre style="background:var(--bg2); color:var(--text); padding:1em; overflow-x:auto; white-space:pre-wrap; border:1px solid var(--border);">{{ draft.proposal_text }}</pre>
+<!-- Wikitext validation panel -->
+{% if validation %}
+<div style="margin:1em 0; padding:0.75rem 1rem; border-radius:4px;
+  background:{% if validation.is_valid %}rgba(47,158,68,0.08){% else %}rgba(224,49,49,0.08){% endif %};
+  border:1px solid {% if validation.is_valid %}var(--success){% else %}var(--danger){% endif %};">
+  <strong>Wikitext Validation:
+    {% if validation.is_valid %}
+      <span style="color:var(--success);">PASS</span>
+    {% else %}
+      <span style="color:var(--danger);">{{ validation.errors|length }} error(s)</span>
+      {% if validation.warnings %}
+        &nbsp;·&nbsp;<span style="color:#e67700;">{{ validation.warnings|length }} warning(s)</span>
+      {% endif %}
+    {% endif %}
+  </strong>
+  {% if validation.errors %}
+  <ul style="margin:0.5em 0 0; padding-left:1.25em; color:var(--danger); font-size:0.875rem;">
+    {% for e in validation.errors %}<li>{{ e.message }}</li>{% endfor %}
+  </ul>
+  {% endif %}
+  {% if validation.warnings %}
+  <ul style="margin:0.5em 0 0; padding-left:1.25em; color:#e67700; font-size:0.875rem;">
+    {% for w in validation.warnings %}<li>{{ w.message }}</li>{% endfor %}
+  </ul>
+  {% endif %}
+</div>
+{% endif %}
+
+<h2>Article Draft</h2>
+
+<!-- Tab bar -->
+<div style="display:flex; border-bottom:2px solid var(--border); margin-bottom:1em;">
+  <button id="tabWikitext" onclick="switchTab('wikitext')" style="padding:0.4em 1.1em; border:none; border-bottom:2px solid var(--accent); background:none; cursor:pointer; font-weight:600; color:var(--accent); margin-bottom:-2px;">Wikitext</button>
+  <button id="tabPreview" onclick="switchTab('preview')" style="padding:0.4em 1.1em; border:none; border-bottom:2px solid transparent; background:none; cursor:pointer; color:var(--text-muted); margin-bottom:-2px;">Preview</button>
+</div>
+
+<div id="panelWikitext">
+  <pre style="background:var(--bg2); color:var(--text); padding:1em; overflow-x:auto; white-space:pre-wrap; border:1px solid var(--border);">{{ draft.proposal_text }}</pre>
+</div>
+
+<div id="panelPreview" style="display:none; border:1px solid var(--border); border-radius:4px; padding:1em; background:var(--bg2); overflow-x:auto;">
+  <span id="previewSpinner" style="display:none; color:var(--text-muted);">Loading preview from Wikipedia…</span>
+  <div id="previewContent"></div>
+</div>
 
 <script>
 (function() {
   const proposalId = {{ draft.id }};
+  const fullName = {{ draft.full_name | tojson }};
+
+  // ── Status change ────────────────────────────────────────────────────────
   document.querySelectorAll('.status-btn').forEach(btn => {
     btn.addEventListener('click', async () => {
       const newStatus = btn.dataset.status;
@@ -70,6 +161,99 @@
         msg.textContent = 'Error: ' + e.message;
       }
     });
+  });
+
+  // ── Tab switching ────────────────────────────────────────────────────────
+  let previewLoaded = false;
+
+  window.switchTab = function(tab) {
+    const isWikitext = tab === 'wikitext';
+    document.getElementById('panelWikitext').style.display = isWikitext ? 'block' : 'none';
+    document.getElementById('panelPreview').style.display = isWikitext ? 'none' : 'block';
+    document.getElementById('tabWikitext').style.cssText =
+      'padding:0.4em 1.1em; border:none; margin-bottom:-2px; background:none; cursor:pointer; font-weight:' +
+      (isWikitext ? '600; color:var(--accent); border-bottom:2px solid var(--accent);' : 'normal; color:var(--text-muted); border-bottom:2px solid transparent;');
+    document.getElementById('tabPreview').style.cssText =
+      'padding:0.4em 1.1em; border:none; margin-bottom:-2px; background:none; cursor:pointer; font-weight:' +
+      (!isWikitext ? '600; color:var(--accent); border-bottom:2px solid var(--accent);' : 'normal; color:var(--text-muted); border-bottom:2px solid transparent;');
+
+    if (!isWikitext && !previewLoaded) {
+      const spinner = document.getElementById('previewSpinner');
+      spinner.style.display = 'inline';
+      fetch('/api/wiki-drafts/' + proposalId + '/preview')
+        .then(r => r.json())
+        .then(d => {
+          spinner.style.display = 'none';
+          if (d.html) {
+            document.getElementById('previewContent').innerHTML = d.html;
+            previewLoaded = true;
+          } else {
+            document.getElementById('previewContent').textContent =
+              'Preview unavailable: ' + (d.detail || 'unknown error');
+          }
+        })
+        .catch(e => {
+          spinner.style.display = 'none';
+          document.getElementById('previewContent').textContent = 'Preview failed: ' + e.message;
+        });
+    }
+  };
+
+  // ── Wikipedia submit ─────────────────────────────────────────────────────
+  fetch('/api/wikipedia/status')
+    .then(r => r.json())
+    .then(data => {
+      if (data.configured) {
+        document.getElementById('submitSection').style.display = 'block';
+      } else {
+        document.getElementById('credentialHelp').style.display = 'block';
+      }
+    })
+    .catch(() => { /* silently hide submit — server unavailable */ });
+
+  function updateModalTitle() {
+    const useDraft = document.getElementById('useDraftNs').checked;
+    document.getElementById('modalTitle').textContent =
+      (useDraft ? 'Draft:' : '') + (fullName || '(unknown)');
+  }
+
+  document.getElementById('submitBtn').addEventListener('click', () => {
+    updateModalTitle();
+    const modal = document.getElementById('submitModal');
+    modal.style.display = 'flex';
+  });
+
+  document.getElementById('useDraftNs').addEventListener('change', updateModalTitle);
+
+  document.getElementById('modalCancel').addEventListener('click', () => {
+    document.getElementById('submitModal').style.display = 'none';
+  });
+
+  document.getElementById('submitModal').addEventListener('click', e => {
+    if (e.target === e.currentTarget) e.currentTarget.style.display = 'none';
+  });
+
+  document.getElementById('modalConfirm').addEventListener('click', async () => {
+    document.getElementById('submitModal').style.display = 'none';
+    const msg = document.getElementById('submitMsg');
+    msg.textContent = 'Submitting to Wikipedia…';
+    const useDraftNs = document.getElementById('useDraftNs').checked;
+    try {
+      const r = await fetch('/api/wiki-drafts/' + proposalId + '/submit', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({use_draft_namespace: useDraftNs}),
+      });
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.detail || 'Submission failed');
+      msg.innerHTML = 'Submitted! Article: <a href="' + window.esc(d.url) +
+        '" target="_blank" rel="noopener">' + window.esc(d.title) + '</a>';
+      document.getElementById('statusBadge').textContent = 'submitted';
+      document.getElementById('statusBadge').className = 'badge badge-submitted';
+      document.getElementById('submitBtn').disabled = true;
+    } catch(e) {
+      msg.textContent = 'Error: ' + e.message;
+    }
   });
 })();
 </script>

--- a/tests/test_ai_office_builder.py
+++ b/tests/test_ai_office_builder.py
@@ -20,6 +20,7 @@ from src.services.ai_office_builder import (
     AIOfficePageResponse,
     AITableConfig,
 )
+from src.services.gemini_vitals_researcher import SourceRecord, VitalsResearchResult
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -390,3 +391,173 @@ try:
 except Exception:
     # TestClient or app import may fail in CI without DB; skip gracefully
     pass
+
+
+# ---------------------------------------------------------------------------
+# polish_wiki_article — repair loop
+# ---------------------------------------------------------------------------
+
+_RESEARCH = VitalsResearchResult(
+    birth_date="1950-03-15",
+    birth_place="Springfield",
+    confidence="high",
+    biographical_notes="Long-serving politician known for public works.",
+    sources=[SourceRecord(url="https://example.com", source_type="government", notes="")],
+)
+
+_INVALID_ARTICLE = "Just plain text — no wikitext structure at all."
+
+_VALID_ARTICLE = """\
+{{Infobox officeholder
+| name       = Jane Politician
+| birth_date = {{birth date|1950|03|15}}
+}}
+Jane Politician was a politician.<ref>https://example.com</ref>
+==References==
+{{reflist}}
+[[Category:People]]
+"""
+
+
+def _make_text_completion(content: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    completion = MagicMock()
+    completion.choices = [choice]
+    return completion
+
+
+class TestPolishWikiArticleRepairLoop:
+    def test_no_repair_when_output_is_valid(self):
+        builder = AIOfficeBuilder(api_key="test-key")
+        with patch.object(
+            builder,
+            "_call_wiki_polish_openai",
+            return_value=_VALID_ARTICLE,
+        ) as mock_call:
+            result = builder.polish_wiki_article(
+                full_name="Jane Politician",
+                office_name="Mayor",
+                term_dates="2000-2004",
+                party="Independent",
+                location="Springfield",
+                research_result=_RESEARCH,
+            )
+        assert mock_call.call_count == 1
+        assert result == _VALID_ARTICLE
+
+    def test_repair_triggered_on_invalid_output(self):
+        builder = AIOfficeBuilder(api_key="test-key")
+        call_results = [_INVALID_ARTICLE, _VALID_ARTICLE]
+        with patch.object(
+            builder,
+            "_call_wiki_polish_openai",
+            side_effect=call_results,
+        ) as mock_call:
+            result = builder.polish_wiki_article(
+                full_name="Jane Politician",
+                office_name="Mayor",
+                term_dates="2000-2004",
+                party="Independent",
+                location="Springfield",
+                research_result=_RESEARCH,
+            )
+        assert mock_call.call_count == 2
+        assert result == _VALID_ARTICLE
+
+    def test_repair_call_includes_original_as_assistant_message(self):
+        builder = AIOfficeBuilder(api_key="test-key")
+        captured: list[list[dict]] = []
+
+        def side_effect(messages):
+            captured.append(list(messages))
+            if len(captured) == 1:
+                return _INVALID_ARTICLE
+            return _VALID_ARTICLE
+
+        with patch.object(builder, "_call_wiki_polish_openai", side_effect=side_effect):
+            builder.polish_wiki_article(
+                full_name="Jane Politician",
+                office_name="Mayor",
+                term_dates="2000-2004",
+                party="Independent",
+                location="Springfield",
+                research_result=_RESEARCH,
+            )
+
+        assert len(captured) == 2
+        repair_messages = captured[1]
+        roles = [m["role"] for m in repair_messages]
+        assert "assistant" in roles
+        assert roles[-1] == "user"
+        # The assistant message must be the first draft
+        assistant_msg = next(m for m in repair_messages if m["role"] == "assistant")
+        assert assistant_msg["content"] == _INVALID_ARTICLE
+
+    def test_first_draft_returned_if_repair_raises(self):
+        builder = AIOfficeBuilder(api_key="test-key")
+        call_count = 0
+
+        def side_effect(messages):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _INVALID_ARTICLE
+            raise openai.RateLimitError("rate limit", response=MagicMock(), body={})
+
+        with patch.object(builder, "_call_wiki_polish_openai", side_effect=side_effect):
+            result = builder.polish_wiki_article(
+                full_name="Jane Politician",
+                office_name="Mayor",
+                term_dates="2000-2004",
+                party="Independent",
+                location="Springfield",
+                research_result=_RESEARCH,
+            )
+        assert result == _INVALID_ARTICLE
+
+    def test_no_repair_when_article_too_long(self):
+        """Articles >= 8000 chars skip the repair attempt."""
+        long_invalid = _INVALID_ARTICLE + ("x" * 8000)
+        builder = AIOfficeBuilder(api_key="test-key")
+        with patch.object(
+            builder,
+            "_call_wiki_polish_openai",
+            return_value=long_invalid,
+        ) as mock_call:
+            result = builder.polish_wiki_article(
+                full_name="Jane Politician",
+                office_name="Mayor",
+                term_dates="2000-2004",
+                party="Independent",
+                location="Springfield",
+                research_result=_RESEARCH,
+            )
+        assert mock_call.call_count == 1
+        assert result == long_invalid
+
+    def test_no_repair_when_only_warnings(self):
+        """Warnings (not errors) should not trigger a repair call."""
+        # Valid article structure but with an unmatched brace warning
+        warning_article = _VALID_ARTICLE + "\n{{"  # extra open brace = warning only? No, this
+        # creates unmatched_braces warning. Errors come from structure checks.
+        # We need an article that has warnings but no errors.
+        warning_only_article = _VALID_ARTICLE + "\n{{"  # unmatched braces → warning
+        builder = AIOfficeBuilder(api_key="test-key")
+        with patch.object(
+            builder,
+            "_call_wiki_polish_openai",
+            return_value=warning_only_article,
+        ) as mock_call:
+            result = builder.polish_wiki_article(
+                full_name="Jane Politician",
+                office_name="Mayor",
+                term_dates="2000-2004",
+                party="Independent",
+                location="Springfield",
+                research_result=_RESEARCH,
+            )
+        assert mock_call.call_count == 1
+        assert result == warning_only_article

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -99,7 +99,11 @@ class TestClaudeStructuredOutput:
         """Claude sometimes wraps its JSON in ```json ... ``` — must be stripped."""
         from src.services.claude_client import ClaudeClient
 
-        fenced = "```json\n" + json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"}) + "\n```"
+        fenced = (
+            "```json\n"
+            + json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"})
+            + "\n```"
+        )
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text=fenced)]
 
@@ -118,7 +122,11 @@ class TestClaudeStructuredOutput:
         """Strip ``` fences with no language tag."""
         from src.services.claude_client import ClaudeClient
 
-        fenced = "```\n" + json.dumps({"is_valid": True, "concerns": [], "confidence": "medium"}) + "\n```"
+        fenced = (
+            "```\n"
+            + json.dumps({"is_valid": True, "concerns": [], "confidence": "medium"})
+            + "\n```"
+        )
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text=fenced)]
 

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -95,7 +95,44 @@ class TestClaudeStructuredOutput:
         assert "Birth date after death date" in result.concerns
         assert result.confidence == "high"
 
-    def test_non_json_response_returns_default(self):
+    def test_code_fenced_json_is_parsed_correctly(self):
+        """Claude sometimes wraps its JSON in ```json ... ``` — must be stripped."""
+        from src.services.claude_client import ClaudeClient
+
+        fenced = "```json\n" + json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"}) + "\n```"
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=fenced)]
+
+        with patch("anthropic.Anthropic") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.messages.create.return_value = mock_response
+            client = ClaudeClient(api_key="test")
+            result = client.check_data_quality("Check this record", {})
+
+        assert result is not None
+        assert result.is_valid is False
+        assert result.concerns == ["year as name"]
+        assert result.confidence == "high"
+
+    def test_code_fenced_json_no_language_tag(self):
+        """Strip ``` fences with no language tag."""
+        from src.services.claude_client import ClaudeClient
+
+        fenced = "```\n" + json.dumps({"is_valid": True, "concerns": [], "confidence": "medium"}) + "\n```"
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=fenced)]
+
+        with patch("anthropic.Anthropic") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.messages.create.return_value = mock_response
+            client = ClaudeClient(api_key="test")
+            result = client.check_data_quality("Check this record", {})
+
+        assert result is not None
+        assert result.is_valid is True
+
+    def test_non_json_response_returns_none(self):
+        """Unparseable response returns None so caller excludes provider from quorum."""
         from src.services.claude_client import ClaudeClient
 
         mock_response = MagicMock()
@@ -107,9 +144,7 @@ class TestClaudeStructuredOutput:
             client = ClaudeClient(api_key="test")
             result = client.check_data_quality("Check this record", {})
 
-        assert result.is_valid is True
-        assert result.concerns == []
-        assert result.confidence == "low"
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -439,6 +439,23 @@ class TestVoteClaude:
         assert vote.is_valid is False
         assert "suspicious" in vote.concerns
 
+    def test_none_result_returns_parse_error_unavailable(self):
+        """When check_data_quality returns None (e.g. code-fenced JSON that still
+        fails to parse), _vote_claude must return is_valid=None so the provider
+        is excluded from quorum rather than voting 'valid'."""
+        from src.services.consensus_voter import _vote_claude
+
+        mock_client = MagicMock()
+        mock_client.check_data_quality.return_value = None
+        with patch(
+            "src.services.claude_client.get_claude_client",
+            return_value=mock_client,
+        ):
+            vote = _vote_claude("prompt", {})
+        assert vote.provider == "claude"
+        assert vote.is_valid is None
+        assert vote.error == "parse error"
+
 
 # ---------------------------------------------------------------------------
 # Vote ordering is deterministic
@@ -470,6 +487,20 @@ class TestVoteOrdering:
 # ---------------------------------------------------------------------------
 # System prompt alignment — Claude and Gemini must receive _SYSTEM_PROMPT
 # ---------------------------------------------------------------------------
+
+
+class TestSystemPromptContent:
+    def test_system_prompt_contains_year_as_name_directive(self):
+        """_SYSTEM_PROMPT must explicitly instruct providers to reject year-as-name
+        records. Regression guard for Issue #398."""
+        from src.services.consensus_voter import _SYSTEM_PROMPT
+
+        assert "4-digit year" in _SYSTEM_PROMPT, (
+            "_SYSTEM_PROMPT must contain explicit year-as-name rejection rule"
+        )
+        assert "is_valid=false" in _SYSTEM_PROMPT, (
+            "_SYSTEM_PROMPT must explicitly say to return is_valid=false for year-as-name"
+        )
 
 
 class TestSystemPromptAlignment:

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -495,12 +495,12 @@ class TestSystemPromptContent:
         records. Regression guard for Issue #398."""
         from src.services.consensus_voter import _SYSTEM_PROMPT
 
-        assert "4-digit year" in _SYSTEM_PROMPT, (
-            "_SYSTEM_PROMPT must contain explicit year-as-name rejection rule"
-        )
-        assert "is_valid=false" in _SYSTEM_PROMPT, (
-            "_SYSTEM_PROMPT must explicitly say to return is_valid=false for year-as-name"
-        )
+        assert (
+            "4-digit year" in _SYSTEM_PROMPT
+        ), "_SYSTEM_PROMPT must contain explicit year-as-name rejection rule"
+        assert (
+            "is_valid=false" in _SYSTEM_PROMPT
+        ), "_SYSTEM_PROMPT must explicitly say to return is_valid=false for year-as-name"
 
 
 class TestSystemPromptAlignment:

--- a/tests/test_data_routes_wiki_submit.py
+++ b/tests/test_data_routes_wiki_submit.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Wikipedia submission and preview endpoints in src/routers/data.py.
+
+Covers:
+- GET /api/wikipedia/status
+- POST /api/wiki-drafts/{proposal_id}/submit
+- GET /api/wiki-drafts/{proposal_id}/preview
+- GET /data/wiki-drafts/{proposal_id} — validation panel rendering
+
+No live HTTP requests are made to Wikipedia in these tests.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_VALID_WIKITEXT = """\
+{{Infobox officeholder
+| name       = John Test
+| birth_date = {{birth date|1950|03|15}}
+}}
+John Test was a politician.<ref>https://example.com</ref>
+==References==
+{{reflist}}
+[[Category:People]]
+"""
+
+_INVALID_WIKITEXT = "Just some plain text with no wikitext structure."
+
+
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("wiki_submit_db")
+    db_path = tmp / "test.db"
+    cache_dir = tmp / "wiki_cache"
+    cache_dir.mkdir()
+
+    os.environ["OFFICE_HOLDER_DB_PATH"] = str(db_path)
+    os.environ["WIKI_CACHE_DIR"] = str(cache_dir)
+    # Ensure no real Wikipedia credentials in the test environment
+    os.environ.pop("WIKIPEDIA_BOT_USERNAME", None)
+    os.environ.pop("WIKIPEDIA_BOT_PASSWORD", None)
+
+    from src.main import app
+    from src.db.connection import init_db
+
+    init_db()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def seeded_draft_id(client):
+    """Create a pending wiki draft for a real individual. Returns proposal_id."""
+    from src.db import individuals as db_individuals
+    from src.db import individual_research_sources as db_research
+
+    ind_id = db_individuals.upsert_individual({
+        "wiki_url": "https://en.wikipedia.org/wiki/John_Test",
+        "full_name": "John Test",
+    })
+    proposal_id = db_research.insert_wiki_draft_proposal(
+        individual_id=ind_id,
+        proposal_text=_VALID_WIKITEXT,
+        status="pending",
+    )
+    return proposal_id
+
+
+@pytest.fixture(scope="module")
+def submitted_draft_id(client):
+    """Create an already-submitted draft. Returns proposal_id."""
+    from src.db import individuals as db_individuals
+    from src.db import individual_research_sources as db_research
+
+    ind_id = db_individuals.upsert_individual({
+        "wiki_url": "https://en.wikipedia.org/wiki/Already_Submitted",
+        "full_name": "Already Submitted",
+    })
+    proposal_id = db_research.insert_wiki_draft_proposal(
+        individual_id=ind_id,
+        proposal_text=_VALID_WIKITEXT,
+        status="submitted",
+    )
+    return proposal_id
+
+
+@pytest.fixture(scope="module")
+def nameless_draft_id(client):
+    """Create a draft for an individual with no full_name. Returns proposal_id."""
+    from src.db import individuals as db_individuals
+    from src.db import individual_research_sources as db_research
+
+    ind_id = db_individuals.upsert_individual({
+        "wiki_url": "https://en.wikipedia.org/wiki/Nameless_Person",
+        "full_name": None,
+    })
+    proposal_id = db_research.insert_wiki_draft_proposal(
+        individual_id=ind_id,
+        proposal_text=_VALID_WIKITEXT,
+        status="pending",
+    )
+    return proposal_id
+
+
+@pytest.fixture(scope="module")
+def invalid_wikitext_draft_id(client):
+    """Create a draft with invalid (unstructured) wikitext. Returns proposal_id."""
+    from src.db import individuals as db_individuals
+    from src.db import individual_research_sources as db_research
+
+    ind_id = db_individuals.upsert_individual({
+        "wiki_url": "https://en.wikipedia.org/wiki/Bad_Format_Person",
+        "full_name": "Bad Format Person",
+    })
+    proposal_id = db_research.insert_wiki_draft_proposal(
+        individual_id=ind_id,
+        proposal_text=_INVALID_WIKITEXT,
+        status="pending",
+    )
+    return proposal_id
+
+
+# ---------------------------------------------------------------------------
+# GET /api/wikipedia/status
+# ---------------------------------------------------------------------------
+
+
+class TestWikipediaStatus:
+    def test_not_configured_when_no_env_vars(self, client, monkeypatch):
+        monkeypatch.delenv("WIKIPEDIA_BOT_USERNAME", raising=False)
+        monkeypatch.delenv("WIKIPEDIA_BOT_PASSWORD", raising=False)
+        r = client.get("/api/wikipedia/status")
+        assert r.status_code == 200
+        assert r.json() == {"configured": False}
+
+    def test_configured_when_both_vars_set(self, client, monkeypatch):
+        monkeypatch.setenv("WIKIPEDIA_BOT_USERNAME", "TestBot@mybot")
+        monkeypatch.setenv("WIKIPEDIA_BOT_PASSWORD", "super-secret")
+        r = client.get("/api/wikipedia/status")
+        assert r.status_code == 200
+        assert r.json() == {"configured": True}
+
+    def test_not_configured_when_only_username_set(self, client, monkeypatch):
+        monkeypatch.setenv("WIKIPEDIA_BOT_USERNAME", "TestBot@mybot")
+        monkeypatch.delenv("WIKIPEDIA_BOT_PASSWORD", raising=False)
+        r = client.get("/api/wikipedia/status")
+        assert r.status_code == 200
+        assert r.json() == {"configured": False}
+
+    def test_not_configured_when_only_password_set(self, client, monkeypatch):
+        monkeypatch.delenv("WIKIPEDIA_BOT_USERNAME", raising=False)
+        monkeypatch.setenv("WIKIPEDIA_BOT_PASSWORD", "secret")
+        r = client.get("/api/wikipedia/status")
+        assert r.status_code == 200
+        assert r.json() == {"configured": False}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/wiki-drafts/{proposal_id}/submit
+# ---------------------------------------------------------------------------
+
+
+def _mock_submitter():
+    submitter = MagicMock()
+    submitter.submit_article.return_value = {"result": "Success"}
+    return submitter
+
+
+class TestSubmitWikiDraft:
+    def test_returns_503_when_no_credentials(self, client, seeded_draft_id):
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=None):
+            r = client.post(f"/api/wiki-drafts/{seeded_draft_id}/submit")
+        assert r.status_code == 503
+
+    def test_returns_404_for_missing_draft(self, client):
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=_mock_submitter()):
+            r = client.post("/api/wiki-drafts/99999/submit")
+        assert r.status_code == 404
+
+    def test_returns_409_for_non_pending_draft(self, client, submitted_draft_id):
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=_mock_submitter()):
+            r = client.post(f"/api/wiki-drafts/{submitted_draft_id}/submit")
+        assert r.status_code == 409
+
+    def test_returns_400_for_nameless_individual(self, client, nameless_draft_id):
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=_mock_submitter()):
+            r = client.post(f"/api/wiki-drafts/{nameless_draft_id}/submit")
+        assert r.status_code == 400
+
+    def test_submit_succeeds_with_draft_namespace_default(self, client, seeded_draft_id):
+        mock_sub = _mock_submitter()
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=mock_sub):
+            r = client.post(
+                f"/api/wiki-drafts/{seeded_draft_id}/submit",
+                json={"use_draft_namespace": True},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is True
+        assert data["title"].startswith("Draft:")
+        assert "John Test" in data["title"]
+        assert "wikipedia.org" in data["url"]
+
+    def test_submit_succeeds_with_main_namespace(self, client):
+        # Need a fresh pending draft for this test
+        from src.db import individuals as db_individuals
+        from src.db import individual_research_sources as db_research
+
+        ind_id = db_individuals.upsert_individual({
+            "wiki_url": "https://en.wikipedia.org/wiki/Direct_Submit_Person",
+            "full_name": "Direct Submit Person",
+        })
+        pid = db_research.insert_wiki_draft_proposal(
+            individual_id=ind_id,
+            proposal_text=_VALID_WIKITEXT,
+            status="pending",
+        )
+        mock_sub = _mock_submitter()
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=mock_sub):
+            r = client.post(
+                f"/api/wiki-drafts/{pid}/submit",
+                json={"use_draft_namespace": False},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert not data["title"].startswith("Draft:")
+        assert data["title"] == "Direct Submit Person"
+
+    def test_submit_sets_status_to_submitted_on_success(self, client):
+        from src.db import individuals as db_individuals
+        from src.db import individual_research_sources as db_research
+
+        ind_id = db_individuals.upsert_individual({
+            "wiki_url": "https://en.wikipedia.org/wiki/Status_Check_Person",
+            "full_name": "Status Check Person",
+        })
+        pid = db_research.insert_wiki_draft_proposal(
+            individual_id=ind_id,
+            proposal_text=_VALID_WIKITEXT,
+            status="pending",
+        )
+        mock_sub = _mock_submitter()
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=mock_sub):
+            client.post(f"/api/wiki-drafts/{pid}/submit", json={"use_draft_namespace": True})
+        # Check DB status was updated
+        draft = db_research.get_wiki_draft_proposal(pid)
+        assert draft["status"] == "submitted"
+
+    def test_submit_returns_502_and_sets_rejected_on_wikipedia_error(self, client):
+        from src.db import individuals as db_individuals
+        from src.db import individual_research_sources as db_research
+        from src.services.wikipedia_submit import WikipediaSubmitError
+
+        ind_id = db_individuals.upsert_individual({
+            "wiki_url": "https://en.wikipedia.org/wiki/Error_Person",
+            "full_name": "Error Person",
+        })
+        pid = db_research.insert_wiki_draft_proposal(
+            individual_id=ind_id,
+            proposal_text=_VALID_WIKITEXT,
+            status="pending",
+        )
+        mock_sub = _mock_submitter()
+        mock_sub.submit_article.side_effect = WikipediaSubmitError("articleexists")
+        with patch("src.services.wikipedia_submit.get_submitter", return_value=mock_sub):
+            r = client.post(f"/api/wiki-drafts/{pid}/submit", json={"use_draft_namespace": True})
+        assert r.status_code == 502
+        draft = db_research.get_wiki_draft_proposal(pid)
+        assert draft["status"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/wiki-drafts/{proposal_id}/preview
+# ---------------------------------------------------------------------------
+
+
+class TestWikiDraftPreview:
+    def test_returns_404_for_missing_draft(self, client):
+        r = client.get("/api/wiki-drafts/99999/preview")
+        assert r.status_code == 404
+
+    def test_returns_html_from_wikipedia_api(self, client, seeded_draft_id):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "parse": {"text": {"*": "<div><p>Rendered article</p></div>"}}
+        }
+        with patch("src.routers.data._requests") as mock_req:
+            mock_req.post.return_value = mock_response
+            r = client.get(f"/api/wiki-drafts/{seeded_draft_id}/preview")
+        assert r.status_code == 200
+        data = r.json()
+        assert "html" in data
+        assert "<p>Rendered article</p>" in data["html"]
+
+    def test_returns_503_on_wikipedia_api_failure(self, client, seeded_draft_id):
+        import requests as real_requests
+        with patch("src.routers.data._requests") as mock_req:
+            mock_req.post.side_effect = real_requests.RequestException("timeout")
+            r = client.get(f"/api/wiki-drafts/{seeded_draft_id}/preview")
+        assert r.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# GET /data/wiki-drafts/{proposal_id} — validation panel
+# ---------------------------------------------------------------------------
+
+
+class TestDraftDetailValidationPanel:
+    def test_detail_page_shows_validation_panel(self, client, seeded_draft_id):
+        r = client.get(f"/data/wiki-drafts/{seeded_draft_id}")
+        assert r.status_code == 200
+        assert "Wikitext Validation" in r.text
+
+    def test_valid_draft_shows_pass(self, client, seeded_draft_id):
+        r = client.get(f"/data/wiki-drafts/{seeded_draft_id}")
+        assert r.status_code == 200
+        assert "PASS" in r.text
+
+    def test_invalid_draft_shows_errors(self, client, invalid_wikitext_draft_id):
+        r = client.get(f"/data/wiki-drafts/{invalid_wikitext_draft_id}")
+        assert r.status_code == 200
+        assert "error" in r.text.lower()
+        # Must not show PASS for a structurally broken draft
+        # (check that the danger color class appears, not a green pass)
+        assert "missing_infobox" not in r.text  # code not shown, message is
+        assert "Infobox" in r.text  # error message mentions Infobox
+
+    def test_detail_page_includes_preview_tab(self, client, seeded_draft_id):
+        r = client.get(f"/data/wiki-drafts/{seeded_draft_id}")
+        assert r.status_code == 200
+        assert "Preview" in r.text
+        assert "switchTab" in r.text

--- a/tests/test_data_routes_wiki_submit.py
+++ b/tests/test_data_routes_wiki_submit.py
@@ -10,6 +10,8 @@ Covers:
 No live HTTP requests are made to Wikipedia in these tests.
 All Wikipedia API calls in the production code (submit + preview) include a
 descriptive User-Agent header via HTTP_USER_AGENT per Wikimedia API etiquette.
+Rate limiting (sleep/backoff/retry) is applied in the production endpoints;
+all HTTP calls in these tests are mocked so no live Wikipedia requests are made.
 """
 
 from __future__ import annotations
@@ -19,7 +21,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -66,10 +67,12 @@ def seeded_draft_id(client):
     from src.db import individuals as db_individuals
     from src.db import individual_research_sources as db_research
 
-    ind_id = db_individuals.upsert_individual({
-        "wiki_url": "https://en.wikipedia.org/wiki/John_Test",
-        "full_name": "John Test",
-    })
+    ind_id = db_individuals.upsert_individual(
+        {
+            "wiki_url": "https://en.wikipedia.org/wiki/John_Test",
+            "full_name": "John Test",
+        }
+    )
     proposal_id = db_research.insert_wiki_draft_proposal(
         individual_id=ind_id,
         proposal_text=_VALID_WIKITEXT,
@@ -84,10 +87,12 @@ def submitted_draft_id(client):
     from src.db import individuals as db_individuals
     from src.db import individual_research_sources as db_research
 
-    ind_id = db_individuals.upsert_individual({
-        "wiki_url": "https://en.wikipedia.org/wiki/Already_Submitted",
-        "full_name": "Already Submitted",
-    })
+    ind_id = db_individuals.upsert_individual(
+        {
+            "wiki_url": "https://en.wikipedia.org/wiki/Already_Submitted",
+            "full_name": "Already Submitted",
+        }
+    )
     proposal_id = db_research.insert_wiki_draft_proposal(
         individual_id=ind_id,
         proposal_text=_VALID_WIKITEXT,
@@ -102,10 +107,12 @@ def nameless_draft_id(client):
     from src.db import individuals as db_individuals
     from src.db import individual_research_sources as db_research
 
-    ind_id = db_individuals.upsert_individual({
-        "wiki_url": "https://en.wikipedia.org/wiki/Nameless_Person",
-        "full_name": None,
-    })
+    ind_id = db_individuals.upsert_individual(
+        {
+            "wiki_url": "https://en.wikipedia.org/wiki/Nameless_Person",
+            "full_name": None,
+        }
+    )
     proposal_id = db_research.insert_wiki_draft_proposal(
         individual_id=ind_id,
         proposal_text=_VALID_WIKITEXT,
@@ -120,10 +127,12 @@ def invalid_wikitext_draft_id(client):
     from src.db import individuals as db_individuals
     from src.db import individual_research_sources as db_research
 
-    ind_id = db_individuals.upsert_individual({
-        "wiki_url": "https://en.wikipedia.org/wiki/Bad_Format_Person",
-        "full_name": "Bad Format Person",
-    })
+    ind_id = db_individuals.upsert_individual(
+        {
+            "wiki_url": "https://en.wikipedia.org/wiki/Bad_Format_Person",
+            "full_name": "Bad Format Person",
+        }
+    )
     proposal_id = db_research.insert_wiki_draft_proposal(
         individual_id=ind_id,
         proposal_text=_INVALID_WIKITEXT,
@@ -218,10 +227,12 @@ class TestSubmitWikiDraft:
         from src.db import individuals as db_individuals
         from src.db import individual_research_sources as db_research
 
-        ind_id = db_individuals.upsert_individual({
-            "wiki_url": "https://en.wikipedia.org/wiki/Direct_Submit_Person",
-            "full_name": "Direct Submit Person",
-        })
+        ind_id = db_individuals.upsert_individual(
+            {
+                "wiki_url": "https://en.wikipedia.org/wiki/Direct_Submit_Person",
+                "full_name": "Direct Submit Person",
+            }
+        )
         pid = db_research.insert_wiki_draft_proposal(
             individual_id=ind_id,
             proposal_text=_VALID_WIKITEXT,
@@ -242,10 +253,12 @@ class TestSubmitWikiDraft:
         from src.db import individuals as db_individuals
         from src.db import individual_research_sources as db_research
 
-        ind_id = db_individuals.upsert_individual({
-            "wiki_url": "https://en.wikipedia.org/wiki/Status_Check_Person",
-            "full_name": "Status Check Person",
-        })
+        ind_id = db_individuals.upsert_individual(
+            {
+                "wiki_url": "https://en.wikipedia.org/wiki/Status_Check_Person",
+                "full_name": "Status Check Person",
+            }
+        )
         pid = db_research.insert_wiki_draft_proposal(
             individual_id=ind_id,
             proposal_text=_VALID_WIKITEXT,
@@ -263,10 +276,12 @@ class TestSubmitWikiDraft:
         from src.db import individual_research_sources as db_research
         from src.services.wikipedia_submit import WikipediaSubmitError
 
-        ind_id = db_individuals.upsert_individual({
-            "wiki_url": "https://en.wikipedia.org/wiki/Error_Person",
-            "full_name": "Error Person",
-        })
+        ind_id = db_individuals.upsert_individual(
+            {
+                "wiki_url": "https://en.wikipedia.org/wiki/Error_Person",
+                "full_name": "Error Person",
+            }
+        )
         pid = db_research.insert_wiki_draft_proposal(
             individual_id=ind_id,
             proposal_text=_VALID_WIKITEXT,
@@ -307,6 +322,7 @@ class TestWikiDraftPreview:
 
     def test_returns_503_on_wikipedia_api_failure(self, client, seeded_draft_id):
         import requests as real_requests
+
         with patch("src.routers.data._requests") as mock_req:
             mock_req.post.side_effect = real_requests.RequestException("timeout")
             r = client.get(f"/api/wiki-drafts/{seeded_draft_id}/preview")

--- a/tests/test_data_routes_wiki_submit.py
+++ b/tests/test_data_routes_wiki_submit.py
@@ -8,6 +8,8 @@ Covers:
 - GET /data/wiki-drafts/{proposal_id} — validation panel rendering
 
 No live HTTP requests are made to Wikipedia in these tests.
+All Wikipedia API calls in the production code (submit + preview) include a
+descriptive User-Agent header via HTTP_USER_AGENT per Wikimedia API etiquette.
 """
 
 from __future__ import annotations

--- a/tests/test_gemini_vitals_researcher.py
+++ b/tests/test_gemini_vitals_researcher.py
@@ -502,3 +502,65 @@ class TestPolicyCompliance:
         service_path = Path("src/services/gemini_vitals_researcher.py")
         content = service_path.read_text()
         assert "max_output_tokens" in content
+
+
+# ---------------------------------------------------------------------------
+# check_data_quality — truncated / unparseable JSON handling (#399)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDataQuality:
+    """check_data_quality must return None on JSONDecodeError rather than raising,
+    so _vote_gemini in consensus_voter.py treats Gemini as unavailable instead of
+    propagating an exception."""
+
+    def _make_researcher(self, response_text: str):
+        """Return a GeminiVitalsResearcher with a mocked Gemini client."""
+        from src.services.gemini_vitals_researcher import GeminiVitalsResearcher
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = response_text
+        mock_client.models.generate_content.return_value = mock_response
+
+        researcher = GeminiVitalsResearcher.__new__(GeminiVitalsResearcher)
+        researcher._client = mock_client
+        researcher._model = "gemini-test"
+        return researcher
+
+    def test_valid_json_returned(self):
+        researcher = self._make_researcher(
+            json.dumps({"is_valid": False, "concerns": ["year as name"], "confidence": "high"})
+        )
+        result = researcher.check_data_quality("some prompt")
+        assert result is not None
+        assert result["is_valid"] is False
+        assert result["concerns"] == ["year as name"]
+
+    def test_truncated_json_returns_none(self):
+        """Gemini occasionally returns truncated JSON (e.g. cut off at 25 chars).
+        check_data_quality must return None rather than raising JSONDecodeError."""
+        researcher = self._make_researcher('{"is_val')
+        result = researcher.check_data_quality("some prompt")
+        assert result is None
+
+    def test_empty_response_returns_none(self):
+        researcher = self._make_researcher("")
+        result = researcher.check_data_quality("some prompt")
+        assert result is None
+
+    def test_max_output_tokens_1024_for_data_quality(self):
+        """data quality calls must use max_output_tokens=1024 (raised from 512)
+        to prevent truncation. Regression guard for Issue #399."""
+        researcher = self._make_researcher(
+            json.dumps({"is_valid": True, "concerns": [], "confidence": "low"})
+        )
+        researcher.check_data_quality("some prompt")
+        call_args = researcher._client.models.generate_content.call_args
+        config = call_args.kwargs.get("config") or (
+            call_args.args[1] if len(call_args.args) > 1 else None
+        )
+        assert config is not None
+        assert (
+            config.max_output_tokens == 1024
+        ), "max_output_tokens must be 1024 for data quality checks to avoid truncation"

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -191,6 +191,7 @@ def _run_api_run_in_thread(rs, **kwargs):
         force_overwrite="",
         living_only="",
         valid_page_paths_only="",
+        forced_office_ids="",
     )
     defaults.update(kwargs)
 

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -245,3 +245,87 @@ def test_job_store_eviction_removes_old_completed_jobs(client, monkeypatch):
     status_resp = client.get(f"/api/run/status/{job_id}")
     assert status_resp.status_code == 200
     assert status_resp.json()["status"] == "complete"
+
+
+# ---------------------------------------------------------------------------
+# Force-run specific offices (#397)
+# ---------------------------------------------------------------------------
+
+
+def test_forced_office_ids_sets_office_id_list_and_refresh(client, monkeypatch):
+    """POST /api/run with forced_office_ids passes office_id_list and refresh_table_cache=True."""
+    import src.routers.run_scraper as rs
+
+    captured = {}
+
+    def _capture_run(**kwargs):
+        captured.update(kwargs)
+        return {"cancelled": False, "terms": 0}
+
+    monkeypatch.setattr(rs, "run_with_db", _capture_run)
+
+    resp = client.post("/api/run", data={"forced_office_ids": "220, 314"})
+    assert resp.status_code == 202
+
+    # Wait for the job to finish so captured is populated
+    job_id = resp.json()["job_id"]
+    for _ in range(40):
+        status = client.get(f"/api/run/status/{job_id}").json()
+        if status.get("status") != "running":
+            break
+        time.sleep(0.05)
+
+    assert set(captured.get("office_ids", [])) == {220, 314}
+    assert captured.get("refresh_table_cache") is True
+
+
+def test_forced_office_ids_ignores_non_numeric_tokens(client, monkeypatch):
+    """Non-numeric tokens in forced_office_ids are silently ignored."""
+    import src.routers.run_scraper as rs
+
+    captured = {}
+
+    def _capture_run(**kwargs):
+        captured.update(kwargs)
+        return {"cancelled": False, "terms": 0}
+
+    monkeypatch.setattr(rs, "run_with_db", _capture_run)
+
+    resp = client.post("/api/run", data={"forced_office_ids": "42, abc, , 99"})
+    assert resp.status_code == 202
+
+    job_id = resp.json()["job_id"]
+    for _ in range(40):
+        status = client.get(f"/api/run/status/{job_id}").json()
+        if status.get("status") != "running":
+            break
+        time.sleep(0.05)
+
+    assert set(captured.get("office_ids", [])) == {42, 99}
+
+
+def test_forced_office_ids_empty_string_does_not_override(client, monkeypatch):
+    """Empty forced_office_ids leaves office_ids and refresh_table_cache unchanged."""
+    import src.routers.run_scraper as rs
+
+    captured = {}
+
+    def _capture_run(**kwargs):
+        captured.update(kwargs)
+        return {"cancelled": False, "terms": 0}
+
+    monkeypatch.setattr(rs, "run_with_db", _capture_run)
+
+    resp = client.post("/api/run", data={"run_mode": "delta", "forced_office_ids": ""})
+    assert resp.status_code == 202
+
+    job_id = resp.json()["job_id"]
+    for _ in range(40):
+        status = client.get(f"/api/run/status/{job_id}").json()
+        if status.get("status") != "running":
+            break
+        time.sleep(0.05)
+
+    # No office_ids filter and no forced refresh
+    assert captured.get("office_ids") is None
+    assert captured.get("refresh_table_cache") is False

--- a/tests/test_suspect_record_flagger.py
+++ b/tests/test_suspect_record_flagger.py
@@ -295,3 +295,83 @@ class TestCheckAndGateErrorHandling:
             should_insert, flag_id = check_and_gate("1978", "", 94, conn)
         assert should_insert is True
         assert flag_id is None
+
+
+# ---------------------------------------------------------------------------
+# GH issue enrichment: source_page_url + row_data (#400)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGhIssueEnrichment:
+    """_create_gh_issue includes source_page_url and row_data in the issue body."""
+
+    def _call(self, source_page_url=None, row_data=None):
+        from src.services.suspect_record_flagger import _create_gh_issue
+
+        captured = {}
+
+        def fake_create_issue(title, body, labels):
+            captured["body"] = body
+            return {"html_url": "https://github.com/org/repo/issues/1"}
+
+        mock_gh = MagicMock()
+        mock_gh.create_issue.side_effect = fake_create_issue
+
+        with patch("src.services.github_client.get_github_client", return_value=mock_gh):
+            _create_gh_issue(
+                full_name="1999",
+                wiki_url="No link:42:1999",
+                office_id=42,
+                flag_reasons=["full_name is a 4-digit year: '1999'"],
+                verdict_name="disagreement",
+                ai_votes_summary="- **claude**: invalid",
+                source_page_url=source_page_url,
+                row_data=row_data,
+            )
+        return captured.get("body", "")
+
+    def test_source_page_url_appears_in_body(self):
+        body = self._call(source_page_url="https://en.wikipedia.org/wiki/Some_Office")
+        assert "### Source" in body
+        assert "https://en.wikipedia.org/wiki/Some_Office" in body
+
+    def test_row_data_appears_as_json_block(self):
+        row_data = {"Name": "1999", "Term start": "1999", "Term end": "2000"}
+        body = self._call(row_data=row_data)
+        assert "### Source" in body
+        assert "```json" in body
+        assert '"Name": "1999"' in body
+
+    def test_no_source_section_when_both_none(self):
+        body = self._call()
+        assert "### Source" not in body
+
+    def test_check_and_gate_passes_source_url_to_gh_issue(self, tmp_path):
+        """check_and_gate forwards source_page_url to _create_gh_issue."""
+        conn = _conn(tmp_path)
+        mock_voter = MagicMock()
+        mock_voter.vote.return_value = _make_verdict(Verdict.DISAGREEMENT)
+        captured = {}
+
+        def fake_gh_issue(**kwargs):
+            captured.update(kwargs)
+            return "https://github.com/org/repo/issues/2"
+
+        with (
+            patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter),
+            patch(
+                "src.services.suspect_record_flagger._create_gh_issue",
+                side_effect=fake_gh_issue,
+            ),
+        ):
+            check_and_gate(
+                full_name="1978",
+                wiki_url="No link:94:1978",
+                office_id=94,
+                conn=conn,
+                source_page_url="https://en.wikipedia.org/wiki/Test_Office",
+                row_data={"Name": "1978"},
+            )
+
+        assert captured.get("source_page_url") == "https://en.wikipedia.org/wiki/Test_Office"
+        assert captured.get("row_data") == {"Name": "1978"}

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -12,7 +12,7 @@ Tests cover:
 - Dict shrinks after references are released (GC frees the lock)
 - Concurrent access from multiple threads does not corrupt the dict
   and each thread gets a usable lock
-- WIKI_TABLE_CACHE_ENABLED=0 bypasses disk I/O and calls _fetch_table_from_url directly
+- TABLE_HTML_CACHE_ENABLED=0 bypasses disk I/O and calls _fetch_table_from_url directly
 """
 
 from __future__ import annotations
@@ -167,18 +167,18 @@ class TestThreadSafety:
 
 
 # ---------------------------------------------------------------------------
-# WIKI_TABLE_CACHE_ENABLED toggle (#396)
+# TABLE_HTML_CACHE_ENABLED toggle (#396)
 # ---------------------------------------------------------------------------
 
 
 class TestCacheToggle:
     def test_disabled_bypasses_disk_and_calls_fetch_directly(self):
-        """When WIKI_TABLE_CACHE_ENABLED=0, get_table_html_cached calls _fetch_table_from_url
+        """When TABLE_HTML_CACHE_ENABLED=0, get_table_html_cached calls _fetch_table_from_url
         directly with run_cache=None and skips all disk I/O."""
         from src.scraper import table_cache
 
         fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
-        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+        with patch.dict("os.environ", {"TABLE_HTML_CACHE_ENABLED": "0"}):
             with patch.object(
                 table_cache, "_fetch_table_from_url", return_value=fake_result
             ) as mock_fetch:
@@ -192,10 +192,10 @@ class TestCacheToggle:
         assert result == fake_result
 
     def test_disabled_write_is_noop(self, tmp_path):
-        """When WIKI_TABLE_CACHE_ENABLED=0, write_table_html_cache writes no files."""
+        """When TABLE_HTML_CACHE_ENABLED=0, write_table_html_cache writes no files."""
         from src.scraper import table_cache
 
-        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+        with patch.dict("os.environ", {"TABLE_HTML_CACHE_ENABLED": "0"}):
             with patch.object(table_cache, "_cache_dir", return_value=tmp_path):
                 table_cache.write_table_html_cache(
                     url="https://en.wikipedia.org/wiki/Test",
@@ -207,7 +207,7 @@ class TestCacheToggle:
         assert list(tmp_path.iterdir()) == []
 
     def test_enabled_by_default(self):
-        """Without WIKI_TABLE_CACHE_ENABLED set, normal disk-cache path is used."""
+        """Without TABLE_HTML_CACHE_ENABLED set, normal disk-cache path is used."""
         from src.scraper import table_cache
 
         fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
@@ -215,7 +215,7 @@ class TestCacheToggle:
             # Remove key if present to test default
             import os
 
-            os.environ.pop("WIKI_TABLE_CACHE_ENABLED", None)
+            os.environ.pop("TABLE_HTML_CACHE_ENABLED", None)
             with patch.object(
                 table_cache, "_fetch_table_from_url", return_value=fake_result
             ) as mock_fetch:
@@ -231,11 +231,11 @@ class TestCacheToggle:
         mock_fetch.assert_called_once()
 
     def test_explicit_enabled_uses_normal_path(self):
-        """WIKI_TABLE_CACHE_ENABLED=1 uses the normal disk-cache path."""
+        """TABLE_HTML_CACHE_ENABLED=1 uses the normal disk-cache path."""
         from src.scraper import table_cache
 
         fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
-        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "1"}):
+        with patch.dict("os.environ", {"TABLE_HTML_CACHE_ENABLED": "1"}):
             with patch.object(
                 table_cache, "_fetch_table_from_url", return_value=fake_result
             ) as mock_fetch:

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Tests for the _key_locks memory-leak fix in table_cache.py (Issue #224).
+"""Tests for the _key_locks memory-leak fix and cache toggle in table_cache.py.
 
-The original implementation used a plain dict[str, threading.Lock] that
-grew forever. The fix uses weakref.WeakValueDictionary so entries are
-automatically removed once no thread holds a reference to the lock.
+table_cache.py never makes HTTP requests directly — all Wikipedia fetches go
+through _fetch_table_from_url() → wiki_session(), which enforces the
+User-Agent header and rate limiting per Wikimedia policy (wiki_fetch.py).
 
 Tests cover:
 - _key_lock returns a _KeyLock with working __enter__/__exit__
@@ -12,6 +12,7 @@ Tests cover:
 - Dict shrinks after references are released (GC frees the lock)
 - Concurrent access from multiple threads does not corrupt the dict
   and each thread gets a usable lock
+- WIKI_TABLE_CACHE_ENABLED=0 bypasses disk I/O and calls _fetch_table_from_url directly
 """
 
 from __future__ import annotations

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import gc
 import threading
 import weakref
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -162,3 +163,87 @@ class TestThreadSafety:
 
         gc.collect()
         assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# WIKI_TABLE_CACHE_ENABLED toggle (#396)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheToggle:
+    def test_disabled_bypasses_disk_and_calls_fetch_directly(self):
+        """When WIKI_TABLE_CACHE_ENABLED=0, get_table_html_cached calls _fetch_table_from_url
+        directly with run_cache=None and skips all disk I/O."""
+        from src.scraper import table_cache
+
+        fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
+        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+            with patch.object(
+                table_cache, "_fetch_table_from_url", return_value=fake_result
+            ) as mock_fetch:
+                result = table_cache.get_table_html_cached(
+                    "https://en.wikipedia.org/wiki/Test", table_no=1
+                )
+
+        mock_fetch.assert_called_once_with(
+            "https://en.wikipedia.org/wiki/Test", 1, False, run_cache=None
+        )
+        assert result == fake_result
+
+    def test_disabled_write_is_noop(self, tmp_path):
+        """When WIKI_TABLE_CACHE_ENABLED=0, write_table_html_cache writes no files."""
+        from src.scraper import table_cache
+
+        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "0"}):
+            with patch.object(table_cache, "_cache_dir", return_value=tmp_path):
+                table_cache.write_table_html_cache(
+                    url="https://en.wikipedia.org/wiki/Test",
+                    table_no=1,
+                    html="<table></table>",
+                    num_tables=1,
+                )
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_enabled_by_default(self):
+        """Without WIKI_TABLE_CACHE_ENABLED set, normal disk-cache path is used."""
+        from src.scraper import table_cache
+
+        fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
+        with patch.dict("os.environ", {}, clear=False):
+            # Remove key if present to test default
+            import os
+
+            os.environ.pop("WIKI_TABLE_CACHE_ENABLED", None)
+            with patch.object(
+                table_cache, "_fetch_table_from_url", return_value=fake_result
+            ) as mock_fetch:
+                with patch.object(table_cache, "_cache_dir") as mock_dir:
+                    mock_path = MagicMock()
+                    mock_path.__truediv__ = MagicMock(return_value=MagicMock(exists=lambda: False))
+                    mock_dir.return_value = mock_path
+                    table_cache.get_table_html_cached(
+                        "https://en.wikipedia.org/wiki/Test2", table_no=1
+                    )
+
+        # Normal path calls _fetch_table_from_url but NOT with run_cache=None forced
+        mock_fetch.assert_called_once()
+
+    def test_explicit_enabled_uses_normal_path(self):
+        """WIKI_TABLE_CACHE_ENABLED=1 uses the normal disk-cache path."""
+        from src.scraper import table_cache
+
+        fake_result = {"table_no": 1, "num_tables": 1, "html": "<table></table>"}
+        with patch.dict("os.environ", {"WIKI_TABLE_CACHE_ENABLED": "1"}):
+            with patch.object(
+                table_cache, "_fetch_table_from_url", return_value=fake_result
+            ) as mock_fetch:
+                with patch.object(table_cache, "_cache_dir") as mock_dir:
+                    mock_path = MagicMock()
+                    mock_path.__truediv__ = MagicMock(return_value=MagicMock(exists=lambda: False))
+                    mock_dir.return_value = mock_path
+                    table_cache.get_table_html_cached(
+                        "https://en.wikipedia.org/wiki/Test3", table_no=1
+                    )
+
+        mock_fetch.assert_called_once()

--- a/tests/test_table_cache_key_locks.py
+++ b/tests/test_table_cache_key_locks.py
@@ -3,7 +3,7 @@
 
 table_cache.py never makes HTTP requests directly — all Wikipedia fetches go
 through _fetch_table_from_url() → wiki_session(), which enforces the
-User-Agent header and rate limiting per Wikimedia policy (wiki_fetch.py).
+User-Agent header, rate_limit, and backoff/retry per Wikimedia policy (wiki_fetch.py).
 
 Tests cover:
 - _key_lock returns a _KeyLock with working __enter__/__exit__

--- a/tests/test_wikitext_validator.py
+++ b/tests/test_wikitext_validator.py
@@ -55,9 +55,7 @@ class TestValidationResult:
         assert r.is_valid is True
 
     def test_is_valid_false_when_errors_present(self):
-        r = WikitextValidationResult(
-            issues=[ValidationIssue(level="error", code="e", message="e")]
-        )
+        r = WikitextValidationResult(issues=[ValidationIssue(level="error", code="e", message="e")])
         assert r.is_valid is False
 
     def test_errors_property_filters_correctly(self):

--- a/tests/test_wikitext_validator.py
+++ b/tests/test_wikitext_validator.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for src/services/wikitext_validator.py.
+
+All checks are pure-Python (no I/O). Tests are grouped by check function and
+cover both the happy path and each individual failure mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.wikitext_validator import (
+    ValidationIssue,
+    WikitextValidationResult,
+    validate_wikitext,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal valid wikitext fixture
+# ---------------------------------------------------------------------------
+
+_VALID = """\
+{{Infobox officeholder
+| name       = Jane Doe
+| birth_date = {{birth date|1970|01|15}}
+}}
+
+Jane Doe is a politician.<ref name="ex">{{cite web |url=https://example.com |title=Jane Doe}}</ref>
+
+==Early life==
+Born in Springfield.
+
+==References==
+{{reflist}}
+
+[[Category:Living people]]
+[[Category:Politicians]]
+"""
+
+
+# ---------------------------------------------------------------------------
+# WikitextValidationResult properties
+# ---------------------------------------------------------------------------
+
+
+class TestValidationResult:
+    def test_is_valid_true_when_no_issues(self):
+        r = WikitextValidationResult()
+        assert r.is_valid is True
+
+    def test_is_valid_true_when_only_warnings(self):
+        r = WikitextValidationResult(
+            issues=[ValidationIssue(level="warning", code="w", message="w")]
+        )
+        assert r.is_valid is True
+
+    def test_is_valid_false_when_errors_present(self):
+        r = WikitextValidationResult(
+            issues=[ValidationIssue(level="error", code="e", message="e")]
+        )
+        assert r.is_valid is False
+
+    def test_errors_property_filters_correctly(self):
+        issues = [
+            ValidationIssue(level="error", code="e1", message="e1"),
+            ValidationIssue(level="warning", code="w1", message="w1"),
+        ]
+        r = WikitextValidationResult(issues=issues)
+        assert len(r.errors) == 1
+        assert r.errors[0].code == "e1"
+
+    def test_warnings_property_filters_correctly(self):
+        issues = [
+            ValidationIssue(level="error", code="e1", message="e1"),
+            ValidationIssue(level="warning", code="w1", message="w1"),
+        ]
+        r = WikitextValidationResult(issues=issues)
+        assert len(r.warnings) == 1
+        assert r.warnings[0].code == "w1"
+
+    def test_as_dict_structure(self):
+        issues = [
+            ValidationIssue(level="error", code="missing_infobox", message="Missing infobox"),
+            ValidationIssue(level="warning", code="unmatched_braces", message="Braces"),
+        ]
+        r = WikitextValidationResult(issues=issues)
+        d = r.as_dict()
+        assert d["is_valid"] is False
+        assert len(d["errors"]) == 1
+        assert d["errors"][0] == {"code": "missing_infobox", "message": "Missing infobox"}
+        assert len(d["warnings"]) == 1
+        assert d["warnings"][0]["code"] == "unmatched_braces"
+
+    def test_as_dict_valid_article(self):
+        r = WikitextValidationResult()
+        d = r.as_dict()
+        assert d == {"is_valid": True, "errors": [], "warnings": []}
+
+
+# ---------------------------------------------------------------------------
+# Full valid article passes all checks
+# ---------------------------------------------------------------------------
+
+
+class TestValidArticle:
+    def test_valid_article_has_no_issues(self):
+        r = validate_wikitext(_VALID)
+        assert r.is_valid is True
+        assert r.issues == []
+
+
+# ---------------------------------------------------------------------------
+# Individual error checks
+# ---------------------------------------------------------------------------
+
+
+class TestMissingInfobox:
+    def test_missing_infobox_produces_error(self):
+        text = _VALID.replace("{{Infobox officeholder", "{{Something else")
+        r = validate_wikitext(text)
+        codes = [i.code for i in r.errors]
+        assert "missing_infobox" in codes
+
+    def test_infobox_match_is_case_insensitive(self):
+        text = _VALID.replace("{{Infobox officeholder", "{{infobox officeholder")
+        r = validate_wikitext(text)
+        assert r.is_valid is True
+
+    def test_infobox_present_no_error(self):
+        r = validate_wikitext(_VALID)
+        codes = [i.code for i in r.errors]
+        assert "missing_infobox" not in codes
+
+
+class TestMissingRefs:
+    def test_missing_ref_tag_produces_error(self):
+        text = _VALID.replace("<ref", "REMOVED_REF")
+        r = validate_wikitext(text)
+        codes = [i.code for i in r.errors]
+        assert "missing_refs" in codes
+
+    def test_ref_present_no_error(self):
+        r = validate_wikitext(_VALID)
+        assert "missing_refs" not in [i.code for i in r.errors]
+
+
+class TestMissingReflist:
+    def test_missing_reflist_produces_error(self):
+        text = _VALID.replace("{{reflist}}", "")
+        r = validate_wikitext(text)
+        assert "missing_reflist" in [i.code for i in r.errors]
+
+    def test_reflist_match_is_case_insensitive(self):
+        text = _VALID.replace("{{reflist}}", "{{Reflist}}")
+        r = validate_wikitext(text)
+        assert "missing_reflist" not in [i.code for i in r.errors]
+
+    def test_reflist_present_no_error(self):
+        r = validate_wikitext(_VALID)
+        assert "missing_reflist" not in [i.code for i in r.errors]
+
+
+class TestMissingReferencesSection:
+    def test_missing_section_produces_error(self):
+        text = _VALID.replace("==References==", "")
+        r = validate_wikitext(text)
+        assert "missing_references_section" in [i.code for i in r.errors]
+
+    def test_section_with_spaces_passes(self):
+        text = _VALID.replace("==References==", "== References ==")
+        r = validate_wikitext(text)
+        assert "missing_references_section" not in [i.code for i in r.errors]
+
+    def test_references_section_present_no_error(self):
+        r = validate_wikitext(_VALID)
+        assert "missing_references_section" not in [i.code for i in r.errors]
+
+
+class TestMissingCategories:
+    def test_missing_category_produces_error(self):
+        text = _VALID.replace("[[Category:", "[[NotACategory:")
+        r = validate_wikitext(text)
+        assert "missing_categories" in [i.code for i in r.errors]
+
+    def test_category_present_no_error(self):
+        r = validate_wikitext(_VALID)
+        assert "missing_categories" not in [i.code for i in r.errors]
+
+
+# ---------------------------------------------------------------------------
+# Warning checks
+# ---------------------------------------------------------------------------
+
+
+class TestUnmatchedBraces:
+    def test_balanced_braces_no_warning(self):
+        r = validate_wikitext(_VALID)
+        assert "unmatched_braces" not in [i.code for i in r.warnings]
+
+    def test_extra_open_brace_produces_warning(self):
+        text = _VALID + "\n{{"  # extra unclosed
+        r = validate_wikitext(text)
+        assert "unmatched_braces" in [i.code for i in r.warnings]
+
+    def test_extra_close_brace_produces_warning(self):
+        text = _VALID + "\n}}"  # extra closing
+        r = validate_wikitext(text)
+        assert "unmatched_braces" in [i.code for i in r.warnings]
+
+    def test_nowiki_block_excluded_from_count(self):
+        # <nowiki>{{</nowiki> should not count as an open brace
+        text = _VALID + "\n<nowiki>{{</nowiki>"
+        r = validate_wikitext(text)
+        assert "unmatched_braces" not in [i.code for i in r.warnings]
+
+
+class TestBirthDateTemplate:
+    def test_birth_date_field_without_template_produces_warning(self):
+        text = _VALID.replace("{{birth date|1970|01|15}}", "1970-01-15")
+        r = validate_wikitext(text)
+        assert "missing_birth_date_template" in [i.code for i in r.warnings]
+
+    def test_birth_date_template_present_no_warning(self):
+        r = validate_wikitext(_VALID)
+        assert "missing_birth_date_template" not in [i.code for i in r.warnings]
+
+    def test_no_birth_info_no_warning(self):
+        # Remove all birth references
+        text = """\
+{{Infobox officeholder
+| name = Bob
+}}
+Bob is a politician.<ref>http://example.com</ref>
+==References==
+{{reflist}}
+[[Category:People]]
+"""
+        r = validate_wikitext(text)
+        assert "missing_birth_date_template" not in [i.code for i in r.warnings]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_string_accumulates_errors(self):
+        r = validate_wikitext("")
+        codes = [i.code for i in r.errors]
+        assert "missing_infobox" in codes
+        assert "missing_refs" in codes
+        assert "missing_reflist" in codes
+        assert "missing_references_section" in codes
+        assert "missing_categories" in codes
+
+    def test_multiple_errors_all_accumulated(self):
+        r = validate_wikitext("")
+        assert len(r.errors) >= 5
+
+    def test_never_raises(self):
+        for text in ["", "   ", "\n\n", "random text", None.__class__.__name__]:
+            validate_wikitext(text)  # must not raise


### PR DESCRIPTION
## Summary

Routine promotion of `dev` → `main`.

### Included since last release

- **feat**: wikitext format enforcement, Wikipedia submit UI, and HTML preview (#408 / #409)
  - Wikitext validator with 7 checks (5 errors, 2 warnings)
  - Repair loop in `polish_wiki_article` for auto-fixing format errors
  - Validation panel + tabbed Wikitext/Preview UI on draft detail page
  - Submit to Wikipedia button with `Draft:` namespace default and confirmation modal
  - `GET /api/wiki-drafts/{id}/preview` via Wikipedia `action=parse` API
  - 56 new tests

- **feat**: force-run specific offices via `POST /api/run forced_office_ids` (#397 / #408)

- **feat**: enrich suspect-record GH issues with source page URL and row data (#400 / #407)

- **ci**: opt into Node.js 24 for inline workflow actions (#410 / #411)

- **perf**: `TABLE_HTML_CACHE_ENABLED` env var for disk cache toggle (#396 / #406)

- **bug**: handle truncated JSON in Gemini `check_data_quality` (#399 / #404)

- **bug**: strip Claude code-fenced JSON and fix `is_valid=True` parse fallback (#398 / #403)

- **security**: remove hardcoded Render service ID from deploy workflow (#387 / #402)

- **security**: add community health files (#405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)