### PR TITLE
fix: add queued to valid run statuses in endpoint test

### DIFF
--- a/src/test_api_endpoints.py
+++ b/src/test_api_endpoints.py
@@ -76,7 +76,7 @@ def test_api_run_status_returns_valid_shape_for_new_job(client):
     status_resp = client.get(f"/api/run/status/{job_id}")
     assert status_resp.status_code == 200
     body = status_resp.json()
-    assert body["status"] in ("running", "complete", "error")
+    assert body["status"] in ("queued", "running", "complete", "error")
     assert "progress" in body
     assert "office" in body["progress"]
 


### PR DESCRIPTION
## Summary
- `test_api_run_status_returns_valid_shape_for_new_job` was asserting status in `('running', 'complete', 'error')` but the force-run-office feature added a `queued` status that appears immediately after job creation
- Adds `queued` to the valid set so CI passes on the dev→main PR (#414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)