### PR TITLE
fix: reduce subprocess OOM + fix cascading job failures after container restart (#464-#467)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -195,10 +195,15 @@ async def lifespan(app: FastAPI):
 
     from src.db.scheduled_job_runs import expire_stale_scheduled_job_runs
 
-    expired_count = expire_stale_scheduled_job_runs()
+    # stale_hours=0 expires every 'running' record regardless of age.  Any job that was
+    # in-flight when the previous process died cannot be running now — the subprocess was
+    # killed with the container.  Using the default stale_hours=4 would leave a record
+    # created 1 minute before an OOM kill alive for 4 hours, blocking downstream jobs
+    # (insufficient_vitals, gemini_research, daily_page_quality) all morning.
+    expired_count = expire_stale_scheduled_job_runs(stale_hours=0)
     if expired_count:
         logger.warning(
-            "[startup] Cleared %d stale scheduled_job_runs row(s) left over from previous OOM kill",
+            "[startup] Cleared %d stale scheduled_job_runs row(s) left over from previous process (OOM kill or restart)",
             expired_count,
         )
     else:

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -2497,7 +2497,9 @@ def run_with_db(
         # already bypasses RunPageCache for table-parsing fetches (table_cache.py:200 passes
         # run_cache=None), but the cache was still created and forwarded to bio extraction
         # where each URL is unique — providing no dedup benefit while accumulating HTML strings.
-        run_cache = RunPageCache() if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") != "0" else None
+        run_cache = (
+            RunPageCache() if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") != "0" else None
+        )
         run_cfg = _RunConfig(
             run_mode=run_mode,
             refresh_table_cache=refresh_table_cache,

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -2493,7 +2493,11 @@ def run_with_db(
         living_errors: list[dict[str, str]] = []
         bio_cancelled = False
 
-        run_cache = RunPageCache()
+        # Skip the in-memory page cache when TABLE_HTML_CACHE_ENABLED=0.  That env var
+        # already bypasses RunPageCache for table-parsing fetches (table_cache.py:200 passes
+        # run_cache=None), but the cache was still created and forwarded to bio extraction
+        # where each URL is unique — providing no dedup benefit while accumulating HTML strings.
+        run_cache = RunPageCache() if os.environ.get("TABLE_HTML_CACHE_ENABLED", "1") != "0" else None
         run_cfg = _RunConfig(
             run_mode=run_mode,
             refresh_table_cache=refresh_table_cache,
@@ -2525,6 +2529,10 @@ def run_with_db(
                 and _cur_office_url != _prev_office_url
                 and _prev_office_url is not None
             ):
+                gc.collect()
+            elif idx > 0 and idx % 25 == 0:
+                # Fallback: nudge GC every 25 offices even when many share the same URL,
+                # so BS4 cyclic references don't accumulate for the whole same-URL batch.
                 gc.collect()
             _prev_office_url = _cur_office_url
             if cancel_check and cancel_check():
@@ -2901,6 +2909,11 @@ def run_with_db(
                 # Split: bio_cache hits (no HTTP) vs URLs that need HTTP fetch.
                 cache_hits = [u for u in to_fetch if (normalize_wiki_url(u) or u) in bio_cache]
                 http_urls = [u for u in to_fetch if (normalize_wiki_url(u) or u) not in bio_cache]
+                # all_office_data is no longer needed — bio_cache has extracted _bio_details
+                # and unique_wiki_urls drives the fetch lists.  Clear it now to free the
+                # parsed term dicts (5–30 MB) before the HTTP bio-fetch phase begins.
+                all_office_data.clear()
+                gc.collect()
                 # Process bio_cache hits sequentially (no rate limiting needed).
                 for wiki_url in cache_hits:
                     bio_cache_key = normalize_wiki_url(wiki_url) or wiki_url

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -266,9 +266,7 @@ class ConsensusVoter:
         # __exit__, which blocks until every thread finishes — meaning a 60 s Gemini response
         # holds up the process for 60 s even after we've logged it as a 30 s timeout.
         executor = ThreadPoolExecutor(max_workers=3)
-        future_to_provider = {
-            executor.submit(fn, prompt, context): name for name, fn in providers
-        }
+        future_to_provider = {executor.submit(fn, prompt, context): name for name, fn in providers}
         pending_futures = set(future_to_provider)
 
         def _collect(future: object) -> None:

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -261,31 +261,36 @@ class ConsensusVoter:
 
         votes: list[AIVote] = []
 
-        with ThreadPoolExecutor(max_workers=3) as executor:
-            future_to_provider = {
-                executor.submit(fn, prompt, context): name for name, fn in providers
-            }
-            pending_futures = set(future_to_provider)
+        # Use explicit executor (not a `with` block) so we can call shutdown(wait=False)
+        # when providers time out.  `with ThreadPoolExecutor` calls shutdown(wait=True) on
+        # __exit__, which blocks until every thread finishes — meaning a 60 s Gemini response
+        # holds up the process for 60 s even after we've logged it as a 30 s timeout.
+        executor = ThreadPoolExecutor(max_workers=3)
+        future_to_provider = {
+            executor.submit(fn, prompt, context): name for name, fn in providers
+        }
+        pending_futures = set(future_to_provider)
 
-            def _collect(future: object) -> None:
-                pending_futures.discard(future)
-                provider_name = future_to_provider[future]
-                try:
-                    vote = future.result(timeout=0)
-                except FuturesTimeoutError:
-                    logger.warning(
-                        "ConsensusVoter: %s timed out after %.0f s", provider_name, timeout_s
-                    )
-                    vote = AIVote(
-                        provider=provider_name,
-                        is_valid=None,
-                        error=f"timed out after {timeout_s:.0f}s",
-                    )
-                except Exception as exc:
-                    logger.exception("ConsensusVoter: %s raised unexpected error", provider_name)
-                    vote = AIVote(provider=provider_name, is_valid=None, error=str(exc))
-                votes.append(vote)
+        def _collect(future: object) -> None:
+            pending_futures.discard(future)
+            provider_name = future_to_provider[future]
+            try:
+                vote = future.result(timeout=0)
+            except FuturesTimeoutError:
+                logger.warning(
+                    "ConsensusVoter: %s timed out after %.0f s", provider_name, timeout_s
+                )
+                vote = AIVote(
+                    provider=provider_name,
+                    is_valid=None,
+                    error=f"timed out after {timeout_s:.0f}s",
+                )
+            except Exception as exc:
+                logger.exception("ConsensusVoter: %s raised unexpected error", provider_name)
+                vote = AIVote(provider=provider_name, is_valid=None, error=str(exc))
+            votes.append(vote)
 
+        try:
             try:
                 for future in as_completed(future_to_provider, timeout=timeout_s + 5):
                     _collect(future)
@@ -309,6 +314,11 @@ class ConsensusVoter:
                             error=f"timed out after {timeout_s:.0f}s",
                         )
                     )
+        finally:
+            # Abandon any still-running threads rather than blocking until they finish.
+            # cancel_futures=True cancels queued-but-not-started futures; already-running
+            # threads are detached (they complete eventually and are GC'd).
+            executor.shutdown(wait=False, cancel_futures=True)
 
         # Sort for deterministic ordering in tests / logs
         votes.sort(key=lambda v: v.provider)

--- a/tests/test_consensus_voter.py
+++ b/tests/test_consensus_voter.py
@@ -645,7 +645,9 @@ class TestConsensusVoterSubmsTimeoutDrain:
             submit_idx = [0]
 
             mock_executor = MagicMock()
-            mock_executor_cls.return_value.__enter__.return_value = mock_executor
+            # ConsensusVoter now uses the executor directly (no `with` block), so
+            # mock_executor_cls() must return the mock executor, not __enter__.
+            mock_executor_cls.return_value = mock_executor
 
             def fake_submit(fn, *args, **kwargs):
                 f = submit_returns[submit_idx[0]]

--- a/tests/test_scheduled_job_runs.py
+++ b/tests/test_scheduled_job_runs.py
@@ -335,8 +335,9 @@ def test_lifespan_calls_expire_stale_scheduled_job_runs_on_startup(monkeypatch, 
     """expire_stale_scheduled_job_runs must be called during lifespan startup (#376)."""
     calls = {"count": 0}
 
-    def fake_expire():
+    def fake_expire(stale_hours=4):
         calls["count"] += 1
+        calls["stale_hours"] = stale_hours
         return 0
 
     monkeypatch.setattr("src.db.scheduled_job_runs.expire_stale_scheduled_job_runs", fake_expire)
@@ -366,3 +367,7 @@ def test_lifespan_calls_expire_stale_scheduled_job_runs_on_startup(monkeypatch, 
         pool.submit(_thread_body).result(timeout=15)
 
     assert calls["count"] == 1, "expire_stale_scheduled_job_runs must be called once at startup"
+    assert calls.get("stale_hours") == 0, (
+        "startup sweep must use stale_hours=0 to expire ALL running records, "
+        "not just those older than N hours — any in-flight job died with the previous process"
+    )


### PR DESCRIPTION
## Summary

Addresses four bugs that together caused the 2026-04-10 OOM crash and the downstream job failures on 2026-04-11.

- **#464** `runner.py`: clear `all_office_data` after bio_cache build + gc.collect every 25 offices — frees 5–30 MB before the HTTP bio-fetch phase; ensures BS4 cyclic refs are collected even when many offices share the same source URL
- **#465** `runner.py`: skip `RunPageCache` when `TABLE_HTML_CACHE_ENABLED=0` — the env var already bypassed it for table fetches but bio extraction was still accumulating up to 100 page HTML strings with no dedup benefit
- **#466** `main.py`: use `stale_hours=0` in startup cleanup — the old `stale_hours=4` left a record created 1 minute before an OOM kill alive for 4 hours, blocking `insufficient_vitals`, `gemini_research`, and `daily_page_quality` all morning
- **#467** `consensus_voter.py`: replace `with ThreadPoolExecutor` with explicit `shutdown(wait=False, cancel_futures=True)` — the `with` block's `shutdown(wait=True)` blocked until all provider threads finished, meaning a 60 s Gemini response held up the process for 60 s even after being logged as a 30 s timeout

## Test plan

- [x] `python -m pytest` — 116 passed, 0 failed
- [ ] After deploy: confirm next 06:00 UTC daily_delta completes without OOM
- [ ] After deploy: confirm 07:00 `insufficient_vitals` runs normally (not skipped)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)