### PR TITLE
feat: login page redesign (RulersAI brand) (#448)

### DIFF
--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -3,66 +3,251 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Sign in — Office Holder</title>
+  <title>Sign in — RulersAI</title>
+  <link rel="icon" type="image/png" href="/static/images/rulersai-icon.png">
+  <link rel="apple-touch-icon" href="/static/images/rulersai-icon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/theme.css">
+  <!-- Dark mode pre-paint: read preference before first paint to avoid flash -->
+  <script>
+    (function () {
+      try {
+        if (localStorage.getItem('rulersai_theme') === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
   <style>
-    .login-wrap {
+    /* Login page — standalone, no sidebar or top bar */
+    html, body {
+      height: 100%;
+    }
+
+    .login-page {
+      min-height: 100vh;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      min-height: 60vh;
-      gap: 1.5rem;
+      padding: 2rem 1rem;
+      background: var(--color-background);
+      position: relative;
+      overflow: hidden;
     }
-    .login-card {
-      padding: 2.5rem 3rem;
-      border: 1px solid var(--border, #444);
-      border-radius: 8px;
-      text-align: center;
-      max-width: 360px;
-      width: 100%;
+
+    /* Decorative radial blur blobs — aria-hidden, purely visual */
+    .blob {
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(120px);
+      opacity: 0.35;
+      pointer-events: none;
     }
-    .login-card h1 {
-      margin: 0 0 0.5rem;
-      font-size: 1.4rem;
+    .blob-1 {
+      width: 400px;
+      height: 400px;
+      background: var(--color-primary-fixed);
+      top: -80px;
+      left: -80px;
     }
-    .login-card p {
-      margin: 0 0 1.5rem;
-      opacity: 0.7;
-      font-size: 0.9rem;
+    .blob-2 {
+      width: 350px;
+      height: 350px;
+      background: var(--color-secondary-container);
+      bottom: -60px;
+      right: -60px;
     }
-    .btn-google {
-      display: inline-flex;
+
+    /* Center column */
+    .login-wrap {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
       align-items: center;
-      gap: 0.6rem;
-      padding: 0.6rem 1.4rem;
-      font-size: 1rem;
-      border-radius: 4px;
-      text-decoration: none;
-      background: #4285f4;
-      color: #fff;
-      font-weight: 500;
+      gap: 1.25rem;
+      width: 100%;
+      max-width: 360px;
     }
-    .btn-google:hover { background: #3367d6; }
+
+    /* Logo */
+    .login-logo {
+      width: 72px;
+      height: 72px;
+      border-radius: var(--radius-lg);
+    }
+
+    /* Wordmark */
+    .login-wordmark {
+      text-align: center;
+      margin: 0;
+    }
+    .login-title {
+      display: block;
+      font-size: 2rem;
+      font-weight: 900;
+      letter-spacing: -0.04em;
+      color: var(--color-primary);
+      line-height: 1;
+    }
+    .login-tagline {
+      display: block;
+      font-size: 0.625rem;
+      font-weight: 700;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: var(--color-on-surface-variant);
+      margin-top: 0.375rem;
+    }
+
+    /* Card */
+    .login-card {
+      width: 100%;
+      background: var(--color-surface-container-lowest);
+      border: 1px solid var(--color-outline-variant);
+      border-radius: var(--radius-lg);
+      box-shadow: 0 12px 32px rgba(24, 28, 30, 0.08);
+      padding: 2rem;
+      position: relative;
+    }
+    html.dark .login-card {
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+    }
+
+    /* Google sign-in button */
+    .btn-google {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      width: 100%;
+      padding: 0.75rem 1.25rem;
+      background: var(--color-surface-container-low);
+      border: 1px solid var(--color-outline);
+      border-radius: var(--radius-md);
+      color: var(--color-on-surface);
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+    .btn-google:hover {
+      background: var(--color-surface-container);
+      text-decoration: none;
+      color: var(--color-on-surface);
+    }
+    .btn-google:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+
+    /* Divider */
+    .login-divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 1.25rem 0 0;
+      color: var(--color-on-surface-variant);
+    }
+    .login-divider::before,
+    .login-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--color-outline-variant);
+    }
+    .login-divider-label {
+      font-size: 0.5rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+    /* Version badge */
+    .version-badge {
+      position: absolute;
+      bottom: 0.75rem;
+      right: 0.75rem;
+      font-size: 0.5rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--color-on-surface-variant);
+      opacity: 0.6;
+    }
+
+    /* Footer */
+    .login-footer {
+      display: flex;
+      gap: 1.25rem;
+      margin-top: 0.5rem;
+    }
+    .login-footer a {
+      font-size: 0.625rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--color-on-surface-variant);
+      text-decoration: none;
+    }
+    .login-footer a:hover {
+      color: var(--color-primary);
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
-  <main class="container">
+  <!-- Skip link (WCAG 2.4.1) -->
+  <a href="#login-card" class="skip-link">Skip to sign-in</a>
+
+  <div class="login-page">
+    <!-- Decorative background blobs — purely visual, hidden from AT -->
+    <div class="blob blob-1" aria-hidden="true"></div>
+    <div class="blob blob-2" aria-hidden="true"></div>
+
     <div class="login-wrap">
-      <div class="login-card">
-        <h1>Office Holder</h1>
-        <p>Sign in to continue</p>
-        <a class="btn-google" href="/auth/google">
-          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-            <path fill="#fff" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z"/>
-            <path fill="#fff" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
-            <path fill="#fff" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"/>
-            <path fill="#fff" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
+
+      <!-- Logo -->
+      <img src="/static/images/rulersai-icon.png"
+           alt="RulersAI"
+           class="login-logo">
+
+      <!-- Wordmark — h1 per WCAG 2.4.6 (one h1 per page) -->
+      <h1 class="login-wordmark">
+        <span class="login-title">RulersAI</span>
+        <span class="login-tagline">Institutional Intelligence</span>
+      </h1>
+
+      <!-- Sign-in card -->
+      <div id="login-card" class="login-card">
+        <!-- Google sign-in — first interactive element (WCAG 2.4.3 focus order) -->
+        <a href="/auth/google" class="btn-google">
+          <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+            <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z"/>
+            <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
+            <path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"/>
+            <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"/>
           </svg>
           Sign in with Google
         </a>
+
+        <div class="login-divider" aria-hidden="true">
+          <span class="login-divider-label">Verification Required</span>
+        </div>
+
+        <span class="version-badge" aria-hidden="true">v1</span>
       </div>
+
+      <!-- Footer links -->
+      <footer class="login-footer">
+        <a href="/static/privacy.html">Privacy</a>
+        <a href="/static/terms.html">Terms</a>
+        <a href="/security.txt">Security Disclosure</a>
+      </footer>
+
     </div>
-  </main>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Redesigns `src/templates/login.html` with the RulersAI brand. Standalone page — no sidebar or top bar. Consumes tokens from #445; does not require the layout shell from #447.

## What changed

| File | Change |
|---|---|
| `src/templates/login.html` | Full rewrite — new brand design, dark mode, a11y, Google Fonts |

## Deliverables

- **Full-page centered layout** — no sidebar, no top bar
- **Background blobs** — two radial `filter: blur(120px)` decorative elements using `--color-primary-fixed` and `--color-secondary-container`, `aria-hidden="true"`
- **Logo** — `rulersai-icon.png`, 72px, `alt="RulersAI"`
- **`<h1>` wordmark** — "RulersAI" in `font-weight: 900 / letter-spacing: -0.04em`; "Institutional Intelligence" uppercase tagline
- **Sign-in card** — `--color-surface-container-lowest`, `border-radius: var(--radius-lg)`, soft shadow
  - Google sign-in button — full-width, colored Google SVG icon + "Sign in with Google", `--color-outline` border (WCAG 1.4.11)
  - "Verification Required" divider
  - Version badge (`v1`, bottom-right, `aria-hidden`)
- **`<title>Sign in — RulersAI</title>`**
- **Dark mode** — pre-paint script preserves `html.dark` across page; all colors via token vars
- **Footer** — Privacy, Terms, Security Disclosure links

## A11y

| Criterion | Implementation |
|---|---|
| 2.4.1 Bypass Blocks | Skip link → `#login-card` |
| 2.4.2 Page Titled | `<title>Sign in — RulersAI</title>` |
| 2.4.3 Focus Order | Google button is first interactive element |
| 2.4.6 Headings | `<h1>` on wordmark |
| 1.4.11 Non-text Contrast | Google button border uses `--color-outline` (#74777d) |

## Test plan
- [x] `python -m pytest` — 1699 passed, 0 failed
- [ ] Visual: light mode — card centered, blobs visible, logo + wordmark above card
- [ ] Visual: dark mode — toggle `html.dark` in DevTools, card readable, no harsh contrasts
- [ ] Google sign-in button triggers OAuth redirect to `/auth/google`
- [ ] Skip link: first Tab from page load lands on skip link; Enter scrolls to sign-in card
- [ ] `<title>` is "Sign in — RulersAI"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)