### PR TITLE
feat: add RulersAI app icon and favicon

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% block title %}Office Holder{% endblock %}</title>
+  <title>{% block title %}RulersAI{% endblock %}</title>
+  <link rel="icon" type="image/png" href="/static/images/rulersai-icon.png">
+  <link rel="apple-touch-icon" href="/static/images/rulersai-icon.png">
   <link rel="stylesheet" href="/static/css/theme.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Adds `src/static/images/rulersai-icon.png` — the RulersAI Chihuahua-with-crown brand icon
- Wires it as `<link rel="icon">` and `<link rel="apple-touch-icon">` in `base.html`
- Updates the default `<title>` from "Office Holder" to "RulersAI"

## Test plan
- [ ] Load any page in the app — browser tab should show the RulersAI crown icon
- [ ] On iOS/Safari, add to home screen — should show the crown icon
- [ ] Confirm no other pages are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)