### PR TITLE
feat: layout shell — sidebar, top bar, dark mode, landmarks (#447)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -257,8 +257,11 @@ async def add_security_headers(request: Request, call_next):
     response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
     response.headers.setdefault(
         "Content-Security-Policy",
-        "default-src 'self'; script-src 'self' 'unsafe-inline'; "
-        "style-src 'self' 'unsafe-inline'; img-src 'self' data:",
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "img-src 'self' data: https://*.googleusercontent.com;",
     )
     response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
     if request.url.scheme == "https":
@@ -326,6 +329,8 @@ async def auth_google_callback(request: Request):
             status_code=403,
         )
     request.session["user_email"] = email
+    request.session["user_name"] = user_info.get("name", "")
+    request.session["user_picture"] = user_info.get("picture", "")
     return RedirectResponse("/")
 
 

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -427,3 +427,231 @@ html.dark .sync-banner { background: #451a03; }
   margin-left: 0.75rem;
   color: var(--color-on-surface-variant);
 }
+
+/* =========================================================
+   20. Layout Shell  (Issue #447)
+   Top app bar + fixed sidebar + main content offset.
+   ========================================================= */
+
+/* ---------------------------------------------------------
+   20a. Top app bar
+   --------------------------------------------------------- */
+.top-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4rem;
+  z-index: 30;
+  background: var(--color-surface-bright);
+  border-bottom: 1px solid var(--color-outline-variant);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0 1rem;
+}
+
+.top-bar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  text-decoration: none;
+}
+.top-bar-logo img { border-radius: var(--radius-sm); }
+.top-bar-wordmark {
+  font-size: 1rem;
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  color: var(--color-primary);
+  line-height: 1;
+}
+
+.top-bar-search {
+  flex: 1;
+  max-width: 28rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.top-bar-search .material-symbols-outlined {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--color-on-surface-variant);
+  font-size: 1.1rem;
+  pointer-events: none;
+}
+.top-bar-search input[type="search"] {
+  width: 100%;
+  background: var(--color-surface-container-low);
+  border: 1px solid var(--color-outline-variant);
+  border-radius: var(--radius-full);
+  padding: 0.375rem 1rem 0.375rem 2.25rem;
+  font-size: 0.875rem;
+  color: var(--color-on-surface);
+}
+.top-bar-search input[type="search"]:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 0;
+  border-color: var(--color-primary);
+}
+
+.top-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-inline-start: auto;
+}
+
+.user-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--color-outline-variant);
+  flex-shrink: 0;
+}
+
+/* ---------------------------------------------------------
+   20b. Sidebar
+   --------------------------------------------------------- */
+.sidebar {
+  position: fixed;
+  top: 4rem;
+  left: 0;
+  width: 16rem;
+  height: calc(100vh - 4rem);
+  background: var(--color-surface-container-low);
+  border-inline-end: 1px solid var(--color-outline-variant);
+  display: flex;
+  flex-direction: column;
+  z-index: 20;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1rem 1rem 0.75rem;
+  border-bottom: 1px solid var(--color-outline-variant);
+  flex-shrink: 0;
+}
+.sidebar-logo img { border-radius: var(--radius-sm); flex-shrink: 0; }
+.sidebar-wordmark {
+  font-size: 0.875rem;
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  color: var(--color-primary);
+  line-height: 1;
+}
+.sidebar-tagline {
+  font-size: 0.5rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-on-surface-variant);
+  margin-top: 0.125rem;
+}
+
+.sidebar-nav {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  flex: 1;
+}
+.sidebar-nav li { margin: 0; }
+
+.sidebar-nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  color: var(--color-on-surface);
+  border-inline-start: 4px solid transparent;
+  text-decoration: none;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.1s;
+}
+.sidebar-nav-link:hover {
+  background: var(--color-surface-container-high);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+.sidebar-nav-link[aria-current="page"] {
+  border-inline-start-color: var(--color-primary);
+  color: var(--color-primary);
+  font-weight: 700;
+  background: var(--color-surface-container);
+}
+.sidebar-nav-link .material-symbols-outlined {
+  font-size: 1.1rem;
+  color: var(--color-on-surface-variant);
+  flex-shrink: 0;
+}
+.sidebar-nav-link[aria-current="page"] .material-symbols-outlined,
+.sidebar-nav-link:hover .material-symbols-outlined {
+  color: var(--color-primary);
+}
+
+.sidebar-footer {
+  padding: 0.75rem 1rem 1rem;
+  border-top: 1px solid var(--color-outline-variant);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+.sidebar-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.625rem 1rem;
+  background: var(--color-primary-container);
+  color: var(--color-on-primary);
+  border-radius: var(--radius-md);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-decoration: none;
+  margin-bottom: 0.25rem;
+}
+.sidebar-cta:hover { opacity: 0.9; color: var(--color-on-primary); text-decoration: none; }
+
+.sidebar-footer-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.25rem;
+  color: var(--color-on-surface-variant);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+}
+.sidebar-footer-link:hover { color: var(--color-primary); text-decoration: none; }
+.sidebar-footer-link .material-symbols-outlined { font-size: 1rem; }
+
+/* ---------------------------------------------------------
+   20c. Main content area
+   --------------------------------------------------------- */
+.main-content {
+  margin-inline-start: 16rem; /* sidebar width — logical property for RTL */
+  margin-top: 4rem;           /* clear fixed top bar */
+  padding: 1.5rem 2rem 6rem;
+  min-height: calc(100vh - 4rem);
+}
+
+/* Dark mode sidebar / top bar overrides */
+html.dark .top-bar,
+html.dark .sidebar {
+  background: var(--color-surface-container-low);
+  border-color: var(--color-outline-variant);
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="/static/css/theme.css">
   <!-- Dark mode pre-paint: read preference before first paint to avoid flash -->
   <script>
-    (function() {
+    (function () {
       try {
         if (localStorage.getItem('rulersai_theme') === 'dark') {
           document.documentElement.classList.add('dark');
@@ -30,110 +30,272 @@
   <script>
   // ---------------------------------------------------------------------------
   // Audio mute — WCAG 1.4.2 Audio Control
-  // Job completion sound plays 5 tones over ~4.5 s (exceeds 3-second threshold).
-  // Mute preference persists in localStorage under 'rulersai_sound_muted'.
   // ---------------------------------------------------------------------------
-  (function() {
-    try {
-      window._soundMuted = localStorage.getItem('rulersai_sound_muted') === 'true';
-    } catch (e) {
-      window._soundMuted = false;
-    }
+  (function () {
+    try { window._soundMuted = localStorage.getItem('rulersai_sound_muted') === 'true'; }
+    catch (e) { window._soundMuted = false; }
   })();
 
-  window.playJobCompleteSound = function() {
-    if (window._soundMuted) return; // respect mute preference (WCAG 1.4.2)
+  window.playJobCompleteSound = function () {
+    if (window._soundMuted) return;
     try {
       var C = window.AudioContext || window.webkitAudioContext;
       if (!C) return;
       var ctx = new C();
-      var t0 = ctx.currentTime;
-      var interval = 1;
+      var t0 = ctx.currentTime, interval = 1;
       for (var i = 0; i < 5; i++) {
-        var osc = ctx.createOscillator();
-        var gain = ctx.createGain();
-        osc.connect(gain);
-        gain.connect(ctx.destination);
-        osc.frequency.value = 800;
-        osc.type = 'sine';
+        var osc = ctx.createOscillator(), gain = ctx.createGain();
+        osc.connect(gain); gain.connect(ctx.destination);
+        osc.frequency.value = 800; osc.type = 'sine';
         gain.gain.setValueAtTime(0.2, t0 + i * interval);
         gain.gain.exponentialRampToValueAtTime(0.01, t0 + i * interval + 0.5);
-        osc.start(t0 + i * interval);
-        osc.stop(t0 + i * interval + 0.5);
+        osc.start(t0 + i * interval); osc.stop(t0 + i * interval + 0.5);
       }
     } catch (e) {}
   };
 
-  window._toggleSound = function() {
+  window._toggleSound = function () {
     window._soundMuted = !window._soundMuted;
     try { localStorage.setItem('rulersai_sound_muted', window._soundMuted); } catch (e) {}
     var btn = document.getElementById('muteBtn');
     if (!btn) return;
-    if (window._soundMuted) {
-      btn.setAttribute('aria-pressed', 'true');
-      btn.setAttribute('aria-label', 'Unmute completion sound');
-      var icon = btn.querySelector('.material-symbols-outlined');
-      if (icon) icon.textContent = 'volume_off';
-    } else {
-      btn.setAttribute('aria-pressed', 'false');
-      btn.setAttribute('aria-label', 'Mute completion sound');
-      var icon = btn.querySelector('.material-symbols-outlined');
-      if (icon) icon.textContent = 'volume_up';
-    }
+    var muted = window._soundMuted;
+    btn.setAttribute('aria-pressed', muted ? 'true' : 'false');
+    btn.setAttribute('aria-label', muted ? 'Unmute completion sound' : 'Mute completion sound');
+    var icon = btn.querySelector('.material-symbols-outlined');
+    if (icon) icon.textContent = muted ? 'volume_off' : 'volume_up';
+  };
+
+  // ---------------------------------------------------------------------------
+  // Dark mode toggle
+  // ---------------------------------------------------------------------------
+  window._darkMode = document.documentElement.classList.contains('dark');
+
+  window._toggleDarkMode = function () {
+    window._darkMode = !window._darkMode;
+    document.documentElement.classList.toggle('dark', window._darkMode);
+    try { localStorage.setItem('rulersai_theme', window._darkMode ? 'dark' : 'light'); } catch (e) {}
+    var btn = document.getElementById('darkModeBtn');
+    if (!btn) return;
+    var dark = window._darkMode;
+    btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+    btn.setAttribute('aria-label', dark ? 'Switch to light mode' : 'Switch to dark mode');
+    var icon = btn.querySelector('.material-symbols-outlined');
+    if (icon) icon.textContent = dark ? 'light_mode' : 'dark_mode';
   };
 
   // ---------------------------------------------------------------------------
   // window.announce() — aria-live helper (WCAG 4.1.3 Status Messages)
-  // All JS status updates must use this function; never update arbitrary divs.
-  // See docs/conventions.md § Accessibility — JS Contracts.
+  // All JS status updates must use this. See docs/conventions.md.
   // ---------------------------------------------------------------------------
-  window.announce = function(message, priority) {
+  window.announce = function (message, priority) {
     var id = (priority === 'assertive') ? 'live-assertive' : 'live-polite';
     var region = document.getElementById(id);
     if (!region) return;
-    // Clear first so the same string re-triggers announcement in screen readers.
     region.textContent = '';
-    setTimeout(function() { region.textContent = message; }, 50);
+    setTimeout(function () { region.textContent = message; }, 50);
   };
 
-  // Apply mute button state once DOM is ready
-  document.addEventListener('DOMContentLoaded', function() {
-    var btn = document.getElementById('muteBtn');
-    if (btn && window._soundMuted) {
-      btn.setAttribute('aria-pressed', 'true');
-      btn.setAttribute('aria-label', 'Unmute completion sound');
-      var icon = btn.querySelector('.material-symbols-outlined');
+  document.addEventListener('DOMContentLoaded', function () {
+    // Sync mute button to persisted state
+    var muteBtn = document.getElementById('muteBtn');
+    if (muteBtn && window._soundMuted) {
+      muteBtn.setAttribute('aria-pressed', 'true');
+      muteBtn.setAttribute('aria-label', 'Unmute completion sound');
+      var icon = muteBtn.querySelector('.material-symbols-outlined');
       if (icon) icon.textContent = 'volume_off';
+    }
+    // Sync dark mode button to persisted state
+    var darkBtn = document.getElementById('darkModeBtn');
+    if (darkBtn && window._darkMode) {
+      darkBtn.setAttribute('aria-pressed', 'true');
+      darkBtn.setAttribute('aria-label', 'Switch to light mode');
+      var icon = darkBtn.querySelector('.material-symbols-outlined');
+      if (icon) icon.textContent = 'light_mode';
     }
   });
   </script>
 
-  <nav aria-label="Primary navigation">
-    <ul>
-      <li><a href="/offices">Offices</a></li>
-      <li><a href="/reports">Reports</a></li>
-      <li><a href="/operations">Operations</a></li>
-      <li><a href="/refs">Reference data</a></li>
+  <!-- =====================================================================
+       Top App Bar  (role=banner, sticky, h-16)
+       ===================================================================== -->
+  <header role="banner" class="top-bar">
+    <!-- Logo -->
+    <a href="/" class="top-bar-logo" aria-label="RulersAI home">
+      <img src="/static/images/rulersai-icon.png" alt="" width="28" height="28" aria-hidden="true">
+      <span class="top-bar-wordmark">RulersAI</span>
+    </a>
+
+    <!-- Global search -->
+    <div role="search" class="top-bar-search">
+      <span class="material-symbols-outlined" aria-hidden="true">search</span>
+      <input type="search"
+             autocomplete="off"
+             aria-label="Search offices, individuals, or research"
+             placeholder="Search…">
+    </div>
+
+    <!-- Icon actions -->
+    <div class="top-bar-actions">
+      <!-- Sound mute toggle (WCAG 1.4.2) -->
+      <button id="muteBtn"
+              type="button"
+              class="btn-icon"
+              onclick="window._toggleSound()"
+              aria-label="Mute completion sound"
+              aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">volume_up</span>
+      </button>
+
+      <!-- Dark mode toggle -->
+      <button id="darkModeBtn"
+              type="button"
+              class="btn-icon"
+              onclick="window._toggleDarkMode()"
+              aria-label="Switch to dark mode"
+              aria-pressed="false">
+        <span class="material-symbols-outlined" aria-hidden="true">dark_mode</span>
+      </button>
+
+      <!-- User avatar — use scope dict directly so tests without SessionMiddleware don't error -->
+      {% set _session = request.scope.get('session', {}) %}
+      {% set _pic = _session.get('user_picture', '') %}
+      {% set _name = _session.get('user_name', '') %}
+      <img src="{{ _pic or '/static/images/rulersai-icon.png' }}"
+           alt="{{ _name or 'User' }}"
+           class="user-avatar"
+           width="32"
+           height="32">
+    </div>
+  </header>
+
+  <!-- =====================================================================
+       Sidebar  (fixed, w-64, below top bar)
+       ===================================================================== -->
+  {% set _path = request.url.path %}
+  <nav aria-label="Primary navigation" class="sidebar">
+
+    <!-- Logo area -->
+    <div class="sidebar-logo" aria-hidden="true">
+      <img src="/static/images/rulersai-icon.png" alt="" width="28" height="28">
+      <div>
+        <div class="sidebar-wordmark">RulersAI</div>
+        <div class="sidebar-tagline">Institutional Intelligence</div>
+      </div>
+    </div>
+
+    <!-- Nav items -->
+    <ul class="sidebar-nav" role="list">
+      <li>
+        <a href="/operations"
+           class="sidebar-nav-link"
+           {% if _path == '/operations' or _path == '/' %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">dashboard</span>
+          Dashboard
+        </a>
+      </li>
+      <li>
+        <a href="/offices"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/offices') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">domain</span>
+          Offices
+        </a>
+      </li>
+      <li>
+        <a href="/run"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/run') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">terminal</span>
+          Command Center
+        </a>
+      </li>
+      <li>
+        <a href="/data/individuals"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/data/individuals') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">groups</span>
+          Data
+        </a>
+      </li>
+      <li>
+        <a href="/data/wiki-drafts"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/data/wiki-drafts') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">description</span>
+          Wiki Drafts
+        </a>
+      </li>
+      <li>
+        <a href="/gemini-research"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/gemini-research') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">person_search</span>
+          Deep Research
+        </a>
+      </li>
+      <li>
+        <a href="/ai-offices"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/ai-offices') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">auto_awesome</span>
+          AI Creation
+        </a>
+      </li>
+      <li>
+        <a href="/refs"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/refs') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">database</span>
+          Reference Data
+        </a>
+      </li>
+      <li>
+        <a href="/reports"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/reports') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">analytics</span>
+          Reports
+        </a>
+      </li>
+      <li>
+        <a href="/data/scheduled-jobs"
+           class="sidebar-nav-link"
+           {% if _path.startswith('/data/scheduled') %}aria-current="page"{% endif %}>
+          <span class="material-symbols-outlined" aria-hidden="true">settings</span>
+          System
+        </a>
+      </li>
     </ul>
-    <!-- Audio mute toggle — positioned in top bar in #447 (Layout Shell) -->
-    <button id="muteBtn"
-            type="button"
-            class="btn-icon"
-            onclick="window._toggleSound()"
-            aria-label="Mute completion sound"
-            aria-pressed="false">
-      <span class="material-symbols-outlined" aria-hidden="true">volume_up</span>
-    </button>
+
+    <!-- Footer: CTA + Support + Logout (WCAG 3.2.6 — consistent position) -->
+    <div class="sidebar-footer">
+      <a href="/offices/new" class="sidebar-cta">New Office</a>
+      <a href="https://github.com/wcmchenry3-stack/office_holder_cursor/issues"
+         class="sidebar-footer-link"
+         target="_blank"
+         rel="noopener noreferrer">
+        <span class="material-symbols-outlined" aria-hidden="true">help</span>
+        Support
+      </a>
+      <a href="/logout" class="sidebar-footer-link">
+        <span class="material-symbols-outlined" aria-hidden="true">logout</span>
+        Logout
+      </a>
+    </div>
   </nav>
 
-  <main id="main-content" class="container{% block container_class %}{% endblock %}">
+  <!-- =====================================================================
+       Main content
+       ===================================================================== -->
+  {# container_class block kept for backward compat — no longer applied to main #}
+  {% block container_class %}{% endblock %}
+  <main id="main-content" class="main-content">
     {% block content %}{% endblock %}
-    <p class="storage-note"><small>All data (offices, parties, individuals, office terms) is saved locally in <code>data/office_holder.db</code> and persists after you close the browser or restart the app.</small></p>
   </main>
 
   <!-- aria-live regions — screen reader announcement endpoints (WCAG 4.1.3) -->
-  <!-- Write to these via window.announce(); never update arbitrary divs directly. -->
-  <div id="live-polite"    aria-live="polite"    aria-atomic="true" class="sr-only"></div>
-  <div id="live-assertive" aria-live="assertive"  aria-atomic="true" class="sr-only"></div>
+  <div id="live-polite"    aria-live="polite"   aria-atomic="true" class="sr-only"></div>
+  <div id="live-assertive" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 </body>
 </html>

--- a/tests/test_axe_a11y.py
+++ b/tests/test_axe_a11y.py
@@ -32,7 +32,9 @@ def playwright_instance():
 @pytest.fixture()
 def page(playwright_instance):
     browser = playwright_instance.chromium.launch()
-    ctx = browser.new_context()
+    # bypass_csp=True lets axe-core load from the CDN without being blocked by
+    # the app's Content-Security-Policy (acceptable for test contexts only).
+    ctx = browser.new_context(bypass_csp=True)
     page = ctx.new_page()
     yield page
     browser.close()


### PR DESCRIPTION
## Summary

Implements the full RulersAI layout shell — top app bar, fixed sidebar, and main content area. Every page now inherits this structure. Unblocks all page redesign stories (#448–#457).

## What changed

| File | Change |
|---|---|
| `src/templates/base.html` | Full layout shell rewrite — top bar, sidebar, dark mode toggle, user avatar, aria landmarks |
| `src/static/css/theme.css` | §20 layout shell CSS — `.top-bar`, `.sidebar`, `.sidebar-nav-link`, `.main-content`, `.user-avatar` |
| `src/main.py` | CSP updated for Google Fonts + profile pictures; `user_name` + `user_picture` saved to session |
| `tests/test_axe_a11y.py` | `bypass_csp=True` so axe-core CDN isn't blocked by the app's CSP |

## Deliverables

### Top App Bar (`role="banner"`, sticky, h-16)
- Logo (icon + wordmark), links to `/`
- Global search input (`role="search"`, `aria-label`, `autocomplete="off"`)
- Sound mute toggle — moved from nav placeholder to top bar (functional from #446)
- Dark mode toggle — `aria-pressed` + dynamic `aria-label`, persists to `localStorage`
- User avatar — 32px circle, falls back to RulersAI icon when no OAuth picture

### Fixed Sidebar (`aria-label="Primary navigation"`, w-64)
- Logo area + "Institutional Intelligence" tagline
- 10 nav items with Material Symbols icons (Dashboard → System)
- `aria-current="page"` via `request.url.path`, `border-inline-start` active indicator (RTL-safe logical property)
- "New Office" CTA button at bottom
- Support + Logout footer — same position on every page (WCAG 3.2.6)

### Main Content
- `margin-inline-start: 16rem` + `margin-top: 4rem` — clears sidebar and top bar; RTL-safe
- Storage-note `<p>` removed from base template per spec

### Bug fixes bundled in this PR
- **CSP** — `fonts.googleapis.com` was blocked by `style-src 'self' 'unsafe-inline'`; Google Fonts and profile pictures now explicitly allowed
- **Session in tests** — `request.session` throws when `SessionMiddleware` absent (test apps); switched to `request.scope.get('session', {})` — fixes 3 `test_ai_decisions` failures that would have appeared in CI

## Test plan
- [x] `python -m pytest` — 1699 passed, 0 failed
- [ ] Visual: all pages render with sidebar + top bar, no clipped content
- [ ] Nav: active item highlighted on each route (`aria-current="page"` present)
- [ ] Dark mode: toggle switches theme, no flash on reload, tokens apply correctly
- [ ] User avatar: renders Google picture after OAuth; falls back to icon when auth bypassed locally
- [ ] Keyboard: skip link → `#main-content`; sidebar reachable via shift-tab
- [ ] 1280px / 1440px / 1920px: sidebar + content layout intact

🤖 Generated with [Claude Code](https://claude.ai/claude-code)