### PR TITLE
fix: catch OverflowError in format_date; retry Gemini 503/500 errors

### DIFF
--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -252,7 +252,7 @@ class DataCleanup:
             parsed = parse(s, default=_parse_default)
             if parsed:
                 return parsed.strftime("%Y-%m-%d")
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError, OverflowError) as e:
             _emit_parse_failure(
                 self._reporter,
                 "DataCleanup.format_date",

--- a/src/services/gemini_vitals_researcher.py
+++ b/src/services/gemini_vitals_researcher.py
@@ -288,6 +288,23 @@ class GeminiVitalsResearcher:
                     backoff *= 2
                 else:
                     raise
+            except errors.ServerError as exc:
+                # 503 UNAVAILABLE / 500 INTERNAL — transient; retry with backoff
+                if attempt == 2:
+                    import sentry_sdk
+
+                    sentry_sdk.add_breadcrumb(
+                        message=f"Gemini server error after 3 retries: {exc}", level="error"
+                    )
+                    raise
+                logger.warning(
+                    "_call_gemini: server error (%s); retrying in %.0f s (attempt %d/3)",
+                    exc,
+                    backoff,
+                    attempt + 1,
+                )
+                time.sleep(backoff)
+                backoff *= 2
         raise RuntimeError("unreachable")
 
     def check_data_quality(self, prompt: str, system_prompt: str | None = None) -> dict | None:


### PR DESCRIPTION
## Summary

- **#416** — `table_parser.py:format_date()`: add `OverflowError` to the caught exception tuple so a Wikipedia cell containing an astronomically large year skips gracefully rather than crashing the entire daily delta run
- **#417** — `gemini_vitals_researcher.py:_call_gemini()`: add `except errors.ServerError` block to retry 503 UNAVAILABLE / 500 INTERNAL responses with the same exponential backoff (1s → 2s → 4s, 3 attempts) already used for 429 rate-limit errors

## Test plan

- [ ] Confirm 1515 previously-passing tests still pass in CI
- [ ] Manually trigger a daily delta run and verify it completes without crash on a page that previously caused `OverflowError`
- [ ] Verify Gemini research retries appear in logs for a 503 response (can be confirmed via Sentry breadcrumbs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)