### PR TITLE
feat: bulk brand pass — Operations, Reports, Reference Data (#457)

### DIFF
--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -655,3 +655,88 @@ html.dark .sidebar {
   background: var(--color-surface-container-low);
   border-color: var(--color-outline-variant);
 }
+
+/* ---------------------------------------------------------
+   21. Page header (icon + title + desc)
+   --------------------------------------------------------- */
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.page-header-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-md);
+  background: var(--color-primary-container);
+  color: var(--color-on-primary-container);
+  flex-shrink: 0;
+}
+.page-header-icon .material-symbols-outlined { font-size: 1.25rem; }
+.page-header-title {
+  font-size: 1.375rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-on-surface);
+  margin: 0;
+  line-height: 1.2;
+}
+.page-header-desc {
+  font-size: 0.8125rem;
+  color: var(--color-on-surface-variant);
+  margin: 0.125rem 0 0;
+}
+
+/* ---------------------------------------------------------
+   22. Nav card grid (hub pages)
+   --------------------------------------------------------- */
+.nav-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+.nav-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  padding: 1rem 1.125rem;
+  background: var(--color-surface-container-lowest);
+  border: 1px solid var(--color-outline-variant);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  color: var(--color-on-surface);
+  transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+}
+.nav-card:hover {
+  background: var(--color-surface-container-low);
+  border-color: var(--color-outline);
+  box-shadow: 0 2px 8px rgba(24, 28, 30, 0.06);
+  text-decoration: none;
+  color: var(--color-on-surface);
+}
+.nav-card:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+.nav-card-icon {
+  font-size: 1.5rem;
+  color: var(--color-primary);
+  flex-shrink: 0;
+  margin-top: 0.0625rem;
+}
+.nav-card-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-on-surface);
+  line-height: 1.3;
+}
+.nav-card-desc {
+  font-size: 0.75rem;
+  color: var(--color-on-surface-variant);
+  margin-top: 0.125rem;
+  line-height: 1.4;
+}

--- a/src/templates/operations.html
+++ b/src/templates/operations.html
@@ -1,13 +1,51 @@
 {% extends "base.html" %}
-{% block title %}Operations – Office Holder{% endblock %}
+{% block title %}Operations — RulersAI{% endblock %}
 {% block content %}
-<h1>Operations</h1>
-<p>Monitoring, job management, and reporting.</p>
-<ul>
-  <li><a href="/data/ai-decisions">AI Decisions</a> — Review AI-generated office configuration decisions</li>
-  <li><a href="/data/scheduled-job-runs">Job Runs</a> — History of scheduled job executions</li>
-  <li><a href="/data/scraper-jobs">Scraper Jobs</a> — Active and recent scraper job queue</li>
-  <li><a href="/data/scheduled-jobs">Scheduled Jobs</a> — Configure and pause/resume scheduled jobs</li>
-  <li><a href="/data/runner-registry">Runner Registry</a> — Available scraper runner configurations</li>
-</ul>
+<div class="page-header">
+  <div class="page-header-icon">
+    <span class="material-symbols-outlined" aria-hidden="true">dashboard</span>
+  </div>
+  <div>
+    <h1 class="page-header-title">Operations</h1>
+    <p class="page-header-desc">Monitoring, job management, and reporting.</p>
+  </div>
+</div>
+
+<div class="nav-card-grid">
+  <a href="/data/ai-decisions" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">auto_awesome</span>
+    <div>
+      <div class="nav-card-title">AI Decisions</div>
+      <div class="nav-card-desc">Review AI-generated office configuration decisions</div>
+    </div>
+  </a>
+  <a href="/data/scheduled-job-runs" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">history</span>
+    <div>
+      <div class="nav-card-title">Job Runs</div>
+      <div class="nav-card-desc">History of scheduled job executions</div>
+    </div>
+  </a>
+  <a href="/data/scraper-jobs" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">queue</span>
+    <div>
+      <div class="nav-card-title">Scraper Jobs</div>
+      <div class="nav-card-desc">Active and recent scraper job queue</div>
+    </div>
+  </a>
+  <a href="/data/scheduled-jobs" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">schedule</span>
+    <div>
+      <div class="nav-card-title">Scheduled Jobs</div>
+      <div class="nav-card-desc">Configure and pause/resume scheduled jobs</div>
+    </div>
+  </a>
+  <a href="/data/runner-registry" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">settings</span>
+    <div>
+      <div class="nav-card-title">Runner Registry</div>
+      <div class="nav-card-desc">Available scraper runner configurations</div>
+    </div>
+  </a>
+</div>
 {% endblock %}

