### PR TITLE
docs: update documentation for P1 issues #427-#431

### DIFF
--- a/docs/ai-pipeline.md
+++ b/docs/ai-pipeline.md
@@ -112,7 +112,12 @@ Gates individual insertions via a pre-insertion AI check. Called from `runner.py
 ### Entry point
 
 ```python
-result = check_and_gate(full_name, wiki_url, office_id, conn=conn)
+result = check_and_gate(
+    full_name, wiki_url, office_id,
+    source_page_url=None,   # optional: Wikipedia source page URL
+    row_data=None,           # optional: dict of parsed row fields
+    conn=conn,
+)
 # Returns: "allowed" | "skipped" | "gh_issue"
 ```
 
@@ -127,6 +132,34 @@ If `result != "allowed"`, the insertion is blocked. The scraper logs the outcome
 | `gh_issue` | Flagged as suspect; insertion blocked; GitHub issue created |
 
 All outcomes are recorded to the `suspect_record_flags` table for audit visibility.
+
+### GitHub issue enrichment
+
+When `source_page_url` and `row_data` are provided, the created GitHub issue body includes a `### Source` section with:
+- The Wikipedia source page URL (clickable link)
+- A JSON block of the parsed row fields (all non-internal keys)
+
+`runner.py` populates both automatically: it stores the source page URL in each row dict during accumulation and passes a clean copy of the row (internal `_`-prefixed keys stripped) to `check_and_gate()`. Callers that don't provide these fields get the original issue body format unchanged.
+
+---
+
+## AI Provider Error Handling
+
+### Claude (`claude_client.py`)
+
+- **Code-fenced JSON:** Claude sometimes wraps its JSON in ` ```json ... ``` ` markdown fences. `_parse_response()` strips the fence before calling `json.loads()`, so fenced responses are parsed correctly.
+- **Parse failures return `None`:** If JSON parsing still fails (malformed response), `check_data_quality()` returns `None` instead of a fallback `DataQualityResult(is_valid=True)`. This causes `_vote_claude()` to record `AIVote(is_valid=None, error="parse error")`, **excluding Claude from quorum** rather than injecting a spurious "valid" vote.
+- **Rate limit backoff:** `RateLimitError` (429) triggers exponential backoff with `time.sleep(2^attempt)` up to 3 retries.
+
+### Gemini (`gemini_vitals_researcher.py` — `check_data_quality`)
+
+- **Truncated JSON:** `check_data_quality()` wraps `json.loads()` in `try/except JSONDecodeError` and returns `None` on failure so Gemini is excluded from quorum rather than crashing.
+- **`max_output_tokens`**: raised from 512 → 1024 to reduce mid-response truncation that causes the above.
+- **Server errors (503/500):** `_call_gemini()` catches `errors.ServerError` and retries up to 3 times with exponential backoff — the same pattern as the existing 429 retry. Transient Gemini outages no longer fail silently.
+
+### Gemini research batch (`runner.py`)
+
+- **Empty-result guard:** `mark_gemini_research_checked()` is only called when the Gemini result contains actual data. A fully empty result (all retries exhausted on 503/500) does **not** stamp `gemini_research_checked_at`, so the individual remains eligible for future research batches and is not silently lost.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ Wikipedia REST API      SQLite file
 | `/data/ai-decisions` | AI decision log across data quality, parse errors, page quality, suspect flags |
 | `/data/wiki-drafts` | Wikipedia draft proposals; list view |
 | `/data/wiki-drafts/<id>` | Draft proposal detail; submit button |
-| `/gemini-research` | Interactive Gemini+OpenAI vitals research test page |
+| `/gemini-research` | Interactive Gemini+OpenAI vitals research test page; shows the 20 most recent wiki draft proposals with links to `/data/wiki-drafts` |
 | `/ai-offices` | AI batch office creation via OpenAI |
 | `/refs` | Reference data index (countries, states, cities, levels, branches, parties, etc.) |
 | `/refs/parties` | Party CRUD |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -88,6 +88,39 @@ After fetching the Wikipedia table HTML, the runner computes a SHA-256 hash of t
 
 ---
 
