### PR TITLE
fix: harden exception handling in auto-table detection and Gemini research

### DIFF
--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -797,7 +797,9 @@ def _try_auto_update_table_no(
     except Exception:
         _log.debug(
             "_try_auto_update_table_no: error computing baseline for table %d of %s — using raw missing count",
-            current_table_no, url, exc_info=True,
+            current_table_no,
+            url,
+            exc_info=True,
         )
     for candidate_no in range(1, num_tables + 1):
         if candidate_no == current_table_no:
@@ -812,7 +814,11 @@ def _try_auto_update_table_no(
             html = candidate_result.get("html") or ""
             if not html:
                 continue
-            candidate_office = {**office_row, "table_no": candidate_no, "find_date_in_infobox": False}
+            candidate_office = {
+                **office_row,
+                "table_no": candidate_no,
+                "find_date_in_infobox": False,
+            }
             table_data = _parse_office_html(
                 candidate_office,
                 html,
@@ -861,7 +867,9 @@ def _try_auto_update_table_no(
         except Exception:
             _log.warning(
                 "_try_auto_update_table_no: error parsing candidate table %d for %s — skipping",
-                candidate_no, url, exc_info=True,
+                candidate_no,
+                url,
+                exc_info=True,
             )
             continue
     return (best_table_no, best_rows)

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -795,65 +795,75 @@ def _try_auto_update_table_no(
                 )
             )
     except Exception:
-        pass
+        _log.debug(
+            "_try_auto_update_table_no: error computing baseline for table %d of %s — using raw missing count",
+            current_table_no, url, exc_info=True,
+        )
     for candidate_no in range(1, num_tables + 1):
         if candidate_no == current_table_no:
             continue
-        candidate_result = get_table_html_cached(
-            url,
-            candidate_no,
-            refresh=refresh_table_cache,
-            use_full_page=bool(office_row.get("use_full_page_for_table")),
-        )
-        html = candidate_result.get("html") or ""
-        if not html:
-            continue
-        candidate_office = {**office_row, "table_no": candidate_no, "find_date_in_infobox": False}
-        table_data = _parse_office_html(
-            candidate_office,
-            html,
-            url,
-            party_list,
-            offices_parser,
-            cached_table_html=html,
-            progress_callback=None,
-        )
-        if not table_data:
-            continue
-        missing = _missing_holder_keys(
-            existing_terms,
-            table_data,
-            int(office_row.get("id") or 0),
-            years_only,
-            key_years_only=key_years_only,
-        )
-        missing_exact = len(missing)
-        missing_years = len(
-            _missing_holder_keys(
+        try:
+            candidate_result = get_table_html_cached(
+                url,
+                candidate_no,
+                refresh=refresh_table_cache,
+                use_full_page=bool(office_row.get("use_full_page_for_table")),
+            )
+            html = candidate_result.get("html") or ""
+            if not html:
+                continue
+            candidate_office = {**office_row, "table_no": candidate_no, "find_date_in_infobox": False}
+            table_data = _parse_office_html(
+                candidate_office,
+                html,
+                url,
+                party_list,
+                offices_parser,
+                cached_table_html=html,
+                progress_callback=None,
+            )
+            if not table_data:
+                continue
+            missing = _missing_holder_keys(
                 existing_terms,
                 table_data,
                 int(office_row.get("id") or 0),
                 years_only,
-                key_years_only=True,
+                key_years_only=key_years_only,
             )
-        )
-        improved = (
-            (missing_exact < best_missing)
-            or (missing_exact == best_missing and missing_years < current_missing_years)
-            or (
-                missing_exact == best_missing
-                and missing_years == current_missing_years
-                and best_rows is not None
-                and len(table_data) > len(best_rows)
+            missing_exact = len(missing)
+            missing_years = len(
+                _missing_holder_keys(
+                    existing_terms,
+                    table_data,
+                    int(office_row.get("id") or 0),
+                    years_only,
+                    key_years_only=True,
+                )
             )
-        )
-        if improved:
-            best_missing = missing_exact
-            current_missing_years = missing_years
-            best_table_no = candidate_no
-            best_rows = table_data
-            if best_missing == 0 and current_missing_years == 0:
-                break
+            improved = (
+                (missing_exact < best_missing)
+                or (missing_exact == best_missing and missing_years < current_missing_years)
+                or (
+                    missing_exact == best_missing
+                    and missing_years == current_missing_years
+                    and best_rows is not None
+                    and len(table_data) > len(best_rows)
+                )
+            )
+            if improved:
+                best_missing = missing_exact
+                current_missing_years = missing_years
+                best_table_no = candidate_no
+                best_rows = table_data
+                if best_missing == 0 and current_missing_years == 0:
+                    break
+        except Exception:
+            _log.warning(
+                "_try_auto_update_table_no: error parsing candidate table %d for %s — skipping",
+                candidate_no, url, exc_info=True,
+            )
+            continue
     return (best_table_no, best_rows)
 
 
@@ -1899,8 +1909,11 @@ def _run_gemini_vitals_research(ctx: _RunContext, report: Callable) -> dict[str,
                 sentry_sdk.capture_exception(exc)
                 errors.append({"url": wiki_url, "error": f"OpenAI polish failed: {exc}"})
 
-        # Mark checked regardless of outcome
-        db_individuals.mark_gemini_research_checked(ind_id)
+        # Only mark checked when research returned real data. If result is
+        # fully empty (transient API failure), leave the individual in the
+        # queue so the next nightly run retries.
+        if result.birth_date or result.death_date or result.sources or result.biographical_notes:
+            db_individuals.mark_gemini_research_checked(ind_id)
 
         report(
             "gemini",
@@ -2089,7 +2102,9 @@ def _run_dead_link_research(ctx: _RunContext, report: Callable) -> dict[str, Any
                 sentry_sdk.capture_exception(exc)
                 errors.append({"url": wiki_url, "error": f"OpenAI polish failed: {exc}"})
 
-        db_individuals.mark_gemini_research_checked(ind_id)
+        # Only mark checked when research returned real data (same logic as Gemini batch above).
+        if result.birth_date or result.death_date or result.sources or result.biographical_notes:
+            db_individuals.mark_gemini_research_checked(ind_id)
 
         report(
             "dead_link",


### PR DESCRIPTION
## Summary

- **#420** — `_try_auto_update_table_no`: wrap the candidate table parsing loop in `try/except` so any parse failure (requests, BeautifulSoup, dateutil, etc.) skips that candidate and logs a warning instead of propagating up and crashing the entire subprocess. Also upgrade the bare `except Exception: pass` on the baseline computation to `_log.debug` for visibility.
- **#421** — `_run_gemini_research_batch` and the dead-link research batch: only call `mark_gemini_research_checked` when `research_individual()` returned a non-empty result. A fully empty `VitalsResearchResult` (caused by 503/500 after all retries) no longer permanently removes the individual from future research batches.

## Test plan

- [ ] All 1515 previously-passing tests green in CI
- [ ] Verify daily delta run completes fully when a Wikipedia page has a malformed alternate table
- [ ] Verify an individual that hits 503 on all retries is NOT marked as researched in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)