--- a/src/templates/refs.html
+++ b/src/templates/refs.html
@@ -1,16 +1,72 @@
 {% extends "base.html" %}
-{% block title %}Reference data – Office Holder{% endblock %}
+{% block title %}Reference Data — RulersAI{% endblock %}
 {% block content %}
-<h1>Reference data</h1>
-<p>Manage countries, states/provinces, levels, and branches used by offices and pages.</p>
-<ul>
-  <li><a href="/refs/countries">Countries</a></li>
-  <li><a href="/refs/states">States (by country)</a></li>
-  <li><a href="/refs/levels">Levels</a></li>
-  <li><a href="/refs/branches">Branches</a></li>
-  <li><a href="/refs/cities">Cities</a></li>
-  <li><a href="/refs/office-categories">Office categories</a></li>
-  <li><a href="/refs/infobox-role-key-filters">Infobox role key filters</a></li>
-  <li><a href="/refs/parties">Parties</a></li>
-</ul>
+<div class="page-header">
+  <div class="page-header-icon">
+    <span class="material-symbols-outlined" aria-hidden="true">database</span>
+  </div>
+  <div>
+    <h1 class="page-header-title">Reference Data</h1>
+    <p class="page-header-desc">Manage countries, states, levels, branches, and other lookup values.</p>
+  </div>
+</div>
+
+<div class="nav-card-grid">
+  <a href="/refs/countries" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">public</span>
+    <div>
+      <div class="nav-card-title">Countries</div>
+      <div class="nav-card-desc">Country lookup values</div>
+    </div>
+  </a>
+  <a href="/refs/states" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">map</span>
+    <div>
+      <div class="nav-card-title">States</div>
+      <div class="nav-card-desc">States and provinces by country</div>
+    </div>
+  </a>
+  <a href="/refs/levels" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">layers</span>
+    <div>
+      <div class="nav-card-title">Levels</div>
+      <div class="nav-card-desc">Federal, state, local, and other levels</div>
+    </div>
+  </a>
+  <a href="/refs/branches" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">account_balance</span>
+    <div>
+      <div class="nav-card-title">Branches</div>
+      <div class="nav-card-desc">Executive, legislative, judicial branches</div>
+    </div>
+  </a>
+  <a href="/refs/cities" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">location_city</span>
+    <div>
+      <div class="nav-card-title">Cities</div>
+      <div class="nav-card-desc">Cities linked to states</div>
+    </div>
+  </a>
+  <a href="/refs/office-categories" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">category</span>
+    <div>
+      <div class="nav-card-title">Office Categories</div>
+      <div class="nav-card-desc">Office classification categories</div>
+    </div>
+  </a>
+  <a href="/refs/infobox-role-key-filters" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">filter_alt</span>
+    <div>
+      <div class="nav-card-title">Infobox Role Key Filters</div>
+      <div class="nav-card-desc">Filter rules for Wikipedia infobox role keys</div>
+    </div>
+  </a>
+  <a href="/refs/parties" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">groups</span>
+    <div>
+      <div class="nav-card-title">Parties</div>
+      <div class="nav-card-desc">Political party lookup values</div>
+    </div>
+  </a>
+</div>
 {% endblock %}

--- a/src/templates/refs_branch_form.html
+++ b/src/templates/refs_branch_form.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if branch else "New" }} branch – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if branch else "New" }} Branch — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if branch else "New" }} branch</h1>
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
 <form method="post" action="{% if branch %}/refs/branches/{{ branch.id }}{% else %}/refs/branches/new{% endif %}">
   <div class="form-group">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" value="{{ branch.name if branch else '' }}" required placeholder="e.g. Executive, Legislative, Judicial">
+    <input type="text" id="name" name="name" value="{{ branch.name if branch else '' }}" required aria-required="true" placeholder="e.g. Executive, Legislative, Judicial">
   </div>
   <div class="actions">
     <button type="submit" class="btn">Save</button>

--- a/src/templates/refs_branches.html
+++ b/src/templates/refs_branches.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Branches – Office Holder{% endblock %}
+{% block title %}Branches — RulersAI{% endblock %}
 {% block content %}
 <h1>Branches</h1>
 {% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
@@ -9,9 +9,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if branches %}
-<table class="table">
+<table class="table" aria-label="Branches">
   <thead>