+## Table HTML cache
+
+Wikipedia table HTML is cached to disk (gzip JSON, under `data/wiki_cache/` by default). The cache avoids redundant HTTP fetches across runs.
+
+### Conditional GET (ETag / Last-Modified)
+
+When a cached entry is older than the configured TTL, the runner sends a **conditional GET** instead of a full re-download:
+
+- `If-None-Match: <stored ETag>` (if available)
+- `If-Modified-Since: <stored Last-Modified>` (if available)
+
+If Wikipedia responds **304 Not Modified**: the cached HTML is reused and the cache file's mtime is touched to reset the TTL clock — no bandwidth consumed, no diff triggered.
+
+If Wikipedia responds **200**: the new HTML and updated validator headers (`ETag`, `Last-Modified`) are stored.
+
+Existing cache files that pre-date this feature have no stored headers. On their first expiry they fall back to an unconditional GET, then gain the headers on the 200 response.
+
+### Batch re-check scheduling (`cache_batch`)
+
+All 1,278+ offices are spread across 7 weekday batches so conditional GETs are distributed evenly across the week rather than all hitting on the same day.
+
+- `office_table_config.cache_batch` (integer 0–6) is set to `id % 7` at insert time and backfilled for existing rows at startup.
+- On each delta run: `today_batch = date.today().weekday()` (0 = Monday … 6 = Sunday).
+  - `office_batch == today_batch` → `max_age_seconds = 86400` (1 day) — triggers conditional GET.
+  - `office_batch != today_batch` → `max_age_seconds = None` — use cache as-is, no HTTP.
+- Result: ~1/7 of offices check for updates each day; each office is checked once per week.
+
+### Kill switch
+
+Set `TABLE_HTML_CACHE_ENABLED=0` to disable the disk cache entirely for all offices. When disabled, every run fetches live HTML unconditionally.
+
+---
+
 ## Structural change detection (link fill rate)
 
 After parsing a table, the runner computes the **link fill rate**: the fraction of parsed holder rows that have a Wikipedia link (0.0–1.0). This is stored in `office_table_config.last_link_fill_rate`.

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -6,6 +6,20 @@ All modes are triggered via `run_with_db(run_mode=..., ...)` in `src/scraper/run
 
 ---
 
+## `forced_office_ids` — force-run specific offices
+
+`POST /api/run` accepts an optional `forced_office_ids` form field: a comma-separated list of integer office IDs.
+
+When set:
+- Only the listed offices are processed, regardless of the selected `run_mode`.
+- `refresh_table_cache=True` is implied — cached HTML for those offices is discarded so the next fetch is guaranteed live.
+- Non-numeric tokens in the list are silently ignored.
+- An empty value leaves the existing `run_mode` behaviour unchanged.
+
+**When to use:** Re-run a specific office after manually fixing its config, or force a fresh fetch for a known-stale table without running the full daily delta.
+
+---
+
 ## UI Run Mode Aliases
 
 The `/run` page exposes several UI-only run mode strings that are translated to internal `run_with_db` modes before execution. The mapping lives in `src/routers/run_scraper.py`:
@@ -287,7 +301,9 @@ When a delta (or full) run parses a table and finds that some existing `office_t
 
 **Disable per-page:** Set `disable_auto_table_update=1` on `source_pages` to skip this logic for that page.
 
-**Note:** With the per-run HTML cache (Phase 5), all tables on a page are already in memory, so step 1 is a re-parse, not a re-fetch.
+**Note:** With the per-run HTML cache, all tables on a page are already in memory, so step 1 is a re-parse, not a re-fetch.
+
+**Exception safety:** Each candidate table is parsed inside a `try/except` block. Any parse error (BeautifulSoup, requests, dateutil, etc.) skips that candidate and continues to the next — a broken candidate table never crashes the entire subprocess run.
 
 ---
 


### PR DESCRIPTION
## Summary

- **#427** — Document table HTML cache: conditional GET (ETag/Last-Modified), batch re-check scheduling (`cache_batch = id % 7`), `TABLE_HTML_CACHE_ENABLED` kill switch (`docs/parser.md`)
- **#428** — Document AI error-handling hardening: Claude code-fence stripping + `None` fallback, Gemini truncated JSON handling + `ServerError` retry, empty-result guard in research batch (`docs/ai-pipeline.md`)
- **#429** — Document `forced_office_ids` POST param and Gemini research UI enhancements (`docs/run-modes.md`, `docs/architecture.md`)
- **#430** — Document suspect record GitHub issue enrichment with `source_page_url` + `row_data` (`docs/ai-pipeline.md`)
- **#431** — Note exception safety in auto-table-update candidate loop (`docs/run-modes.md`, `docs/parser.md`)

## Test plan

- [ ] Review each doc section against the linked commit for accuracy
- [ ] Confirm no broken cross-references between docs
- [ ] CI passes (no code changes — doc-only PR)

Closes #427, #428, #429, #430, #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)