### PR TITLE
feat: office list brand pass — page-header, table a11y (#449)

### DIFF
--- a/src/templates/offices.html
+++ b/src/templates/offices.html
@@ -1,7 +1,15 @@
 {% extends "base.html" %}
-{% block title %}Offices – Office Holder{% endblock %}
+{% block title %}Offices — RulersAI{% endblock %}
 {% block content %}
-<h1>Office configs</h1>
+<div class="page-header">
+  <div class="page-header-icon">
+    <span class="material-symbols-outlined" aria-hidden="true">corporate_fare</span>
+  </div>
+  <div>
+    <h1 class="page-header-title">Offices</h1>
+    <p class="page-header-desc">Manage office configurations and scraper pages.</p>
+  </div>
+</div>
 {% if saved %}<div class="alert alert-success">Saved to local database (data/office_holder.db).</div>{% endif %}
 {% if validation_error %}<div class="alert alert-error">{{ validation_error }}</div>{% endif %}
 {% if imported %}<div class="alert alert-success">Imported {{ imported_count }} offices to local database (data/office_holder.db).{% if imported_errors %}{{ imported_errors }} row(s) had errors.{% endif %}</div>{% endif %}
@@ -190,18 +198,18 @@
 })();
 </script>
 {% if pages %}
-<table id="pagesTable" class="table">
+<table id="pagesTable" class="table" aria-label="Pages">
   <thead>
     <tr>
-      <th>On</th>
-      <th>Country</th>
-      <th>State</th>
-      <th>Level</th>
-      <th>Branch</th>
-      <th>Office count</th>
-      <th>Table count</th>
-      <th>URL</th>
-      <th></th>
+      <th scope="col">On</th>
+      <th scope="col">Country</th>
+      <th scope="col">State</th>
+      <th scope="col">Level</th>
+      <th scope="col">Branch</th>
+      <th scope="col">Office count</th>
+      <th scope="col">Table count</th>
+      <th scope="col">URL</th>
+      <th scope="col"><span class="sr-only">Actions</span></th>
     </tr>
   </thead>
   <tbody>
@@ -286,19 +294,19 @@
     </select>
   </div>
 </div>
-<table id="officesTable">
+<table id="officesTable" aria-label="Offices" class="table">
   <thead>
     <tr>
-      <th class="sortable" data-sort="enabled" title="Sort by on/off"><span>On</span></th>
-      <th class="sortable" data-sort="name" title="Sort by name"><span>Name</span></th>
-      <th class="sortable" data-sort="country" title="Sort by country"><span>Country</span></th>
-      <th class="sortable" data-sort="state" title="Sort by state"><span>State</span></th>
-      <th class="sortable" data-sort="level" title="Sort by level"><span>Level</span></th>
-      <th class="sortable" data-sort="branch" title="Sort by branch"><span>Branch</span></th>
-      <th class="sortable" data-sort="url" title="Sort by URL"><span>URL</span></th>
-      <th class="sortable" data-sort="table" title="Sort by table number"><span>Table</span></th>
-      <th>Terms</th>
-      <th></th>
+      <th scope="col" class="sortable" data-sort="enabled" title="Sort by on/off"><span>On</span></th>
+      <th scope="col" class="sortable" data-sort="name" title="Sort by name"><span>Name</span></th>
+      <th scope="col" class="sortable" data-sort="country" title="Sort by country"><span>Country</span></th>
+      <th scope="col" class="sortable" data-sort="state" title="Sort by state"><span>State</span></th>
+      <th scope="col" class="sortable" data-sort="level" title="Sort by level"><span>Level</span></th>
+      <th scope="col" class="sortable" data-sort="branch" title="Sort by branch"><span>Branch</span></th>
+      <th scope="col" class="sortable" data-sort="url" title="Sort by URL"><span>URL</span></th>
+      <th scope="col" class="sortable" data-sort="table" title="Sort by table number"><span>Table</span></th>
+      <th scope="col">Terms</th>
+      <th scope="col"><span class="sr-only">Actions</span></th>
     </tr>
   </thead>
   <tbody>

--- a/tests/test_axe_a11y.py
+++ b/tests/test_axe_a11y.py
@@ -5,6 +5,7 @@ Injects axe-core into 7 key pages and asserts zero WCAG violations.
 Marked xfail(strict=False) until all screen stories (#447–#457) ship —
 each story's definition of done includes keeping these tests green.
 Remove the xfail marker for a given test once its screen story is complete.
+Completed: #448 (login), #449 (offices), #457 (operations/reports/refs).
 """
 
 import os
@@ -84,7 +85,6 @@ def test_axe_login(page):
     assert v == [], f"/login WCAG violations:\n{_fmt(v)}"
 
 
-@pytest.mark.xfail(strict=False, reason="WCAG violations expected until screen story #449 ships")
 def test_axe_offices(page):
     v = _run_axe(page, "/offices")
     assert v == [], f"/offices WCAG violations:\n{_fmt(v)}"


### PR DESCRIPTION
## Summary
- Added `page-header` component (icon + title + desc) to `offices.html`
- Added `aria-label` and `scope="col"` to both `pagesTable` and `officesTable`
- Added `<span class="sr-only">Actions</span>` for empty action column headers
- Removed `xfail` from `test_axe_offices` — screen story #449 complete

Closes #449. Contributes to WCAG audit (#456).

## Test plan
- [x] All 1699 non-Playwright tests pass locally
- [ ] Verify `/offices` renders with page-header and correct table markup
- [ ] Verify dark mode, both page_search_view and office list views
- [ ] Axe `test_axe_offices` should now pass (not just xfail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)