-    <tr><th>Name</th><th></th></tr>
+    <tr><th scope="col">Name</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for b in branches %}

--- a/src/templates/refs_cities.html
+++ b/src/templates/refs_cities.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Cities – Office Holder{% endblock %}
+{% block title %}Cities — RulersAI{% endblock %}
 {% block content %}
 <h1>Cities</h1>
 <p>Manage cities; each city is linked to exactly one state (state implies country).</p>
@@ -10,9 +10,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if cities %}
-<table class="table">
+<table class="table" aria-label="Cities">
   <thead>
-    <tr><th>City</th><th>Country</th><th>State</th><th></th></tr>
+    <tr><th scope="col">City</th><th scope="col">Country</th><th scope="col">State</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for c in cities %}

--- a/src/templates/refs_city_form.html
+++ b/src/templates/refs_city_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if city else "New" }} city – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if city else "New" }} City — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if city else "New" }} city</h1>
 <p>Select country, then state, then enter the city name.</p>
@@ -7,7 +7,7 @@
 <form method="post" action="{% if city %}/refs/cities/{{ city.id }}{% else %}/refs/cities/new{% endif %}">
   <div class="form-group">
     <label for="country_id">Country</label>
-    <select id="country_id" name="country_id" required>
+    <select id="country_id" name="country_id" required aria-required="true">
       <option value="">— Select country —</option>
       {% for c in countries %}
       <option value="{{ c.id }}" {% if form_country_id is defined and form_country_id == c.id %}selected{% endif %}>{{ c.name }}</option>
@@ -16,7 +16,7 @@
   </div>
   <div class="form-group">
     <label for="state_id">State / Province / Territory</label>
-    <select id="state_id" name="state_id" required>
+    <select id="state_id" name="state_id" required aria-required="true">
       <option value="">— Select country first —</option>
       {% for s in states %}
       <option value="{{ s.id }}" {% if city and city.state_id == s.id %}selected{% elif form_state_id is defined and form_state_id == s.id %}selected{% endif %}>{{ s.name }}</option>
@@ -25,7 +25,7 @@
   </div>
   <div class="form-group">
     <label for="name">City name</label>
-    <input type="text" id="name" name="name" value="{{ city.name if city else (form_name if form_name is defined else '') }}" required placeholder="City name">
+    <input type="text" id="name" name="name" value="{{ city.name if city else (form_name if form_name is defined else '') }}" required aria-required="true" placeholder="City name">
   </div>
   <div class="actions">
     <button type="submit" class="btn">Save</button>

--- a/src/templates/refs_countries.html
+++ b/src/templates/refs_countries.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Countries – Office Holder{% endblock %}
+{% block title %}Countries — RulersAI{% endblock %}
 {% block content %}
 <h1>Countries</h1>
 {% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
@@ -9,9 +9,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if countries %}
-<table class="table">
+<table class="table" aria-label="Countries">
   <thead>
-    <tr><th>Name</th><th></th></tr>
+    <tr><th scope="col">Name</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for c in countries %}

--- a/src/templates/refs_country_form.html
+++ b/src/templates/refs_country_form.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if country else "New" }} country – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if country else "New" }} Country — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if country else "New" }} country</h1>
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
 <form method="post" action="{% if country %}/refs/countries/{{ country.id }}{% else %}/refs/countries/new{% endif %}">
   <div class="form-group">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" value="{{ country.name if country else '' }}" required placeholder="Country name">
+    <input type="text" id="name" name="name" value="{{ country.name if country else '' }}" required aria-required="true" placeholder="Country name">
   </div>
   <div class="actions">
     <button type="submit" class="btn">Save</button>

--- a/src/templates/refs_infobox_role_key_filter_form.html
+++ b/src/templates/refs_infobox_role_key_filter_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if filter_obj else "New" }} infobox role key filter – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if filter_obj else "New" }} Infobox Role Key Filter — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if filter_obj else "New" }} infobox role key filter</h1>
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
@@ -7,11 +7,11 @@
 <form method="post" action="{% if filter_obj %}/refs/infobox-role-key-filters/{{ filter_obj.id }}{% else %}/refs/infobox-role-key-filters/new{% endif %}">
   <div class="form-group">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" value="{{ filter_obj.name if filter_obj else (form_name if form_name is defined else '') }}" required placeholder="Filter name">
