### PR TITLE
docs: branding, accessibility, and localization guides

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,583 @@
+# RulersAI — Accessibility (WCAG 2.2 A + AA)
+
+This document is the engineering specification for WCAG 2.2 Level A and Level AA compliance across all RulersAI surfaces (web and mobile). The app had no prior WCAG implementation; this spec covers ground-up compliance.
+
+For visual design tokens, color contrast values, and component patterns see `docs/branding.md`.  
+For locale-specific considerations (lang/dir attributes) see `docs/localization.md`.
+
+---
+
+## Baseline Audit (pre-implementation)
+
+### What existed before this work
+
+| Item | Status |
+|---|---|
+| `<html lang="en">` (static) | ✓ |
+| `<nav>` and `<main>` elements | ✓ partial — unlabelled, `<main>` has no `id` |
+| `role="alert"` on validation error banner | ✓ in page_form only |
+| `aria-label` on ~5 specific buttons | ✓ sparse |
+| `aria-hidden="true"` on loading spinner | ✓ |
+| CSS focus ring | ✗ none — browser defaults only |
+| Skip link | ✗ |
+| `aria-live` regions | ✗ zero instances |
+| `aria-required` / `aria-invalid` | ✗ zero instances |
+| `aria-expanded` / `aria-controls` | ✗ zero instances |
+| `role="progressbar"` | ✗ zero instances |
+| `role="switch"` | ✗ zero instances |
+| `autocomplete` attributes | ✗ zero instances |
+| `<th scope>` on data tables | ✗ none |
+| Audio mute control | ✗ (completion sound plays ~4.5s uncontrolled) |
+
+### Confirmed Level A failures (pre-implementation)
+
+| # | Criterion | Failure |
+|---|---|---|
+| 1 | **1.3.1 Info and Relationships** | Many `<label>Text</label><input>` pairs in `page_form.html` and `run.html` have no `for`/`id` linkage — screen readers do not announce field names |
+| 2 | **1.4.2 Audio Control** | Job completion sound plays 5 tones over ~4.5 seconds (exceeds 3-second limit). No mute or stop control |
+| 3 | **2.4.1 Bypass Blocks** | No skip link — keyboard users tab through the full nav on every page |
+| 4 | **2.4.2 Page Titled** | All pages share the same generic title; no page-specific context |
+| 5 | **2.4.3 Focus Order** | Sortable table columns have no keyboard interaction. Dynamically-opened preview panels receive no focus |
+| 6 | **4.1.2 Name, Role, Value** | Progress bars are plain `<div>` elements. Job status text updated by JS has no `aria-live`. Sortable `<th>` elements have no `aria-sort` |
+
+### Confirmed Level AA failures (pre-implementation)
+
+| # | Criterion | Failure |
+|---|---|---|
+| 7 | **1.3.5 Identify Input Purpose** | No `autocomplete` on any input |
+| 8 | **1.4.11 Non-text Contrast** | Input borders use `outline-variant` (#c4c6cd) — fails 3:1 against white |
+| 9 | **2.4.6 Headings and Labels** | Inconsistent heading hierarchy across templates; some pages skip levels |
+| 10 | **2.4.7 Focus Visible** | No CSS focus ring defined — browser defaults unreliable, especially Chrome |
+| 11 | **3.3.1 Error Identification** | Validation error banner does not associate to the failing field — no `aria-invalid`, no `aria-describedby` |
+| 12 | **3.3.3 Error Suggestion** | Error messages state what failed but give no guidance on how to fix |
+| 13 | **4.1.3 Status Messages** | "Saved." alerts, job progress updates, and completion have no `aria-live` — screen readers never hear them |
+
+---
+
+## Criteria Not Applicable to This App
+
+| Criterion | Reason |
+|---|---|
+| 1.2.x (captions, audio description) | No video or prerecorded audio content |
+| 2.1.4 Character Key Shortcuts | No single-character keyboard shortcuts defined |
+| 2.2.1 Timing Adjustable | No session timeouts affecting users |
+| 2.3.1 Three Flashes | No flashing content |
+| 2.5.1 Pointer Gestures | No multi-point pointer gestures required |
+| 3.3.7 Redundant Entry | No multi-step forms requiring re-entry of data |
+| 3.3.8 Accessible Authentication | Google OAuth — no CAPTCHA or cognitive test ✓ |
+
+---
+
+## Implementation Strategy
+
+Accessibility is **baked into every screen story**, not bolted on at the end.
+
+- **STORY-16a (Infrastructure):** Shell-level items that all screens inherit — lives in `base.html` and `theme.css`. Do alongside design token work.
+- **Stories 5–14 (Screen stories):** Each screen story has the per-screen requirements below as acceptance criteria.
+- **STORY-16b (Audit):** After all screens ship — automated + manual testing, fix stragglers.
+
+---
+
+## Infrastructure (STORY-16a)
+
+Everything in this section lives in `base.html` or `theme.css` and applies globally.
+
+### Skip Link
+
+First child of `<body>`:
+
+```html
+<a href="#main-content"
+   class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4
+          focus:z-50 focus:bg-primary-container focus:text-white
+          focus:px-4 focus:py-2 focus:rounded focus:text-sm focus:font-bold">
+  Skip to main content
+</a>
+```
+
+Satisfies: **2.4.1 Bypass Blocks**
+
+### Landmarks
+
+```html
+<header role="banner">                          <!-- top app bar -->
+<nav aria-label="Primary navigation">           <!-- sidebar -->
+<main id="main-content">                        <!-- page content -->
+```
+
+The `id="main-content"` is the skip link target. Every page uses `<main>` via `base.html`.
+
+### Focus Ring (theme.css)
+
+```css
+/* Keyboard focus: visible ring */
+*:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Mouse click: no outline (browser default suppressed) */
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+Satisfies: **2.4.7 Focus Visible**
+
+### Scroll Padding (theme.css)
+
+```css
+html {
+  scroll-padding-top: 4.5rem; /* equals sticky top bar height */
+}
+```
+
+Satisfies: **2.4.11 Focus Not Obscured (Minimum)** — prevents the sticky top bar from hiding a focused element when the user scrolls via Tab.
+
+### aria-live Regions
+
+Two regions at the end of `<body>`, before `</body>`:
+
+```html
+<div id="live-polite"
+     aria-live="polite"
+     aria-atomic="true"
+     class="sr-only"
+     aria-label="Status messages"></div>
+
+<div id="live-assertive"
+     aria-live="assertive"
+     aria-atomic="true"
+     class="sr-only"
+     aria-label="Urgent notifications"></div>
+```
+
+**Global JS helper** (in `base.html`):
+
+```js
+window.announce = function(message, priority = 'polite') {
+  const region = document.getElementById(
+    priority === 'assertive' ? 'live-assertive' : 'live-polite'
+  );
+  if (!region) return;
+  // Clear first so repeated identical messages still fire
+  region.textContent = '';
+  requestAnimationFrame(() => { region.textContent = message; });
+};
+```
+
+**Contract:** All JS that produces a user-visible status message (save confirmation, job progress, job completion, error notification) must call `window.announce()` instead of — or in addition to — updating a visible element. Never write status to an element without an `aria-live` attribute.
+
+Satisfies: **4.1.3 Status Messages**
+
+### Audio Mute Toggle
+
+The job completion sound (`playJobCompleteSound`) plays 5 tones over ~4.5 seconds — exceeds the 3-second threshold for **1.4.2 Audio Control**.
+
+**Fix:**
+
+```js
+// In base.html, update playJobCompleteSound:
+window.playJobCompleteSound = function() {
+  if (window._soundMuted) return;  // ADD THIS LINE
+  // ... rest of existing function
+};
+
+// Mute toggle wired to a button in the top bar:
+window._soundMuted = localStorage.getItem('rulersai_sound_muted') === 'true';
+
+window.toggleSound = function() {
+  window._soundMuted = !window._soundMuted;
+  localStorage.setItem('rulersai_sound_muted', window._soundMuted);
+  const btn = document.getElementById('soundToggleBtn');
+  if (btn) {
+    btn.setAttribute('aria-label', window._soundMuted
+      ? 'Unmute completion sound'
+      : 'Mute completion sound');
+    btn.setAttribute('aria-pressed', window._soundMuted);
+  }
+};
+```
+
+Button in top bar:
+
+```html
+<button id="soundToggleBtn"
+        type="button"
+        onclick="toggleSound()"
+        aria-label="Mute completion sound"
+        aria-pressed="false"
+        class="icon-btn">
+  <span class="material-symbols-outlined" aria-hidden="true">volume_up</span>
+</button>
+```
+
+Satisfies: **1.4.2 Audio Control**
+
+### axe-core CI Setup
+
+```bash
+npm install --save-dev @axe-core/playwright
+```
+
+Test pattern (add to existing Playwright suite):
+
+```ts
+import AxeBuilder from '@axe-core/playwright';
+
+test('offices list has no axe violations', async ({ page }) => {
+  await page.goto('/offices');
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag22aa'])
+    .analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+One test per key page. Fails CI on any violation. Add to: `/offices`, `/offices/new`, `/offices/{id}`, `/run`, `/data/wiki-drafts`, `/gemini-research`, `/login`.
+
+---
+
+## Per-Screen Requirements
+
+These are acceptance criteria for **every** screen story (stories 5–14). A story is not done until all of these pass.
+
+### Page Titles (2.4.2)
+
+Every page has a unique, descriptive `<title>`. Format: `[Page Name] — RulersAI`.
+
+```
+Offices — RulersAI
+Edit Office — RulersAI
+New Office — RulersAI
+Command Center — RulersAI
+Research Output — RulersAI
+Deep Research — RulersAI
+Sign in — RulersAI
+Reports — RulersAI
+Reference Data — RulersAI
+```
+
+### Heading Hierarchy (2.4.6)
+
+- One `<h1>` per page — the masthead title
+- Card/section headers: `<h2>`
+- Sub-sections within cards: `<h3>`
+- Table config blocks within office sections: `<h4>`
+- Never skip levels (no `<h1>` → `<h3>`)
+
+### Form Label Association (1.3.1)
+
+Every `<input>`, `<select>`, and `<textarea>` must be programmatically associated to its label.
+
+**Preferred pattern (wrapping — for checkboxes and radios):**
+```html
+<label>
+  <input type="checkbox" name="enabled" value="1">
+  Include in runs
+</label>
+```
+
+**Required pattern (explicit for — for all other inputs):**
+```html
+<label for="office-name">Office name</label>
+<input id="office-name" type="text" name="name">
+```
+
+No `<label>Text</label><input>` without either wrapping or `for`/`id` pairing. This was the most widespread failure in the pre-implementation audit.
+
+### Required Fields (3.3.2, 4.1.2)
+
+```html
+<label for="office-name">
+  Office name
+  <span aria-hidden="true"> *</span>
+  <span class="sr-only">(required)</span>
+</label>
+<input id="office-name"
+       type="text"
+       name="name"
+       aria-required="true"
+       required>
+```
+
+### Validation Errors (3.3.1, 3.3.3)
+
+Error banner: `role="alert"` so screen readers announce immediately.
+Failing field: `aria-invalid="true"` + `aria-describedby` pointing to error message element.
+Error text: must state both what failed AND how to fix it.
+
+```html
+<!-- Error banner -->
+<div role="alert" class="alert alert-error">
+  <strong>Save failed</strong> — Office name is required.
+  Enter a name for this office and try again.
+</div>
+
+<!-- Failing field -->
+<label for="office-name">Office name <span aria-hidden="true">*</span></label>
+<input id="office-name"
+       aria-invalid="true"
+       aria-describedby="office-name-error"
+       aria-required="true">
+<span id="office-name-error" class="field-error" role="none">
+  Office name is required.
+</span>
+```
+
+### Input Purpose (1.3.5)
+
+Apply `autocomplete` to all user-facing inputs:
+
+| Input type | `autocomplete` value |
+|---|---|
+| Wikipedia URL | `url` |
+| Office name, department | `off` (unique institutional names) |
+| Table numbers, column indices | `off` |
+| Search fields | `off` |
+| Login email (if ever shown) | `email` |
+
+### Data Tables (1.3.1)
+
+```html
+<table aria-label="Offices">
+  <caption class="sr-only">List of configured offices with status and actions</caption>
+  <thead>
+    <tr>
+      <th scope="col">Enabled</th>
+      <th scope="col" aria-sort="none">
+        <button type="button" class="sort-btn" aria-label="Sort by name">
+          Name <span class="sort-indicator" aria-hidden="true"></span>
+        </button>
+      </th>
+      <th scope="col">Country</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><button role="switch" aria-checked="true" ...>...</button></td>
+      <td>US Senate</td>
+      <td>United States</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+When user clicks a sortable column header, update `aria-sort` on that `<th>`:
+- `aria-sort="ascending"` / `aria-sort="descending"` on the active sort column
+- `aria-sort="none"` on all other sortable columns
+
+Satisfies: **1.3.1**, **4.1.2**
+
+### Custom Toggle Switches (4.1.2)
+
+```html
+<button type="button"
+        role="switch"
+        aria-checked="true"
+        class="toggle-switch"
+        aria-label="Include US Senate in scraper runs">
+  <span aria-hidden="true" class="toggle-thumb"></span>
+  <span class="sr-only">Include in runs</span>
+</button>
+```
+
+When toggled, update `aria-checked` and call `window.announce('US Senate enabled')`.
+
+### Progress Bars (4.1.2)
+
+```html
+<div role="progressbar"
+     id="office-progress-bar"
+     aria-valuenow="42"
+     aria-valuemin="0"
+     aria-valuemax="120"
+     aria-label="Scraping offices"
+     aria-valuetext="42 of 120 offices">
+  <div class="progress-bar-fill" style="width: 35%"></div>
+</div>
+<div class="progress-label" aria-hidden="true">Offices: 42 / 120</div>
+```
+
+JS update on each poll cycle:
+```js
+bar.setAttribute('aria-valuenow', current);
+bar.setAttribute('aria-valuetext', `${current} of ${total} offices`);
+// On completion only, announce to live region:
+if (current >= total) window.announce(`Offices complete: ${total} processed`);
+```
+
+### Collapsible Sections (4.1.2)
+
+```html
+<button type="button"
+        aria-expanded="false"
+        aria-controls="table-config-panel-1"
+        class="collapse-trigger">
+  Table Extraction Config
+  <span class="material-symbols-outlined" aria-hidden="true">expand_more</span>
+</button>
+<div id="table-config-panel-1" hidden>
+  <!-- fields -->
+</div>
+```
+
+When opened: remove `hidden`, set `aria-expanded="true"`, move focus to the panel's first interactive element or heading.
+
+### Icon-Only Buttons (2.4.4, 4.1.2)
+
+```html
+<button type="button"
+        aria-label="Test config for US Senate table 1"
+        class="icon-btn">
+  <span class="material-symbols-outlined" aria-hidden="true">science</span>
+</button>
+```
+
+The `aria-label` must name the **action** and the **target** (not just the action).  
+Material Symbols icons must always have `aria-hidden="true"` — they are decorative.
+
+### Tooltips on Info Icons (3.2.6)
+
+Do not use `title` attribute for help text — inaccessible on keyboard and touch.
+
+```html
+<button type="button"
+        class="info-icon-btn"
+        aria-label="Help: Infobox role key"
+        aria-expanded="false"
+        aria-controls="infobox-help-text">
+  <span class="material-symbols-outlined" aria-hidden="true">info</span>
+</button>
+<div id="infobox-help-text"
+     role="tooltip"
+     hidden>
+  Use exact role phrase to disambiguate shared links. Example: "chief judge".
+</div>
+```
+
+### Target Size (2.5.8 — new in WCAG 2.2)
+
+Minimum 24×24 CSS px for all interactive elements (AA requirement).  
+Recommended 44×44px for mobile touch targets.
+
+- Icon buttons in toolbars: `min-width: 24px; min-height: 24px; padding: 0.375rem` (p-1.5)
+- Toggle switch thumb: minimum 24px × 24px
+- Sortable column buttons: full `<th>` width, `padding: 0.5rem`
+
+### Focus Not Obscured (2.4.11 — new in WCAG 2.2)
+
+The `scroll-padding-top: 4.5rem` in `theme.css` handles the sticky top bar.
+
+Additional check: the floating outline sidebar (multi-office editor) must not cover any focusable form element. The sidebar occupies `right: 0`, and the form content uses `margin-right: 13rem` — verify these values do not create overlap on viewports 1024px–1280px wide.
+
+### Status Messages (4.1.3)
+
+All of these must call `window.announce()`:
+- Save confirmation: `window.announce('Office saved successfully.')`
+- Job started: `window.announce('Scraper job started.')`
+- Job cancelled: `window.announce('Job cancelled.')`
+- Job completed: `window.announce('Scraper job complete. Processed 1,284 offices.')`
+- Preview complete: `window.announce('Preview complete. 42 results found.')`
+- Error: `window.announce('Save failed. See errors above.', 'assertive')`
+
+Visible status text elements are still updated visually — `announce()` is additive, not a replacement.
+
+### Dragging Alternative (2.5.7 — new in WCAG 2.2)
+
+The "Move table" drag-to-reorder has a keyboard-accessible alternative: the "Move to office" `<select>` + "Move table" `<button>`. These must always be visible and keyboard-reachable alongside any drag handle. This is already the current implementation — ensure it is not removed during the redesign.
+
+### Color Not Sole Indicator (1.4.1)
+
+Status badges must always include text alongside color:
+- ✓ `<span class="badge badge-enabled">Enabled</span>` — text + green background ✓
+- ✗ `<span class="badge badge-enabled"></span>` — green background only ✗
+
+Error states: `aria-invalid` + red border + error text below field. Never red border alone.
+
+### Input Border Contrast (1.4.11)
+
+Input, select, and textarea borders: use `--color-outline` (#74777d), which achieves 4.6:1 against white — passes 3:1 threshold for non-text contrast.  
+Never use `--color-outline-variant` (#c4c6cd) for borders — fails 3:1.
+
+---
+
+## Mobile Accessibility
+
+Mobile-specific additions on top of all web requirements:
+
+- Minimum touch target size: **44×44px** (exceeds the 24px AA minimum; recommended for mobile)
+- Hamburger/menu button: `aria-label="Open navigation"` / `"Close navigation"`, `aria-expanded` reflecting drawer state
+- Navigation drawer when open: `role="dialog" aria-modal="true" aria-label="Navigation"` with focus trap (Tab cycles within drawer; Escape closes and returns focus to hamburger button)
+- Bottom navigation bar: `role="navigation" aria-label="Primary mobile navigation"`; active item has `aria-current="page"`
+- `prefers-reduced-motion`: wrap all CSS transitions and animations in `@media (prefers-reduced-motion: no-preference)` — default state is no animation
+
+---
+
+## Testing Protocol
+
+### Automated (CI)
+
+`@axe-core/playwright` runs on every Playwright CI execution. Tags: `wcag2a`, `wcag2aa`, `wcag22aa`.
+
+Pages with required axe tests:
+- `/login`
+- `/offices`
+- `/offices/new`
+- `/offices/{id}` (single-office mode)
+- `/offices/{id}` (multi-office mode — test against a page with 2+ offices)
+- `/run`
+- `/data/wiki-drafts`
+- `/data/wiki-drafts/{id}`
+- `/gemini-research`
+- `/refs`
+- `/data/ai-decisions`
+- `/data/individuals`
+
+### Manual Keyboard Walkthroughs (STORY-16b)
+
+Three flows, each verified keyboard-only (Tab, Shift+Tab, Enter, Space, Escape, arrow keys):
+
+**Flow 1: Create office**
+1. Navigate to `/offices/new` via skip link + sidebar
+2. Tab through all fields in Source Context card
+3. Tab through Office Details card
+4. Tab through Table Extraction Config (expand with Enter on trigger)
+5. Submit — verify error announced if validation fails
+6. Fix error — verify correct field is focused/announced
+7. Submit successfully — verify "Office saved" announced in live region
+
+**Flow 2: Run scraper and cancel**
+1. Navigate to `/run` via sidebar
+2. Select run mode using keyboard (tile grid or select)
+3. Set options using keyboard
+4. Start job — verify "Job started" announced
+5. Monitor progress bars — verify `aria-valuenow` updates
+6. Cancel job with keyboard — verify "Job cancelled" announced
+
+**Flow 3: Review wiki draft**
+1. Navigate to `/data/wiki-drafts`
+2. Filter by status using keyboard
+3. Open a draft detail page
+4. Tab through the split-pane (wikitext + preview)
+5. Update status using keyboard — verify status change announced
+
+### Screen Reader Testing (STORY-16b)
+
+| SR + Browser | Platform | Flows to test |
+|---|---|---|
+| NVDA 2024 + Chrome | Windows | All 3 flows |
+| VoiceOver + Safari | macOS | All 3 flows |
+
+For each flow verify:
+- Field names announced when focused
+- Required fields announced as required
+- Error messages announced on validation failure
+- Status messages (save, progress, completion) announced without focus change
+- Custom controls (toggles, progress bars) announce role, state, and value
+
+### Color Contrast Audit
+
+Run once before STORY-16b closes:
+- Browser DevTools → Accessibility panel → check every text color / background pair on: offices list, edit office form, login page, run page
+- Minimum 4.5:1 for normal text, 3:1 for large text (≥18pt / ≥14pt bold) and UI components

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,611 @@
+# RulersAI — Branding Guidelines
+
+> Single source of truth for color, typography, iconography, and component patterns.
+> Covers web and mobile. Apply to all new templates and any redesigned pages.
+
+---
+
+## 1. Identity
+
+**Name:** RulersAI  
+**Tagline:** Institutional Intelligence  
+**Tone:** Authoritative, precise, data-forward. Not playful, not corporate-generic.  
+**Logo mark:** Chihuahua wearing a gold crown inside a dark circular badge with circuit-board detail.  
+**Wordmark:** `RulersAI` — `Rulers` in deep navy, `AI` in metallic gold.  
+**Asset:** `src/static/images/rulersai-icon.png`
+
+### Logo Usage Rules
+- Never recolor the logo mark.
+- Minimum clear space: equal to the height of the crown on all sides.
+- On dark backgrounds: use the icon as-is (it has a dark badge that works on dark surfaces).
+- Do not stretch, rotate, or add drop shadows to the logo.
+- In the sidebar, display the text wordmark `RulersAI` in `font-black` + `tracking-tighter` alongside a small icon.
+
+---
+
+## 2. Color System (Material You)
+
+The palette is a Material Design 3 tonal system with two roles: **light** and **dark**.
+All tokens map directly to Tailwind CSS custom colors.
+
+### Light Mode
+
+| Token | Hex | Usage |
+|---|---|---|
+| `primary` | `#041627` | Headings, active nav, high-emphasis text |
+| `primary-container` | `#1a2b3c` | Dark navy masthead backgrounds, primary CTA |
+| `on-primary` | `#ffffff` | Text on primary-container |
+| `on-primary-container` | `#8192a7` | Muted text on dark surfaces, secondary stats |
+| `primary-fixed` | `#d2e4fb` | Icon container backgrounds, light accent fills |
+| `primary-fixed-dim` | `#b7c8de` | Disabled states, placeholder icons |
+| `secondary` | `#545f72` | Secondary nav text, metadata labels |
+| `secondary-container` | `#d5e0f7` | Chip backgrounds, secondary badges |
+| `background` | `#f7fafc` | Page background |
+| `surface` | `#f7fafc` | Card surface |
+| `surface-container-lowest` | `#ffffff` | Elevated card background |
+| `surface-container-low` | `#f1f4f6` | Input fields, sidebar background |
+| `surface-container` | `#ebeef0` | Dividers, nested containers |
+| `surface-container-high` | `#e5e9eb` | Hover states |
+| `surface-container-highest` | `#e0e3e5` | Strongly pressed states |
+| `surface-dim` | `#d7dadc` | Disabled surface |
+| `surface-bright` | `#f7fafc` | Top app bar |
+| `on-surface` | `#181c1e` | Body text |
+| `on-surface-variant` | `#44474c` | Secondary body text, captions |
+| `outline` | `#74777d` | Input borders, dividers |
+| `outline-variant` | `#c4c6cd` | Subtle dividers |
+| `tertiary` | `#00162c` | Deep accent (sparingly) |
+| `tertiary-container` | `#002b4e` | Status chips on dark backgrounds |
+| `on-tertiary-container` | `#4894e2` | Steel blue accent — progress, active states |
+| `error` | `#ba1a1a` | Destructive actions, validation errors |
+| `error-container` | `#ffdad6` | Error badge backgrounds |
+| `inverse-surface` | `#2d3133` | Tooltip / snackbar backgrounds |
+| `inverse-on-surface` | `#eef1f3` | Tooltip text |
+
+### Dark Mode
+
+| Token | Hex |
+|---|---|
+| `background` | `#0b1326` |
+| `surface` | `#0b1326` |
+| `surface-container-lowest` | `#060e20` |
+| `surface-container-low` | `#131b2e` |
+| `surface-container` | `#171f33` |
+| `surface-container-high` | `#222a3d` |
+| `surface-container-highest` | `#2d3449` |
+| `primary` | `#8ed5ff` |
+| `primary-container` | `#38bdf8` |
+| `on-primary-container` | `#7bd0ff` |
+| `secondary` | `#b9c8de` |
+| `secondary-container` | `#39485a` |
+| `outline` | `#87929a` |
+| `outline-variant` | `#3e484f` |
+| `on-surface` | `#e2e8f0` |
+| `error` | `#ffb4ab` |
+| `error-container` | `#93000a` |
+
+### Semantic Color Usage
+
+| Semantic | Light | Dark | Use case |
+|---|---|---|---|
+| Enabled / success | `#16a34a` (green-600) | `#4ade80` | Toggle on, enabled badge |
+| Warning | `#d97706` (amber-600) | `#fbbf24` | Pending updates, stale jobs |
+| Running / active | `on-tertiary-container` `#4894e2` | same | Job in progress |
+| Disabled | `outline` `#74777d` | same | Toggle off, disabled office |
+| Destructive | `error` `#ba1a1a` | `#ffb4ab` | Delete buttons |
+
+### Gold Accent (Logo only)
+`#C9A84C` — the crown/`AI` gold. **Only use in the logo wordmark and icon.** Do not use as a UI color.
+
+---
+
+## 3. Typography
+
+**Single font family: Inter** (Google Fonts)
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+| Role | Weight | Size | Letter-spacing | Use |
+|---|---|---|---|---|
+| Display / Hero | 800–900 | 2.5–3rem | `tracking-tighter` | Page masthead titles |
+| Headline | 700 | 1.25–1.5rem | `tracking-tight` | Card headers, section titles |
+| Title | 600 | 1rem | normal | Sub-section titles |
+| Label | 700 | 0.625rem (10px) | `tracking-widest` (0.1em+) | Field labels, nav items, badges |
+| Body | 500 | 0.875rem (14px) | normal | Table data, form values |
+| Caption | 500 | 0.75rem (12px) | `tracking-wide` | Helper text, timestamps |
+
+**Label style rule:** All form field labels, navigation items, and badge text use `text-[10px] font-bold uppercase tracking-widest`. This is the single most distinctive typographic pattern in the design.
+
+---
+
+## 4. Iconography
+
+**Library: Material Symbols Outlined**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+```
+
+```css
+.material-symbols-outlined {
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+/* Filled variant (active/selected states): */
+.material-symbols-outlined.filled {
+    font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+```
+
+### Navigation Icon Map
+
+| Screen | Icon |
+|---|---|
+| Operations / Dashboard | `dashboard` |
+| Offices | `domain` |
+| Run / Scraper | `terminal` |
+| Data / Individuals | `groups` |
+| Wiki Drafts | `description` |
+| Gemini Research | `person_search` |
+| AI Offices | `auto_awesome` |
+| Reference Data | `database` |
+| Reports | `analytics` |
+| System / Settings | `settings` |
+| Logout | `logout` |
+| Support | `help` |
+
+---
+
+## 5. Layout Shell
+
+### Web (≥768px)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  TopAppBar  (h-16, sticky, z-30, bg-surface-bright)     │
+├───────────┬─────────────────────────────────────────────┤
+│           │                                             │
+│  Sidebar  │  Main Content                               │
+│  w-64     │  ml-64, pb-24                               │
+│  fixed    │                                             │
+│  h-screen │  [DataMasthead: bg-primary-container]       │
+│           │  [Card Grid: -mt-16, z-20, space-y-8]       │
+│           │                                             │
+└───────────┴─────────────────────────────────────────────┘
+```
+
+**Sidebar:**
+- Background: `bg-[#F1F4F6]` light / `bg-[#0b1326]` dark
+- Logo area: icon + "RulersAI" wordmark + "Institutional Intelligence" caption
+- Nav items: `text-[10px] font-bold uppercase tracking-wider`
+- Active state: `border-l-4 border-primary font-bold text-primary` (light) / `border-r-2 border-primary` (dark)
+- Hover state: `hover:bg-[#E2E8F0]` light / `hover:bg-[#131b2e]` dark
+- Bottom: "New Office" CTA button (full width, `bg-primary-container text-white rounded`) + Support + Logout
+
+**Top App Bar:**
+- Background: `bg-[#F7FAFC]` / `bg-[#0b1326]` dark
+- Global search input: `bg-surface-container-low rounded-full pl-10` with search icon
+- Right: notifications icon, settings icon, user avatar (32px circle)
+- No secondary tab-bar (the design template included "Intelligence/Campaigns/Legislative/Archives" tabs — these are **not implemented**; the app uses the sidebar for all navigation)
+
+**Data Masthead (signature element on every main page):**
+- Background: `bg-primary-container` (dark navy)
+- Content: eyebrow label (10px uppercase), large title (3rem bold), optional body text
+- Floating stat cards: `backdrop-blur-xl bg-white/5 border border-white/10 p-5 rounded-lg`
+- The main content cards are positioned with `-mt-16 relative z-20` to overlap the masthead bottom edge
+
+### Mobile (<768px)
+
+- Sidebar hidden by default, opens as an overlay drawer via hamburger button
+- Top app bar: hamburger (left), logo (center), avatar (right)
+- Bottom navigation bar: 5 key items (Dashboard, Offices, Run, Research, More)
+- Data tables collapse to card view (one card per row)
+- Data masthead: full width, no floating stat cards (stats stack vertically below title)
+- Touch targets: minimum 44×44px for all interactive elements
+- Font size floor: 14px for body, 12px for captions — no smaller
+
+---
+
+## 6. Component Patterns
+
+### Cards
+```
+bg-surface-container-lowest
+rounded-xl
+shadow-[0px_12px_32px_rgba(24,28,30,0.06)]
+p-8
+```
+
+### Section Headers (inside cards)
+```
+w-10 h-10 rounded-full bg-primary-fixed flex items-center justify-center
++ material symbol icon text-primary
++ h3 text-xl font-bold tracking-tight text-primary
+```
+
+### Form Field Labels
+```
+text-[10px] font-bold uppercase tracking-widest text-on-secondary-container mb-2
+```
+
+### Inputs
+```
+bg-surface-container-low border-none rounded-lg
+focus:ring-2 focus:ring-primary
+py-3 px-4 font-medium text-sm
+```
+
+### Buttons
+
+| Variant | Classes |
+|---|---|
+| Primary | `bg-primary-container text-white font-bold py-3 px-6 rounded hover:opacity-90` |
+| Secondary | `bg-surface-container-low text-primary font-bold py-2 px-4 rounded hover:bg-surface-container-high` |
+| Danger | `bg-error text-white font-bold py-2 px-4 rounded hover:opacity-90` |
+| Ghost / Icon | `text-on-surface-variant hover:bg-surface-container-low p-2 rounded-full` |
+| Small | Add `text-xs py-1.5 px-3` |
+
+### Badges / Status Pills
+
+| State | Classes |
+|---|---|
+| Enabled (green) | `bg-green-100 text-green-800 text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide` |
+| Disabled (gray) | `bg-surface-container text-outline text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide` |
+| Running (blue) | `bg-tertiary-container text-on-tertiary-container text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-widest` |
+| Error (red) | `bg-error-container text-on-error-container text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide` |
+| Pending (amber) | `bg-amber-100 text-amber-800 text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide` |
+
+### Toggles (Enable/Disable)
+Use a styled checkbox or custom toggle:
+- On: `bg-primary-container` thumb slides right
+- Off: `bg-surface-container-highest` thumb left
+- Always include visible label text + accessible `aria-label`
+
+### Data Tables
+- Header row: `text-[10px] font-bold uppercase tracking-widest text-on-secondary-container bg-surface-container-low`
+- Row: `border-b border-outline-variant/20 hover:bg-surface-container-low transition-colors`
+- Actions column: icon buttons with tooltips, right-aligned
+
+### Border Radius Scale
+```
+DEFAULT: 2px    (inputs, small elements)
+lg:      4px    (buttons)
+xl:      8px    (cards, modals)
+full:    12px   (pills, chips, avatars)
+```
+
+---
+
+## 7. Dark Mode
+
+Toggle via `class="dark"` on `<html>`. Persist in `localStorage`.
+Toggle button in top app bar (moon/sun icon).
+
+Dark background: `#0b1326` — a very deep midnight navy, not pure black.
+Dark sidebar: same `#0b1326`, blending into the content area.
+Dark cards: `bg-[#131b2e]` with subtle `border border-outline-variant/20`.
+
+---
+
+## 8. Navigation Mapping
+
+The design tool used aspirational nav labels. This table maps design labels to actual routes:
+
+| Design label | Actual route | Icon |
+|---|---|---|
+| Dashboard | `/operations` | `dashboard` |
+| Offices | `/offices` | `domain` |
+| Command Center | `/run` | `terminal` |
+| Intelligence Data | `/data/individuals` | `groups` |
+| Wiki Drafts | `/data/wiki-drafts` | `description` |
+| Deep Research | `/gemini-research` | `person_search` |
+| AI Creation | `/ai-offices` | `auto_awesome` |
+| Reference Data | `/refs` | `database` |
+| Reports | `/reports` | `analytics` |
+| System | `/data/scheduled-jobs` | `settings` |
+
+The "New Research Report" CTA in the sidebar maps to **"New Office"** (`/offices/new`).
+
+The top-bar secondary tab nav (Intelligence / Campaigns / Legislative / Archives) from the design templates is **not implemented** — these labels have no equivalent routes.
+
+---
+
+## 9. Mobile-First Considerations
+
+The mobile designs cover: Login, Dashboard, Offices List, Scraper Control, Gemini Research, Wiki Drafts.
+
+Key mobile-specific patterns:
+- **Bottom nav bar**: 5 items (Dashboard, Offices, Run, Research, More)
+- **Drawer**: Full-height overlay sidebar, dismiss on backdrop tap
+- **Cards over tables**: On screens < 640px, list views render as stacked cards instead of tables
+- **Masthead**: Full-bleed, title only, stat cards stack below (no float)
+- **Form sections**: Accordion/collapsible — only the active section is expanded
+- The heavy "Table Extraction Config" section in the office editor is **web-only** in v1 (collapse to read-only summary on mobile with a "Open on desktop" prompt)
+
+---
+
+## 10. Localization (i18n)
+
+> Full spec: `docs/localization.md`
+
+### Supported Locales
+`en` (default), `es`, `fr-CA`, `de`, `nl`, `pt`, `ru`, `hi`, `zh`, `ja`, `ko`, `ar`, `he`
+
+RTL locales: `ar`, `he`. Translation files for all 13 locales are created upfront; RTL layout work ships in a separate story.
+
+### Web (FastAPI + Jinja2)
+- Python `babel` + Jinja2 `i18n` extension (gettext)
+- Strings in templates: `{{ _("Save office") }}` / `{% trans %}Save office{% endtrans %}`
+- Translation files: `src/locales/{lang}/LC_MESSAGES/messages.po` (compiled to `.mo`)
+- Extract: `pybabel extract -F babel.cfg -o src/locales/messages.pot src/`
+- Locale detection order: session cookie `lang` → `Accept-Language` header → `en`
+- Language switcher: icon button in top app bar
+
+### Mobile (React Native / Expo — future)
+- Same pattern as `gaming_app` and `book_app`: `i18next` + `react-i18next` + `i18next-resources-to-backend`
+- `expo-localization` for device locale; same `resolveLocale()` fallback logic
+- Namespaces mirror web namespaces; `en` bundled statically, others lazy-loaded
+- `useHtmlAttributes()` hook sets `<html lang>` and `<html dir>` (same pattern as `gaming_app`)
+
+### Namespaces
+| Namespace | Contents |
+|---|---|
+| `common` | Shared UI: buttons, labels, errors, confirmations, date formats |
+| `nav` | Sidebar and top-bar navigation labels |
+| `offices` | Office list + edit form: field labels, placeholders, validation |
+| `run` | Scraper / Command Center: run modes, options, progress labels |
+| `research` | Gemini research, Wiki drafts |
+| `refs` | Reference data labels |
+| `auth` | Login screen |
+| `system` | Scheduled jobs, settings, system admin |
+
+### Meta Files
+Each namespace has `src/locales/_meta/{namespace}.meta.json` with per-key:
+- `description` — what the string is and where it appears
+- `tone` — neutral / action / functional / instructional / celebratory
+- `characterLimit` — max characters the UI can display
+- `placeholders` — list of interpolation variables (e.g. `["{{name}}"]`)
+- `doNotTranslate` — proper nouns to keep in source language (e.g. `["Wikipedia", "RulersAI"]`)
+
+### RTL Rules
+- `<html dir="rtl">` set server-side for `ar` and `he` locales
+- All layout uses CSS logical properties: `margin-inline-start`, `padding-inline-end`, `border-inline-start`, etc.
+- Sidebar: flips to right side in RTL (`right: 0`, main content uses `margin-inline-start: 16rem`)
+- Floating outline sidebar (multi-office editor): flips to opposite side
+- Directional icons (chevrons, arrows): `[dir=rtl] .icon-directional { transform: scaleX(-1); }`
+- Font stacks: Arabic → `'Inter', 'Noto Sans Arabic', sans-serif`; Hebrew → `'Inter', 'Noto Sans Hebrew', sans-serif`
+- RTL is gated: `ar`/`he` files are created in i18n story but layout ships in a separate RTL story
+
+---
+
+## 11. Accessibility (WCAG 2.2 A + AA — ground-up implementation)
+
+The app has no existing WCAG compliance. Every screen story ships with a11y baked in.
+This section is the authoritative spec for all screen stories (5–14).
+
+### Approach
+- **Infrastructure** (STORY-16a): skip link, audio mute, focus-ring CSS, `aria-live` containers, axe CI — lives in `base.html` and `theme.css`
+- **Per-screen** (stories 5–14): each screen story includes a11y as part of its definition of done
+- **Audit** (STORY-16b): after all screens ship — keyboard walkthrough + screen reader testing + fix stragglers
+
+### What is N/A for this app
+- 1.2.x — no video or prerecorded audio content
+- 2.1.4 — no single-character keyboard shortcuts
+- 2.2.1 — no session timeouts affecting users
+- 2.3.1 — no flashing content
+- 2.5.1 — no multi-point pointer gestures
+- 3.3.7 Redundant Entry — no multi-step form flows requiring re-entry
+- 3.3.8 Accessible Authentication — Google OAuth, no CAPTCHA ✓
+
+---
+
+### Infrastructure (STORY-16a — part of STORY-3/4)
+
+**Skip link** — first child of `<body>`:
+```html
+<a href="#main-content"
+   class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50
+          focus:bg-primary-container focus:text-white focus:px-4 focus:py-2 focus:rounded">
+  Skip to main content
+</a>
+```
+
+**Landmarks:**
+```html
+<nav aria-label="Primary navigation">   <!-- sidebar -->
+<header role="banner">                   <!-- top app bar -->
+<main id="main-content">                 <!-- page content -->
+```
+
+**Focus ring** — single CSS rule in `theme.css` covers the whole app:
+```css
+*:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+*:focus:not(:focus-visible) {
+  outline: none;  /* suppress on mouse click, keep on keyboard */
+}
+```
+
+**`scroll-padding-top`** (2.4.11 Focus Not Obscured):
+```css
+html { scroll-padding-top: 4.5rem; }  /* equals top bar height */
+```
+
+**`aria-live` regions** — in `base.html`, before `</body>`. JS writes to these; never updates arbitrary divs:
+```html
+<div id="live-polite"   aria-live="polite"   aria-atomic="true"  class="sr-only"></div>
+<div id="live-assertive" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
+```
+Usage: `document.getElementById('live-polite').textContent = 'Saved.'`
+
+**Audio mute toggle** (1.4.2 Audio Control):
+The job completion sound plays 5 tones over ~4.5 seconds — exceeds the 3-second threshold.
+Add a `🔇` icon button to the top bar that toggles `window._soundMuted`.
+`playJobCompleteSound()` checks `if (window._soundMuted) return;` before playing.
+Persist preference in `localStorage`.
+
+---
+
+### Per-Screen Requirements (definition of done for stories 5–14)
+
+**Page titles (2.4.2):**
+Every page has a unique, descriptive title:
+```html
+{% block title %}Edit Office — RulersAI{% endblock %}
+{% block title %}Offices — RulersAI{% endblock %}
+{% block title %}Command Center — RulersAI{% endblock %}
+```
+Format: `[Page Name] — RulersAI`
+
+**Form labels (1.3.1):**
+- Every `<input>`, `<select>`, `<textarea>` has an associated `<label for="id">` or is wrapped inside a `<label>`
+- Wrapping is preferred for checkboxes; `for`/`id` is required for all other inputs
+- No orphaned `<label>Text</label><input>` without explicit association
+
+**Required fields (3.3.2):**
+```html
+<label for="office-name">
+  Office name
+  <span aria-hidden="true"> *</span>
+  <span class="sr-only">(required)</span>
+</label>
+<input id="office-name" aria-required="true" ...>
+```
+
+**Validation errors (3.3.1, 3.3.3):**
+```html
+<!-- Error banner -->
+<div role="alert">
+  <strong>Save failed</strong> — Office name is required. Enter a name and try again.
+</div>
+<!-- Failing field -->
+<input id="office-name" aria-invalid="true" aria-describedby="office-name-error">
+<span id="office-name-error" class="field-error">Office name is required.</span>
+```
+Error messages must say both what failed AND how to fix it (3.3.3).
+
+**Heading hierarchy:**
+- One `<h1>` per page — the masthead title
+- Card headers: `<h2>`
+- Sub-sections within cards: `<h3>`
+- Table config blocks: `<h4>`
+- Never skip levels
+
+**Data tables (1.3.1):**
+```html
+<table aria-label="Offices">
+  <thead>
+    <tr>
+      <th scope="col" aria-sort="none">Name</th>
+      <th scope="col">Country</th>
+    </tr>
+  </thead>
+```
+Update `aria-sort="ascending/descending"` via JS when user sorts a column.
+
+**Custom toggles (4.1.2):**
+```html
+<button role="switch" aria-checked="true" class="toggle">
+  <span class="sr-only">Include in runs: </span>
+  <span aria-hidden="true"><!-- visual toggle --></span>
+</button>
+```
+
+**Progress bars (4.1.2):**
+```html
+<div role="progressbar"
+     aria-valuenow="42" aria-valuemin="0" aria-valuemax="100"
+     aria-label="Offices: 42 of 120"
+     aria-valuetext="42 of 120 offices">
+  <!-- visual bar -->
+</div>
+```
+Update `aria-valuenow` and `aria-valuetext` via JS on each poll cycle.
+Also write a summary to the `aria-live="polite"` region on completion.
+
+**Collapsible panels (4.1.2):**
+```html
+<button aria-expanded="false" aria-controls="preview-panel-id">
+  Preview
+</button>
+<div id="preview-panel-id" hidden>...</div>
+```
+When panel opens: `hidden` removed, `aria-expanded="true"`, focus moved to panel heading or first interactive element.
+
+**Icon buttons (2.4.4):**
+```html
+<button aria-label="Test config for US House of Representatives">
+  <span class="material-symbols-outlined" aria-hidden="true">science</span>
+</button>
+```
+Label must name the action AND the target.
+
+**Input purpose (1.3.5):**
+```html
+<input autocomplete="url">         <!-- URL fields -->
+<input autocomplete="name">        <!-- name fields -->
+<input autocomplete="off">         <!-- table numbers, column indices -->
+```
+
+**Target size (2.5.8):**
+- All interactive elements: minimum 24×24 CSS px hit area
+- Mobile touch targets: minimum 44×44px
+- Icon buttons in toolbars: use `p-1.5` minimum (gives 24px)
+- Toggle switch thumb: minimum 24px
+
+**Focus not obscured (2.4.11):**
+- `scroll-padding-top` in base CSS handles the sticky top bar
+- Floating outline sidebar: only contains jump links, not form elements — no overlap concern
+- Sticky save-all bar: positioned at top (below top app bar), not bottom — test that elements at the bottom of the page aren't obscured
+
+**Consistent help (3.2.6):**
+- "Support" link in sidebar footer, same position on every page
+- `ⓘ` info icons on fields use `<button type="button" aria-label="Help: [field name]">` opening a tooltip or small description block — not bare `title` attributes (inaccessible on touch/keyboard)
+
+**Color not sole indicator (1.4.1):**
+- Status badges: text label always present alongside color (`Enabled` / `Disabled`)
+- Error states: `aria-invalid` + red border + error text — never red border alone
+
+**Input border contrast (1.4.11):**
+Use `outline` (#74777d) for input borders — 4.6:1 against white. Never `outline-variant`.
+
+---
+
+### Testing (STORY-16b)
+- `@axe-core/playwright` — one test per key page, fails CI on any axe violation
+- Keyboard-only walkthrough of three flows after all screen stories ship:
+  1. Create a new office and save
+  2. Run scraper, monitor progress, cancel job
+  3. Review wiki draft and update status
+- Screen reader testing: NVDA + Chrome (Windows), VoiceOver + Safari (macOS)
+- Confirm: job completion sound can be muted, status messages are announced, error fields are announced on save failure
+
+---
+
+## 12. Story Map
+
+| # | Story | Key deliverables | Depends on |
+|---|---|---|---|
+| 1 | App Icon & Favicon (PR #442) | Icon asset, favicon, apple-touch-icon | — |
+| 2 | Branding Guidelines (this file) | Color tokens, typography, component spec, a11y spec, i18n spec | — |
+| 3 | Design Tokens & Global CSS | `theme.css` rewrite, Inter + Material Symbols, CSS focus ring, `scroll-padding-top` | — |
+| **16a** | **A11y Infrastructure** | Skip link, `aria-live` regions, audio mute toggle, axe CI setup — all in `base.html` / `theme.css` | 3 |
+| 4 | Layout Shell | Fixed sidebar, top bar, `<main id>`, landmarks, dark mode toggle, audio mute button | 3, 16a |
+| 5 | Office List Page | Masthead, restyled table with `<th scope>` + `aria-sort`, filter bar, status badges | 4 |
+| 6 | Edit Office — Single Mode | Cards, bento layout, all form labels associated, progress bars with ARIA, error field markup | 4 |
+| 7 | Edit Office — Multi-Office Mode | Collapsible office sections with `aria-expanded`, save-all bar, restyled floating outline | 6 |
+| 8 | Scraper / Command Center | Run mode tiles, options toggles as `role="switch"`, progress bars with ARIA, cancel keyboard accessible | 4 |
+| 9 | Wiki Drafts | Status tabs, draft cards, detail split-pane | 4 |
+| 10 | Gemini Research | Search card, research progress panel | 4 |
+| 11 | Login Page | Full-page card, Google OAuth button | 3 |
+| 12 | Remaining Pages (bulk pass) | Apply shell + tokens to reports, refs, system admin, data views | 4 |
+| 13 | Dark Mode (end-to-end) | Toggle persistence, verify all pages in dark | 4 |
+| 14 | Mobile Layouts | Drawer, bottom nav, table→card, edit-office 3-tier | 4, 6 |
+| 15a | i18n Foundation | `babel` setup, en strings extracted to `.po`, 12 locale stubs, language switcher in top bar | 4 |
+| 15b | RTL Layout | `ar` + `he` layout — logical CSS properties, sidebar flip, directional icon flip, Noto font fallbacks | 15a |
+| 15c | Translation Delivery | All 13 locales translated, meta files, CI locale smoke tests | 15a |
+| **16b** | **A11y Audit** | axe on all pages, keyboard walkthroughs (3 flows), NVDA + VoiceOver testing, fix stragglers | 5–14 |
+
+**Parallel tracks after STORY-4:** Stories 5–13 can run in parallel. Stories 14, 15a, and 16b are independent of each other after their stated dependencies.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,442 @@
+# RulersAI — Localization (i18n)
+
+This document covers the full localization architecture for RulersAI across web (FastAPI / Jinja2) and mobile (React Native / Expo — future). It covers locale registry, translation file structure, extraction workflow, RTL layout, testing, and the translation delivery process.
+
+For component-level branding and visual considerations see `docs/branding.md`.  
+For `lang` and `dir` attribute handling see the Infrastructure section of `docs/accessibility.md`.
+
+---
+
+## Supported Locales
+
+| Code | Language | Script | Direction | Status |
+|---|---|---|---|---|
+| `en` | English | Latin | LTR | Source language — always complete |
+| `es` | Spanish | Latin | LTR | Translate |
+| `fr-CA` | French (Canadian) | Latin | LTR | Translate |
+| `de` | German | Latin | LTR | Translate |
+| `nl` | Dutch | Latin | LTR | Translate |
+| `pt` | Portuguese | Latin | LTR | Translate |
+| `ru` | Russian | Cyrillic | LTR | Translate |
+| `hi` | Hindi | Devanagari | LTR | Translate |
+| `zh` | Chinese (Simplified) | Han | LTR | Translate |
+| `ja` | Japanese | Mixed | LTR | Translate |
+| `ko` | Korean | Hangul | LTR | Translate |
+| `ar` | Arabic | Arabic | **RTL** | Translate + RTL layout (gated on STORY-O) |
+| `he` | Hebrew | Hebrew | **RTL** | Translate + RTL layout (gated on STORY-O) |
+
+RTL locales (`ar`, `he`) have translation files created alongside all other locales but are not enabled in the language switcher until the RTL layout story (STORY-O) ships.
+
+This locale set matches `book_app` and `gaming_app` exactly for consistency across the product portfolio.
+
+---
+
+## Architecture
+
+### Web (FastAPI + Jinja2)
+
+**Library:** Python `babel` + Jinja2 `i18n` extension (gettext standard)
+
+**Why gettext, not a custom JSON loader?**  
+- Industry standard for Python server-side i18n
+- `pybabel` toolchain handles extraction from Jinja2 templates automatically
+- `.po`/`.mo` format is translator-friendly (professional CAT tool support)
+- Lazy evaluation prevents import-time issues in FastAPI
+
+**Directory structure:**
+```
+src/
+  locales/
+    _meta/                        ← per-namespace meta files (see below)
+      common.meta.json
+      nav.meta.json
+      offices.meta.json
+      run.meta.json
+      research.meta.json
+      refs.meta.json
+      auth.meta.json
+      system.meta.json
+    messages.pot                  ← master template (generated, not committed)
+    en/
+      LC_MESSAGES/
+        messages.po               ← English source strings (committed)
+        messages.mo               ← compiled binary (generated at deploy, not committed)
+    es/
+      LC_MESSAGES/
+        messages.po
+        messages.mo
+    ar/
+      LC_MESSAGES/
+        messages.po
+        messages.mo
+    ... (one directory per locale)
+  babel.cfg                       ← extraction configuration
+```
+
+**`babel.cfg`:**
+```ini
+[python: src/**.py]
+[jinja2: src/templates/**.html]
+extensions = jinja2.ext.i18n
+encoding = utf-8
+```
+
+**Jinja2 setup in `src/main.py`:**
+```python
+from babel.support import Translations
+from jinja2 import Environment
+
+def get_translations(locale: str) -> Translations:
+    return Translations.load('src/locales', [locale])
+
+# In request middleware:
+# 1. Detect locale (cookie → Accept-Language → 'en')
+# 2. Load translations
+# 3. Install into Jinja2 env via env.install_gettext_translations(t)
+```
+
+**In templates:**
+```html
+<!-- Simple string -->
+<h1>{{ _("Office Configuration") }}</h1>
+
+<!-- With variable interpolation -->
+<p>{{ _("%(count)s offices configured", count=office_count) }}</p>
+
+<!-- Block form (multi-word) -->
+{% trans %}Save office{% endtrans %}
+
+<!-- Plural form -->
+{% trans count=num_offices %}
+  {{ count }} office
+{% pluralize %}
+  {{ count }} offices
+{% endtrans %}
+```
+
+**In Python router code:**
+```python
+from babel.support import LazyProxy
+
+def lazy_gettext(string): ...  # standard lazy_gettext pattern
+
+# Example usage:
+error_msg = lazy_gettext("Office name is required.")
+```
+
+### Mobile (React Native / Expo — future)
+
+Matches `gaming_app` and `book_app` exactly:
+
+- **Library:** `i18next` + `react-i18next` + `i18next-resources-to-backend`
+- **Device locale detection:** `expo-localization` → `resolveLocale()` with fallback chain
+- **Loading:** `en` bundled statically; all other locales lazy-loaded via `import()`
+- **RTL:** `I18nManager.forceRTL()` for `ar` and `he`, plus `useHtmlAttributes()` hook for web targets
+- **Persistence:** `AsyncStorage` under key `rulersai_locale`
+
+**Namespace → JSON file mapping (mirrors web namespaces):**
+```
+frontend/src/i18n/locales/
+  en/
+    common.json
+    nav.json
+    offices.json
+    run.json
+    research.json
+    refs.json
+    auth.json
+    system.json
+  es/
+    common.json
+    ...
+```
+
+**Key naming convention:** `namespace.component.element.type`  
+Example: `offices.form.url.label`, `offices.form.url.placeholder`, `run.mode.full.label`
+
+**Shared key names:** Web `.po` message IDs and mobile JSON keys use the same naming convention. The English source is the single source of truth; mobile JSON files are generated from `.po` files by a script at `scripts/po_to_json.py`.
+
+---
+
+## Namespaces
+
+| Namespace | Coverage |
+|---|---|
+| `common` | Buttons (Save, Cancel, Delete, Confirm, Close, Remove), generic error titles, date/number formats, pagination labels, loading states |
+| `nav` | Sidebar nav items, top bar labels, breadcrumb labels, page section labels |
+| `offices` | Office list filters, office form field labels, placeholders, validation messages, table config field labels, action button labels |
+| `run` | Run mode names and descriptions, option labels, progress phase labels, job status messages |
+| `research` | Gemini research labels, wiki draft statuses, draft detail labels, submission options |
+| `refs` | Reference data page titles and form labels (countries, states, cities, levels, branches, categories, parties, infobox filters) |
+| `auth` | Login page: sign-in button, tagline, verification labels |
+| `system` | Scheduled jobs labels, settings keys, runner registry labels, system admin section titles |
+
+---
+
+## Meta Files
+
+Each namespace has a meta file at `src/locales/_meta/{namespace}.meta.json`.
+
+**Purpose:** Provide context to translators and enforce constraints in CI.
+
+**Format per key:**
+```json
+{
+  "offices.form.url.label": {
+    "description": "Label for the Wikipedia source URL input on the office edit form",
+    "tone": "neutral",
+    "characterLimit": 25,
+    "placeholders": [],
+    "doNotTranslate": ["Wikipedia"],
+    "notes": null
+  },
+  "offices.form.name.label": {
+    "description": "Label for the office name input. This is the primary identifier.",
+    "tone": "neutral",
+    "characterLimit": 20,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Keep short — renders inside a compact form label above the input."
+  },
+  "run.progress.offices": {
+    "description": "Progress label for the offices phase of a scraper run",
+    "tone": "neutral",
+    "characterLimit": 30,
+    "placeholders": ["current", "total"],
+    "doNotTranslate": [],
+    "notes": "Example: 'Offices: 42 / 120'. Keep numeric format flexible."
+  }
+}
+```
+
+**Fields:**
+- `description` — what the string is and which component/page it appears on
+- `tone` — `neutral` / `action` / `functional` / `instructional` / `celebratory` / `sympathetic`
+- `characterLimit` — maximum character count the UI can display without overflow
+- `placeholders` — list of interpolation variables that must appear in translated string
+- `doNotTranslate` — proper nouns, product names, technical terms to keep in source language
+- `notes` — optional translator context
+
+---
+
+## Locale Detection (Web)
+
+Detection order, evaluated on each request:
+
+1. **Session cookie** `lang` — set by the language switcher, persists across requests
+2. **`Accept-Language` HTTP header** — browser preference, matched against supported locales
+3. **Fallback** — `en`
+
+**Matching logic for `Accept-Language`:**
+```python
+def resolve_locale(accept_language: str, supported: list[str]) -> str:
+    # Parse quality-weighted list: "fr-CA,fr;q=0.9,en;q=0.8"
+    for tag in parse_accept_language(accept_language):
+        if tag in supported:
+            return tag
+        # Base language fallback: "fr" matches "fr-CA"
+        base = tag.split('-')[0]
+        match = next((l for l in supported if l.split('-')[0] == base), None)
+        if match:
+            return match
+    return 'en'
+```
+
+**Language switcher** (in top bar):
+- Icon button opens a dropdown listing all active locales (name in native script, e.g. "Español", "Deutsch", "العربية")
+- On selection: POST to `/set-locale` which sets the `lang` cookie and redirects back to current page
+- `ar` and `he` appear in the list only after STORY-O (RTL layout) ships
+
+---
+
+## Extraction Workflow
+
+```bash
+# 1. Extract all translatable strings from templates and Python files
+pybabel extract -F babel.cfg \
+  --project=RulersAI \
+  --version=1.0 \
+  -o src/locales/messages.pot \
+  src/
+
+# 2a. Initialize a new locale (first time only)
+pybabel init -i src/locales/messages.pot \
+  -d src/locales \
+  -l es
+
+# 2b. Update existing locale with new/changed strings
+pybabel update -i src/locales/messages.pot \
+  -d src/locales
+
+# 3. Translate: edit src/locales/{lang}/LC_MESSAGES/messages.po
+# (or send to translator / use translation platform)
+
+# 4. Compile to binary (done at deploy time, not committed)
+pybabel compile -d src/locales
+
+# Helper script (runs extract + update for all locales):
+python scripts/i18n_update.py
+```
+
+**`scripts/i18n_update.py`** automates steps 1 + 2b and reports:
+- New strings added since last extraction
+- Strings removed (marked `#, obsolete` in `.po` files)
+- Strings with `fuzzy` flag (changed source, needs re-translation)
+
+**`scripts/po_to_json.py`** generates mobile JSON files from `.po` files (for React Native consumption).
+
+---
+
+## RTL Layout (STORY-O)
+
+RTL layout for `ar` and `he` requires changes at multiple layers:
+
+### HTML
+
+```html
+<!-- base.html — set by locale detection middleware -->
+<html lang="{{ locale }}" dir="{{ 'rtl' if locale in RTL_LOCALES else 'ltr' }}">
+```
+
+`RTL_LOCALES = {'ar', 'he'}` — defined as a Python constant in `src/i18n.py`.
+
+### CSS — Logical Properties
+
+Replace all directional CSS with logical equivalents throughout `theme.css` and all component styles:
+
+| Replace | With |
+|---|---|
+| `margin-left` | `margin-inline-start` |
+| `margin-right` | `margin-inline-end` |
+| `padding-left` | `padding-inline-start` |
+| `padding-right` | `padding-inline-end` |
+| `border-left` | `border-inline-start` |
+| `border-right` | `border-inline-end` |
+| `left: 0` | `inset-inline-start: 0` |
+| `right: 0` | `inset-inline-end: 0` |
+| `text-align: left` | `text-align: start` |
+| `text-align: right` | `text-align: end` |
+| `float: left` | `float: inline-start` |
+
+### Sidebar
+
+```css
+/* Sidebar — flips automatically with logical properties */
+nav[aria-label="Primary navigation"] {
+  position: fixed;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;  /* left in LTR, right in RTL */
+  width: 16rem;
+}
+
+main {
+  margin-inline-start: 16rem;  /* right-offset in RTL */
+}
+```
+
+### Floating Outline Sidebar (Multi-Office Editor)
+
+```css
+.page-outline {
+  position: fixed;
+  inset-block-start: 6rem;
+  inset-inline-end: 1rem;  /* right in LTR, left in RTL */
+}
+
+.page-edit-main {
+  margin-inline-end: 13rem;
+}
+```
+
+### Directional Icons
+
+Icons that imply direction (chevrons, arrows, back/forward) must mirror in RTL:
+
+```css
+[dir="rtl"] .icon-directional {
+  transform: scaleX(-1);
+}
+```
+
+Apply `.icon-directional` class to: `chevron_right`, `chevron_left`, `arrow_forward`, `arrow_back`, `navigate_next`, `navigate_before`.
+
+Icons that are not directional (check marks, warnings, settings, etc.) do not get this class.
+
+### Font Stacks
+
+```css
+/* Arabic */
+:lang(ar) {
+  font-family: 'Inter', 'Noto Sans Arabic', 'Arial', sans-serif;
+}
+
+/* Hebrew */
+:lang(he) {
+  font-family: 'Inter', 'Noto Sans Hebrew', 'Arial', sans-serif;
+}
+```
+
+Load Noto Sans Arabic and Noto Sans Hebrew from Google Fonts only when the active locale requires them (lazy-load via JS to avoid loading for all users).
+
+### Number Formatting
+
+Arabic uses Eastern Arabic numerals in some contexts. Use `Intl.NumberFormat(locale)` in JavaScript and Python's `babel.numbers.format_number(n, locale=locale)` for displayed counts and statistics — not hardcoded digit strings.
+
+---
+
+## Testing
+
+### CI — Locale Smoke Tests
+
+Render each of the 6 key pages with each of the 13 locales. Assert:
+- HTTP 200 response
+- No raw translation keys visible (no strings matching `^[a-z]+\.[a-z_]+\.[a-z_]+` in page body)
+- Page `lang` attribute matches requested locale
+- Page `dir` attribute is `rtl` for `ar` and `he`, `ltr` for all others
+
+Pages tested: `/offices`, `/offices/new`, `/run`, `/data/wiki-drafts`, `/gemini-research`, `/login`
+
+### CI — Character Limit Checks
+
+`scripts/check_char_limits.py` — reads all `.po` files and compares translated string lengths against `characterLimit` in meta files. Fails CI if any translation exceeds its limit by more than 20% (buffer for natural language expansion).
+
+### CI — Placeholder Completeness
+
+`scripts/check_placeholders.py` — verifies that every placeholder listed in a meta `placeholders` array is present in each locale's translation. Fails CI if a placeholder is missing from a translation (would cause a runtime error).
+
+### Manual RTL Visual Check (STORY-O)
+
+Screenshot test for `ar` and `he` on 4 pages: offices list, edit office (single), run page, login.  
+Verify:
+- Sidebar appears on the right side
+- Text is right-aligned
+- Chevrons point the correct direction
+- No text/UI overflow
+
+### Translation Review
+
+Before STORY-P is marked done:
+- All `.po` files reviewed for completeness (no `msgstr ""` entries except intentionally empty strings)
+- No `fuzzy` flags in any production locale
+- `doNotTranslate` terms verified to be untranslated in each locale's `.po` file
+
+---
+
+## Deployment Notes
+
+`.mo` (compiled binary) files are **not committed to git**. They are compiled at deploy time:
+
+```bash
+# In Render build command or CI deploy step:
+pybabel compile -d src/locales
+```
+
+Add to `render.yaml` build command:
+```yaml
+buildCommand: pip install -r requirements.txt && pybabel compile -d src/locales
+```
+
+`messages.pot` (the template) is also not committed — it is regenerated on each extraction run.
+
+Only `.po` source files and `_meta/*.meta.json` files are committed.


### PR DESCRIPTION
## Summary
- Adds `docs/branding.md` — RulersAI design system: Material Design 3 token palette (light + dark), Inter typography, Material Symbols iconography, layout shell spec, component patterns, navigation label mapping, story map
- Adds `docs/accessibility.md` — WCAG 2.2 A + AA ground-up implementation spec: baseline audit findings, per-screen requirements, infrastructure (skip link, landmarks, aria-live, audio mute), testing protocol
- Adds `docs/localization.md` — i18n architecture: babel/gettext for web, i18next for mobile, 13 locales (incl. RTL), namespace structure, meta file format, extraction workflow, RTL CSS logical properties, CI testing

## Why these docs first
These three documents are the source of truth for GitHub issues #445–#462 (brand redesign, a11y, i18n stories). They must be in `dev` before implementation begins so engineers can reference them.

## Test plan
- [ ] All three files render correctly as Markdown in GitHub
- [ ] No broken cross-references between the three docs
- [ ] `docs/localization.md` RTL table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)