### PR TITLE
feat: mobile responsive layout and e2e tests (#459)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           OFFICE_HOLDER_DB_PATH: /tmp/playwright_ci.db
 
       - name: Run Playwright tests
-        run: pytest src/test_ui_edit_office_playwright.py src/test_ui_offices_list_playwright.py src/test_ui_run_playwright.py tests/test_axe_a11y.py tests/test_dark_mode_e2e.py --tb=short -v
+        run: pytest src/test_ui_edit_office_playwright.py src/test_ui_offices_list_playwright.py src/test_ui_run_playwright.py tests/test_axe_a11y.py tests/test_dark_mode_e2e.py tests/test_mobile_e2e.py --tb=short -v
         env:
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:8000
           OFFICE_HOLDER_DB_PATH: /tmp/playwright_ci.db

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ except ImportError:
         "src/test_ui_run_playwright.py",
         "tests/test_axe_a11y.py",
         "tests/test_dark_mode_e2e.py",
+        "tests/test_mobile_e2e.py",
     ]
 
 # Router files that match test_*.py naming but are not test modules.

--- a/src/static/css/theme.css
+++ b/src/static/css/theme.css
@@ -740,3 +740,88 @@ html.dark .sidebar {
   margin-top: 0.125rem;
   line-height: 1.4;
 }
+
+/* =========================================================
+   §23  Mobile responsive  (Issue #459)
+   Breakpoint: 768px — sidebar becomes an off-screen drawer.
+   ========================================================= */
+
+/* Hamburger button — hidden on desktop, shown on mobile */
+.menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-on-surface);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.menu-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Sidebar overlay — covers page behind open sidebar on mobile */
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 19;
+}
+
+@media (max-width: 768px) {
+  /* Show hamburger in top-bar */
+  .menu-btn { display: flex; }
+
+  /* Collapse sidebar off-screen to the left */
+  .sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    z-index: 21;
+  }
+  .sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  /* Overlay visible when sidebar is open */
+  .sidebar-overlay.is-open {
+    display: block;
+  }
+
+  /* Main content takes full width — no sidebar offset */
+  .main-content {
+    margin-inline-start: 0;
+    padding: 1rem 1rem 4rem;
+  }
+
+  /* Hide global search in top-bar (space-constrained) */
+  .top-bar-search { display: none; }
+
+  /* Tables: horizontal scroll so data isn't clipped */
+  table.table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Nav card grid: single column on narrow screens */
+  .nav-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Give forms breathing room */
+  input[type="text"],
+  input[type="search"],
+  input[type="url"],
+  input[type="email"],
+  input[type="number"],
+  select,
+  textarea {
+    max-width: 100%;
+  }
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -113,6 +113,44 @@
       var icon = darkBtn.querySelector('.material-symbols-outlined');
       if (icon) icon.textContent = 'light_mode';
     }
+
+    // Mobile nav drawer toggle
+    var menuBtn = document.getElementById('menuBtn');
+    var sidebar = document.getElementById('primaryNav');
+    var overlay = document.getElementById('sidebarOverlay');
+    function openNav() {
+      sidebar.classList.add('is-open');
+      overlay.classList.add('is-open');
+      menuBtn.setAttribute('aria-expanded', 'true');
+      menuBtn.setAttribute('aria-label', 'Close navigation menu');
+    }
+    function closeNav() {
+      sidebar.classList.remove('is-open');
+      overlay.classList.remove('is-open');
+      menuBtn.setAttribute('aria-expanded', 'false');
+      menuBtn.setAttribute('aria-label', 'Open navigation menu');
+    }
+    if (menuBtn) {
+      menuBtn.addEventListener('click', function () {
+        sidebar.classList.contains('is-open') ? closeNav() : openNav();
+      });
+    }
+    if (overlay) {
+      overlay.addEventListener('click', closeNav);
+    }
+    // Close drawer on nav link click (single-page navigation)
+    if (sidebar) {
+      sidebar.querySelectorAll('a').forEach(function (link) {
+        link.addEventListener('click', closeNav);
+      });
+    }
+    // Close drawer on Escape
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && sidebar && sidebar.classList.contains('is-open')) {
+        closeNav();
+        if (menuBtn) menuBtn.focus();
+      }
+    });
   });
   </script>
 
@@ -120,6 +158,16 @@
        Top App Bar  (role=banner, sticky, h-16)
        ===================================================================== -->
   <header role="banner" class="top-bar">