+    <input type="text" id="name" name="name" value="{{ filter_obj.name if filter_obj else (form_name if form_name is defined else '') }}" required aria-required="true" placeholder="Filter name">
   </div>
   <div class="form-group">
     <label for="role_key">Role key</label>
-    <input type="text" id="role_key" name="role_key" value="{{ filter_obj.role_key if filter_obj else (form_role_key if form_role_key is defined else '') }}" required placeholder="Infobox role key">
+    <input type="text" id="role_key" name="role_key" value="{{ filter_obj.role_key if filter_obj else (form_role_key if form_role_key is defined else '') }}" required aria-required="true" placeholder="Infobox role key">
   </div>
   <div class="form-group">
     <label for="country_ids">Countries (optional; leave empty for all)</label>

--- a/src/templates/refs_infobox_role_key_filters.html
+++ b/src/templates/refs_infobox_role_key_filters.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Infobox role key filters – Office Holder{% endblock %}
+{% block title %}Infobox Role Key Filters — RulersAI{% endblock %}
 {% block content %}
 <h1>Infobox role key filters</h1>
 {% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
@@ -9,9 +9,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if filters %}
-<table class="table">
+<table class="table" aria-label="Infobox Role Key Filters">
   <thead>
-    <tr><th>Name</th><th>Role key</th><th></th></tr>
+    <tr><th scope="col">Name</th><th scope="col">Role key</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for f in filters %}

--- a/src/templates/refs_level_form.html
+++ b/src/templates/refs_level_form.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if level else "New" }} level – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if level else "New" }} Level — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if level else "New" }} level</h1>
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
 <form method="post" action="{% if level %}/refs/levels/{{ level.id }}{% else %}/refs/levels/new{% endif %}">
   <div class="form-group">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" value="{{ level.name if level else '' }}" required placeholder="e.g. Federal, State, Local">
+    <input type="text" id="name" name="name" value="{{ level.name if level else '' }}" required aria-required="true" placeholder="e.g. Federal, State, Local">
   </div>
   <div class="actions">
     <button type="submit" class="btn">Save</button>

--- a/src/templates/refs_levels.html
+++ b/src/templates/refs_levels.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Levels – Office Holder{% endblock %}
+{% block title %}Levels — RulersAI{% endblock %}
 {% block content %}
 <h1>Levels</h1>
 {% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
@@ -9,9 +9,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if levels %}
-<table class="table">
+<table class="table" aria-label="Levels">
   <thead>
-    <tr><th>Name</th><th></th></tr>
+    <tr><th scope="col">Name</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for l in levels %}

--- a/src/templates/refs_office_categories.html
+++ b/src/templates/refs_office_categories.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Office categories – Office Holder{% endblock %}
+{% block title %}Office Categories — RulersAI{% endblock %}
 {% block content %}
 <h1>Office categories</h1>
 {% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
@@ -9,9 +9,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if categories %}
-<table class="table">
+<table class="table" aria-label="Office Categories">
   <thead>
-    <tr><th>Name</th><th></th></tr>
+    <tr><th scope="col">Name</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for c in categories %}

--- a/src/templates/refs_office_category_form.html
+++ b/src/templates/refs_office_category_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if category else "New" }} office category – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if category else "New" }} Office Category — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if category else "New" }} office category</h1>
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
@@ -7,7 +7,7 @@
 <form method="post" action="{% if category %}/refs/office-categories/{{ category.id }}{% else %}/refs/office-categories/new{% endif %}">
   <div class="form-group">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" value="{{ category.name if category else (form_name if form_name is defined else '') }}" required placeholder="Category name">
+    <input type="text" id="name" name="name" value="{{ category.name if category else (form_name if form_name is defined else '') }}" required aria-required="true" placeholder="Category name">
   </div>
   <div class="form-group">
     <label for="country_ids">Countries (optional; leave empty for all)</label>

--- a/src/templates/refs_state_form.html
+++ b/src/templates/refs_state_form.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if state else "New" }} state – Office Holder{% endblock %}
+{% block title %}{{ "Edit" if state else "New" }} State — RulersAI{% endblock %}
 {% block content %}
 <h1>{{ "Edit" if state else "New" }} state</h1>
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
 <form method="post" action="{% if state %}/refs/states/{{ state.id }}{% else %}/refs/states/new{% endif %}">
   <div class="form-group">
     <label for="country_id">Country</label>
