### PR TITLE
feat: wiki drafts brand pass — page-header, table a11y, filter nav (#454)

### DIFF
--- a/src/templates/wiki_drafts.html
+++ b/src/templates/wiki_drafts.html
@@ -1,21 +1,36 @@
 {% extends "base.html" %}
-{% block title %}Wiki Draft Proposals – Office Holder{% endblock %}
+{% block title %}Wiki Draft Proposals — RulersAI{% endblock %}
 {% block content %}
-<h1>Wiki Draft Proposals</h1>
-
-<div style="margin-bottom:1em">
-  <strong>Filter:</strong>
-  <a href="/data/wiki-drafts"{% if not status_filter %} style="font-weight:bold"{% endif %}>All</a> |
-  <a href="/data/wiki-drafts?status=pending"{% if status_filter == 'pending' %} style="font-weight:bold"{% endif %}>Pending</a> |
-  <a href="/data/wiki-drafts?status=submitted"{% if status_filter == 'submitted' %} style="font-weight:bold"{% endif %}>Submitted</a> |
-  <a href="/data/wiki-drafts?status=published"{% if status_filter == 'published' %} style="font-weight:bold"{% endif %}>Published</a> |
-  <a href="/data/wiki-drafts?status=rejected"{% if status_filter == 'rejected' %} style="font-weight:bold"{% endif %}>Rejected</a>
+<div class="page-header">
+  <div class="page-header-icon">
+    <span class="material-symbols-outlined" aria-hidden="true">edit_document</span>
+  </div>
+  <div>
+    <h1 class="page-header-title">Wiki Draft Proposals</h1>
+    <p class="page-header-desc">Review and manage Wikipedia draft proposals.</p>
+  </div>
 </div>
 
+<nav aria-label="Filter by status" style="margin-bottom:1rem;">
+  <a href="/data/wiki-drafts"{% if not status_filter %} aria-current="page" style="font-weight:600"{% endif %}>All</a> |
+  <a href="/data/wiki-drafts?status=pending"{% if status_filter == 'pending' %} aria-current="page" style="font-weight:600"{% endif %}>Pending</a> |
+  <a href="/data/wiki-drafts?status=submitted"{% if status_filter == 'submitted' %} aria-current="page" style="font-weight:600"{% endif %}>Submitted</a> |
+  <a href="/data/wiki-drafts?status=published"{% if status_filter == 'published' %} aria-current="page" style="font-weight:600"{% endif %}>Published</a> |
+  <a href="/data/wiki-drafts?status=rejected"{% if status_filter == 'rejected' %} aria-current="page" style="font-weight:600"{% endif %}>Rejected</a>
+</nav>
+
 {% if drafts %}
-<table>
+<table class="table" aria-label="Wiki Draft Proposals">
   <thead>
-    <tr><th>ID</th><th>Individual</th><th>Wiki URL</th><th>Status</th><th>Origin</th><th>Created</th><th></th></tr>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">Individual</th>
+      <th scope="col">Wiki URL</th>
+      <th scope="col">Status</th>
+      <th scope="col">Origin</th>
+      <th scope="col">Created</th>
+      <th scope="col"><span class="sr-only">Actions</span></th>
+    </tr>
   </thead>
   <tbody>
     {% for d in drafts %}

--- a/tests/test_axe_a11y.py
+++ b/tests/test_axe_a11y.py
@@ -5,7 +5,7 @@ Injects axe-core into 7 key pages and asserts zero WCAG violations.
 Marked xfail(strict=False) until all screen stories (#447–#457) ship —
 each story's definition of done includes keeping these tests green.
 Remove the xfail marker for a given test once its screen story is complete.
-Completed: #448 (login), #449 (offices), #451 (offices/new), #453 (run), #457 (operations/reports/refs).
+Completed: #448 (login), #449 (offices), #451 (offices/new), #453 (run), #454 (wiki-drafts), #457 (operations/reports/refs).
 """
 
 import os
@@ -100,7 +100,6 @@ def test_axe_run(page):
     assert v == [], f"/run WCAG violations:\n{_fmt(v)}"
 
 
-@pytest.mark.xfail(strict=False, reason="WCAG violations expected until screen story #454 ships")
 def test_axe_wiki_drafts(page):
     v = _run_axe(page, "/data/wiki-drafts")
     assert v == [], f"/data/wiki-drafts WCAG violations:\n{_fmt(v)}"


### PR DESCRIPTION
## Summary
- Fixed title to `Wiki Draft Proposals — RulersAI`
- Added `page-header` component (`edit_document` icon + title + desc)
- Wrapped status filter links in `<nav aria-label="Filter by status">` with `aria-current="page"` on the active link (replacing `style="font-weight:bold"`)
- Added `aria-label`, `class="table"`, and `scope="col"` to all table headers
- Added `<span class="sr-only">Actions</span>` for the empty action column header
- Removed `xfail` from `test_axe_wiki_drafts` — screen story #454 complete

Closes #454. Contributes to WCAG audit (#456).

## Test plan
- [x] All 1699 non-Playwright tests pass locally
- [ ] Verify `/data/wiki-drafts` renders with page-header and filter nav
- [ ] Verify active filter link has `aria-current="page"` in rendered HTML
- [ ] Axe `test_axe_wiki_drafts` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)