+    <!-- Hamburger — mobile only, toggles sidebar drawer -->
+    <button id="menuBtn"
+            type="button"
+            class="menu-btn"
+            aria-label="Open navigation menu"
+            aria-expanded="false"
+            aria-controls="primaryNav">
+      <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+    </button>
+
     <!-- Logo -->
     <a href="/" class="top-bar-logo" aria-label="RulersAI home">
       <img src="/static/images/rulersai-icon.png" alt="" width="28" height="28" aria-hidden="true">
@@ -173,7 +221,10 @@
        Sidebar  (fixed, w-64, below top bar)
        ===================================================================== -->
   {% set _path = request.url.path %}
-  <nav aria-label="Primary navigation" class="sidebar">
+  <!-- Sidebar overlay — tapping it closes the drawer on mobile -->
+  <div id="sidebarOverlay" class="sidebar-overlay" aria-hidden="true"></div>
+
+  <nav id="primaryNav" aria-label="Primary navigation" class="sidebar">
 
     <!-- Logo area -->
     <div class="sidebar-logo" aria-hidden="true">

--- a/tests/test_mobile_e2e.py
+++ b/tests/test_mobile_e2e.py
@@ -1,0 +1,174 @@
+"""
+Mobile responsive end-to-end tests (Issue #459).
+
+Tests are run at a 375×812 viewport (iPhone SE / small phone) to verify:
+  1. Layout — sidebar is off-screen, main content takes full width.
+  2. Hamburger — #menuBtn is visible; clicking it opens the sidebar drawer.
+  3. Drawer close — overlay click and Escape key close the drawer.
+  4. Axe-core at mobile viewport — zero WCAG 2.2 AA violations on key pages.
+"""
+
+import os
+
+import pytest
+from playwright.sync_api import sync_playwright
+
+BASE_URL = os.getenv("PLAYWRIGHT_BASE_URL", "http://127.0.0.1:8000")
+AXE_CDN = "https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.0/axe.min.js"
+AXE_TAGS = ["wcag2a", "wcag2aa", "wcag22aa"]
+
+MOBILE_VIEWPORT = {"width": 375, "height": 812}
+SHELL_PAGES = ["/offices", "/run", "/data/wiki-drafts"]
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def pw():
+    try:
+        p = sync_playwright().start()
+    except Exception as e:
+        pytest.skip(f"Playwright not available: {e}")
+    try:
+        yield p
+    finally:
+        p.stop()
+
+
+@pytest.fixture()
+def mobile_page(pw):
+    browser = pw.chromium.launch()
+    ctx = browser.new_context(viewport=MOBILE_VIEWPORT, bypass_csp=True)
+    pg = ctx.new_page()
+    yield pg
+    browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _goto(page, path: str):
+    try:
+        page.goto(f"{BASE_URL}{path}", wait_until="networkidle", timeout=15_000)
+    except Exception as e:
+        pytest.skip(f"Server not reachable at {BASE_URL}{path}: {e}")
+
+
+def _run_axe(page) -> list:
+    page.add_script_tag(url=AXE_CDN)
+    page.wait_for_function("typeof axe !== 'undefined'", timeout=10_000)
+    return page.evaluate(
+        """(tags) => new Promise((resolve, reject) => {
+            axe.run(
+                { runOnly: { type: 'tag', values: tags } },
+                function(err, res) {
+                    if (err) { reject(err); } else { resolve(res.violations); }
+                }
+            );
+        })""",
+        AXE_TAGS,
+    )
+
+
+def _fmt(violations: list) -> str:
+    lines = []
+    for v in violations:
+        lines.append(f"  [{v['impact']}] {v['id']}: {v['description']}")
+        for node in v.get("nodes", [])[:2]:
+            lines.append(f"    {node.get('html', '')[:120]}")
+    return "\n".join(lines) if lines else "(none)"
+
+
+def _sidebar_x(page) -> float:
+    """Return the sidebar's getBoundingClientRect().x (left edge position)."""
+    return page.evaluate("document.getElementById('primaryNav').getBoundingClientRect().x")
+
+
+# ---------------------------------------------------------------------------
+# 1. Layout at mobile viewport
+# ---------------------------------------------------------------------------
+
+
+def test_mobile_hamburger_visible(mobile_page):
+    """#menuBtn is visible at mobile viewport."""
+    _goto(mobile_page, "/offices")
+    btn = mobile_page.locator("#menuBtn")
+    assert btn.count() == 1, "#menuBtn not found"
+    assert btn.is_visible(), "#menuBtn should be visible on mobile"
+
+
+def test_mobile_sidebar_hidden_by_default(mobile_page):
+    """Sidebar is translated off-screen on mobile (x < 0)."""
+    _goto(mobile_page, "/offices")
+    x = _sidebar_x(mobile_page)
+    assert x < 0, f"Sidebar should be off-screen on mobile (x={x})"
+
+
+def test_mobile_main_content_full_width(mobile_page):
+    """Main content margin-inline-start is 0 on mobile."""
+    _goto(mobile_page, "/offices")
+    margin = mobile_page.evaluate(
+        "parseFloat(getComputedStyle(document.querySelector('.main-content')).marginInlineStart)"
+    )
+    assert margin == 0, f"main-content margin-inline-start should be 0 on mobile, got {margin}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Hamburger / drawer
+# ---------------------------------------------------------------------------
+
+
+def test_mobile_hamburger_opens_sidebar(mobile_page):
+    """Clicking #menuBtn slides the sidebar into view."""
+    _goto(mobile_page, "/offices")
+    mobile_page.locator("#menuBtn").click()
+    x = _sidebar_x(mobile_page)
+    assert x >= 0, f"Sidebar should be on-screen after hamburger click (x={x})"
+
+
+def test_mobile_hamburger_aria_expanded(mobile_page):
+    """aria-expanded on #menuBtn reflects open/closed state."""
+    _goto(mobile_page, "/offices")
+    btn = mobile_page.locator("#menuBtn")
+    assert btn.get_attribute("aria-expanded") == "false", "Should start closed"
+    btn.click()
+    assert btn.get_attribute("aria-expanded") == "true", "Should be open after click"
+    btn.click()
+    assert btn.get_attribute("aria-expanded") == "false", "Should close on second click"
+
+
+def test_mobile_overlay_closes_sidebar(mobile_page):
+    """Clicking the sidebar overlay closes the drawer."""
+    _goto(mobile_page, "/offices")
+    mobile_page.locator("#menuBtn").click()
+    # Overlay is now visible — click it
+    mobile_page.locator("#sidebarOverlay").click()
+    x = _sidebar_x(mobile_page)
+    assert x < 0, f"Sidebar should close after overlay click (x={x})"
+
+
+def test_mobile_escape_closes_sidebar(mobile_page):
+    """Pressing Escape closes the sidebar drawer."""
+    _goto(mobile_page, "/offices")
+    mobile_page.locator("#menuBtn").click()
+    mobile_page.keyboard.press("Escape")
+    x = _sidebar_x(mobile_page)
+    assert x < 0, f"Sidebar should close on Escape (x={x})"
+
+
+# ---------------------------------------------------------------------------
+# 3. Axe-core at mobile viewport — no WCAG regressions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", SHELL_PAGES)
+def test_mobile_axe(mobile_page, path):
+    """Zero WCAG 2.2 AA violations on key pages at 375px viewport."""
+    _goto(mobile_page, path)
+    violations = _run_axe(mobile_page)
+    assert violations == [], f"{path} mobile WCAG violations:\n{_fmt(violations)}"