-    <select id="country_id" name="country_id" required>
+    <select id="country_id" name="country_id" required aria-required="true">
       <option value="">— Select country —</option>
       {% for c in countries %}
       <option value="{{ c.id }}" {% if state and state.country_id == c.id %}selected{% elif form_country_id is defined and form_country_id == c.id %}selected{% endif %}>{{ c.name }}</option>
@@ -15,7 +15,7 @@
   </div>
   <div class="form-group">
     <label for="name">Name</label>
-    <input type="text" id="name" name="name" value="{{ state.name if state else (form_name if form_name is defined else '') }}" required placeholder="State / province name">
+    <input type="text" id="name" name="name" value="{{ state.name if state else (form_name if form_name is defined else '') }}" required aria-required="true" placeholder="State / province name">
   </div>
   <div class="actions">
     <button type="submit" class="btn">Save</button>

--- a/src/templates/refs_states.html
+++ b/src/templates/refs_states.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}States – Office Holder{% endblock %}
+{% block title %}States — RulersAI{% endblock %}
 {% block content %}
 <h1>States (by country)</h1>
 {% if saved %}<div class="alert alert-success">Saved to local database.</div>{% endif %}
@@ -9,9 +9,9 @@
   <a href="/refs" class="btn btn-secondary">Back to Reference data</a>
 </div>
 {% if states %}
-<table class="table">
+<table class="table" aria-label="States">
   <thead>
-    <tr><th>State</th><th>Country</th><th></th></tr>
+    <tr><th scope="col">State</th><th scope="col">Country</th><th scope="col"><span class="sr-only">Actions</span></th></tr>
   </thead>
   <tbody>
     {% for s in states %}

--- a/src/templates/reports.html
+++ b/src/templates/reports.html
@@ -1,11 +1,37 @@
 {% extends "base.html" %}
-{% block title %}Reports – Office Holder{% endblock %}
+{% block title %}Reports — RulersAI{% endblock %}
 {% block content %}
-<h1>Reports</h1>
-<p>Data views and analytical reports.</p>
-<ul>
-  <li><a href="/data/individuals">Individuals</a> — Browse and filter the individuals database</li>
-  <li><a href="/data/office-terms">Office Terms</a> — Browse scraped office term records</li>
-  <li><a href="/report/milestones">Milestone Report</a> — Aggregated progress report across all offices</li>
-</ul>
+<div class="page-header">
+  <div class="page-header-icon">
+    <span class="material-symbols-outlined" aria-hidden="true">bar_chart</span>
+  </div>
+  <div>
+    <h1 class="page-header-title">Reports</h1>
+    <p class="page-header-desc">Data views and analytical reports.</p>
+  </div>
+</div>
+
+<div class="nav-card-grid">
+  <a href="/data/individuals" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">person</span>
+    <div>
+      <div class="nav-card-title">Individuals</div>
+      <div class="nav-card-desc">Browse and filter the individuals database</div>
+    </div>
+  </a>
+  <a href="/data/office-terms" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">assignment</span>
+    <div>
+      <div class="nav-card-title">Office Terms</div>
+      <div class="nav-card-desc">Browse scraped office term records</div>
+    </div>
+  </a>
+  <a href="/report/milestones" class="nav-card">
+    <span class="material-symbols-outlined nav-card-icon" aria-hidden="true">flag</span>
+    <div>
+      <div class="nav-card-title">Milestone Report</div>
+      <div class="nav-card-desc">Aggregated progress report across all offices</div>
+    </div>
+  </a>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Rewrote `operations.html`, `reports.html`, `refs.html` as nav-card hub pages with `page-header` component (icon + title + desc)
- Added `scope="col"` and `aria-label` to all 7 refs list tables for WCAG 2.2 AA compliance
- Added `aria-required="true"` to all required inputs/selects across 7 refs form templates
- Fixed page titles from `– Office Holder` to `— RulersAI` format across all refs templates
- Added §21 `.page-header` and §22 `.nav-card-grid` / `.nav-card` CSS components to `theme.css`

Closes #457. Contributes to WCAG audit (#456).

## Test plan
- [x] All 1699 non-Playwright tests pass locally
- [ ] Verify Operations, Reports, Reference Data hub pages render with nav-card grid
- [ ] Verify dark mode renders correctly on hub pages
- [ ] Verify table `scope="col"` present on all refs list pages
- [ ] Axe-core tests remain xfail-passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)