### PR DESCRIPTION
## Summary
- **CSS (`theme.css` §23)**: `@media (max-width: 768px)` — sidebar becomes an off-screen drawer (`translateX(-100%)`), main content drops the 16rem offset, top-bar search hidden, `table.table` gets `overflow-x: auto`, nav-card-grid collapses to 1 column, form inputs capped at `max-width: 100%`
- **`.menu-btn`**: hamburger button hidden on desktop, shown on mobile
- **`.sidebar-overlay`**: full-screen scrim behind the open drawer
- **`base.html`**: `#menuBtn` added to top-bar with `aria-expanded` / `aria-controls`; `#sidebarOverlay` div added; `#primaryNav` id added to sidebar; JS wires open/close, overlay tap, Escape key, auto-close on nav-link click
- **`tests/test_mobile_e2e.py`** (9 Playwright tests at 375×812 viewport):
  - Layout: hamburger visible, sidebar off-screen by default, main-content margin = 0
  - Drawer: opens on hamburger click, `aria-expanded` stays in sync, overlay click closes, Escape closes
  - Axe-core: zero WCAG 2.2 AA violations on `/offices`, `/run`, `/data/wiki-drafts` at mobile viewport

## Test plan
- [ ] All CI checks green
- [ ] Playwright tests include the 9 new mobile tests
- [ ] No regressions on desktop layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)