### PR TITLE
feat: AI provider budget management — kill switches, balance probes, …

### DIFF
--- a/src/scheduled_tasks.py
+++ b/src/scheduled_tasks.py
@@ -515,6 +515,33 @@ def run_daily_gemini_research() -> None:
     if _has_active_scheduled_run("gemini_research"):
         return
 
+    from src.services.ai_provider_status import check_providers
+
+    provider_status = check_providers(required=["gemini", "openai"])
+    if not provider_status.all_available:
+        run_id = db_job_runs.create_run("gemini_research")
+        db_job_runs.finish_run(
+            run_id,
+            status="skipped",
+            result={
+                "skip_reason": provider_status.skip_reason,
+                "disabled_providers": provider_status.disabled_providers,
+                "exhausted_providers": provider_status.exhausted_providers,
+            },
+        )
+        logger.info("Gemini research run skipped: %s", provider_status.skip_reason)
+        _send_job_summary_email(
+            "Gemini Research",
+            {
+                "skip_reason": provider_status.skip_reason,
+                "disabled_providers": provider_status.disabled_providers,
+                "exhausted_providers": provider_status.exhausted_providers,
+            },
+            0.0,
+            datetime.now(timezone.utc),
+        )
+        return
+
     run_start = datetime.now(timezone.utc)
     today_batch = run_start.day % 30
     logger.info(
@@ -573,13 +600,39 @@ def run_daily_page_quality() -> None:
     if _has_active_scheduled_run("daily_page_quality"):
         return
 
+    from src.db import scheduled_job_runs as db_job_runs
+    from src.services.ai_provider_status import check_providers
+
+    provider_status = check_providers(required=["openai", "gemini", "anthropic"])
+    if not provider_status.all_available:
+        run_id = db_job_runs.create_run("daily_page_quality")
+        db_job_runs.finish_run(
+            run_id,
+            status="skipped",
+            result={
+                "skip_reason": provider_status.skip_reason,
+                "disabled_providers": provider_status.disabled_providers,
+                "exhausted_providers": provider_status.exhausted_providers,
+            },
+        )
+        logger.info("Page quality run skipped: %s", provider_status.skip_reason)
+        _send_job_summary_email(
+            "Page Quality",
+            {
+                "skip_reason": provider_status.skip_reason,
+                "disabled_providers": provider_status.disabled_providers,
+                "exhausted_providers": provider_status.exhausted_providers,
+            },
+            0.0,
+            datetime.now(timezone.utc),
+        )
+        return
+
     run_start = datetime.now(timezone.utc)
     logger.info(
         "Page quality inspection starting at %s UTC",
         run_start.strftime("%Y-%m-%d %H:%M:%S"),
     )
-
-    from src.db import scheduled_job_runs as db_job_runs
 
     run_id = db_job_runs.create_run("daily_page_quality")
 
@@ -681,6 +734,25 @@ def _send_job_summary_email(
             f"Status    : FAILED\n\n"
             f"Error:\n{error or 'Unknown error'}\n"
         )
+    elif result.get("skip_reason"):
+        status = "SKIPPED"
+        disabled = result.get("disabled_providers") or []
+        exhausted = result.get("exhausted_providers") or []
+        lines = [
+            f"Job       : {job_name}",
+            f"Run date  : {date_str}",
+            f"Started   : {started_str}",
+            "Status    : SKIPPED",
+            "",
+            "SKIP REASON",
+            "-----------",
+            f"  {result['skip_reason']}",
+        ]
+        if disabled:
+            lines.append(f"  Disabled providers : {', '.join(disabled)}")
+        if exhausted:
+            lines.append(f"  Exhausted providers: {', '.join(exhausted)}")
+        body = "\n".join(lines) + "\n"
     else:
         status = "Complete"
         lines = [

--- a/src/sentry_setup.py
+++ b/src/sentry_setup.py
@@ -9,6 +9,26 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 
+def _before_send(event: dict, hint: dict) -> dict | None:
+    """Drop intentional budget-exhaustion events from Sentry.
+
+    Defense-in-depth: scheduled job guards and balance probes already handle
+    these exceptions before they can reach sentry_sdk.capture_exception(), but
+    this filter ensures no stray RateLimitError / RESOURCE_EXHAUSTED events
+    produce noise if one escapes through an unguarded path.
+    """
+    exc_info = hint.get("exc_info")
+    if exc_info and exc_info[0] is not None:
+        type_name = exc_info[0].__name__
+        # openai.RateLimitError and anthropic.RateLimitError share the same __name__
+        if type_name == "RateLimitError":
+            return None
+        # Gemini signals quota exhaustion via ClientError with RESOURCE_EXHAUSTED in the message
+        if exc_info[1] is not None and "RESOURCE_EXHAUSTED" in str(exc_info[1]):
+            return None
+    return event
+
+
 def init_sentry() -> None:
     """Initialize Sentry SDK. No-ops gracefully when SENTRY_DSN is unset (local dev)."""
     dsn = os.environ.get("SENTRY_DSN")
@@ -30,4 +50,5 @@ def init_sentry() -> None:
         ],
         traces_sample_rate=traces_rate,
         send_default_pii=False,
+        before_send=_before_send,
     )

--- a/src/services/ai_provider_status.py
+++ b/src/services/ai_provider_status.py
@@ -121,9 +121,7 @@ def poll_gemini_balance() -> bool:
             logger.warning("poll_gemini_balance: RESOURCE_EXHAUSTED — Gemini quota exhausted")
             result = False
         else:
-            logger.warning(
-                "poll_gemini_balance: non-quota error (assuming available): %s", exc
-            )
+            logger.warning("poll_gemini_balance: non-quota error (assuming available): %s", exc)
             result = True
 
     _set_probe_cache("gemini", result)
@@ -157,14 +155,10 @@ def poll_anthropic_balance() -> bool:
         )
         result = True
     except anthropic.RateLimitError:
-        logger.warning(
-            "poll_anthropic_balance: RateLimitError — Anthropic quota exhausted"
-        )
+        logger.warning("poll_anthropic_balance: RateLimitError — Anthropic quota exhausted")
         result = False
     except Exception as exc:
-        logger.warning(
-            "poll_anthropic_balance: non-quota error (assuming available): %s", exc
-        )
+        logger.warning("poll_anthropic_balance: non-quota error (assuming available): %s", exc)
         result = True
 
     _set_probe_cache("anthropic", result)
@@ -198,14 +192,10 @@ def poll_openai_balance() -> bool:
         )
         result = True
     except openai.RateLimitError:
-        logger.warning(
-            "poll_openai_balance: RateLimitError — OpenAI quota exhausted"
-        )
+        logger.warning("poll_openai_balance: RateLimitError — OpenAI quota exhausted")
         result = False
     except Exception as exc:
-        logger.warning(
-            "poll_openai_balance: non-quota error (assuming available): %s", exc
-        )
+        logger.warning("poll_openai_balance: non-quota error (assuming available): %s", exc)
         result = True
 
     _set_probe_cache("openai", result)

--- a/src/services/ai_provider_status.py
+++ b/src/services/ai_provider_status.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+"""AI provider availability — kill switches and balance probes.
+
+Single source of truth for whether each AI provider is currently available.
+All scheduled jobs and ad-hoc callers check this before making any AI calls.
+
+Kill-switch env vars (set to 0/false/no/off to disable):
+  GEMINI_ENABLED      — controls google-genai (Gemini)
+  ANTHROPIC_ENABLED   — controls anthropic SDK
+  OPENAI_ENABLED      — controls openai SDK
+
+Balance probes make a minimal 1-token call and cache the result for 1 hour.
+Non-quota errors (network, 5xx) return True and log at WARNING to avoid
+false-blocking.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_PROBE_CACHE_TTL = 3600  # seconds
+_probe_cache: dict[str, tuple[bool, float]] = {}
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProviderCheckResult:
+    all_available: bool
+    disabled_providers: list[str] = field(default_factory=list)
+    exhausted_providers: list[str] = field(default_factory=list)
+    skip_reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Kill-switch check
+# ---------------------------------------------------------------------------
+
+
+def is_provider_enabled(name: str) -> bool:
+    """Return False if the {NAME}_ENABLED env var is set to a false-like value.
+
+    Reads GEMINI_ENABLED, ANTHROPIC_ENABLED, or OPENAI_ENABLED.
+    Defaults to True (enabled) when the var is unset.  Same pattern as
+    is_runners_enabled() in scheduled_tasks.py.
+    """
+    raw = os.environ.get(f"{name.upper()}_ENABLED", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+# ---------------------------------------------------------------------------
+# Probe cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_probe_cached(name: str) -> tuple[bool, bool]:
+    """Return (cached_value, cache_hit). Cache hit only when within TTL."""
+    if name in _probe_cache:
+        value, ts = _probe_cache[name]
+        if time.monotonic() - ts < _PROBE_CACHE_TTL:
+            return value, True
+    return False, False
+
+
+def _set_probe_cache(name: str, value: bool) -> None:
+    _probe_cache[name] = (value, time.monotonic())
+
+
+def _clear_probe_cache() -> None:
+    """Clear the probe cache — used in tests."""
+    _probe_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Per-provider balance probes
+# ---------------------------------------------------------------------------
+
+
+def poll_gemini_balance() -> bool:
+    """Probe Gemini with a minimal 1-token call. Returns False on RESOURCE_EXHAUSTED.
+
+    Non-quota errors (network, 5xx, etc.) return True and log at WARNING so
+    that transient infrastructure problems don't false-block the provider.
+    Result is cached for 1 hour.
+    """
+    cached, hit = _is_probe_cached("gemini")
+    if hit:
+        return cached
+
+    result = True
+    try:
+        from google import genai
+        from google.genai import types
+
+        api_key = os.environ.get("GEMINI_OFFICE_HOLDER", "")
+        if not api_key:
+            # No key configured — cannot probe; assume available so job can
+            # fail naturally with "client not configured".
+            _set_probe_cache("gemini", True)
+            return True
+
+        client = genai.Client(api_key=api_key)
+        client.models.generate_content(
+            model="gemini-2.0-flash",
+            contents="hi",
+            config=types.GenerateContentConfig(max_output_tokens=1),
+        )
+        result = True
+    except Exception as exc:
+        exc_str = str(exc)
+        exc_type = type(exc).__name__
+        if "RESOURCE_EXHAUSTED" in exc_str or "ResourceExhausted" in exc_type:
+            logger.warning("poll_gemini_balance: RESOURCE_EXHAUSTED — Gemini quota exhausted")
+            result = False
+        else:
+            logger.warning(
+                "poll_gemini_balance: non-quota error (assuming available): %s", exc
+            )
+            result = True
+
+    _set_probe_cache("gemini", result)
+    return result
+
+
+def poll_anthropic_balance() -> bool:
+    """Probe Anthropic with a minimal 1-token call. Returns False on RateLimitError.
+
+    Non-quota errors return True and log at WARNING.
+    Result is cached for 1 hour.
+    """
+    cached, hit = _is_probe_cached("anthropic")
+    if hit:
+        return cached
+
+    result = True
+    try:
+        import anthropic
+
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if not api_key:
+            _set_probe_cache("anthropic", True)
+            return True
+
+        client = anthropic.Anthropic(api_key=api_key)
+        client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        result = True
+    except anthropic.RateLimitError:
+        logger.warning(
+            "poll_anthropic_balance: RateLimitError — Anthropic quota exhausted"
+        )
+        result = False
+    except Exception as exc:
+        logger.warning(
+            "poll_anthropic_balance: non-quota error (assuming available): %s", exc
+        )
+        result = True
+
+    _set_probe_cache("anthropic", result)
+    return result
+
+
+def poll_openai_balance() -> bool:
+    """Probe OpenAI with a minimal 1-token call. Returns False on RateLimitError.
+
+    Non-quota errors return True and log at WARNING.
+    Result is cached for 1 hour.
+    """
+    cached, hit = _is_probe_cached("openai")
+    if hit:
+        return cached
+
+    result = True
+    try:
+        import openai
+
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        if not api_key:
+            _set_probe_cache("openai", True)
+            return True
+
+        client = openai.OpenAI(api_key=api_key)
+        client.chat.completions.create(
+            model="gpt-4o-mini",
+            max_completion_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        result = True
+    except openai.RateLimitError:
+        logger.warning(
+            "poll_openai_balance: RateLimitError — OpenAI quota exhausted"
+        )
+        result = False
+    except Exception as exc:
+        logger.warning(
+            "poll_openai_balance: non-quota error (assuming available): %s", exc
+        )
+        result = True
+
+    _set_probe_cache("openai", result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main check function
+# ---------------------------------------------------------------------------
+
+
+def _run_probe(name: str) -> bool | None:
+    """Run the balance probe for a named provider. Returns None for unknown providers."""
+    if name == "gemini":
+        return poll_gemini_balance()
+    if name == "anthropic":
+        return poll_anthropic_balance()
+    if name == "openai":
+        return poll_openai_balance()
+    return None
+
+
+def check_providers(required: list[str]) -> ProviderCheckResult:
+    """Check availability of the required AI providers.
+
+    Algorithm:
+    1. Check kill switches for all required providers first.  If any is
+       disabled, return immediately — no balance probes are wasted.
+    2. If all kill switches pass, run balance probes for each provider.
+       If any probe returns False, mark as exhausted.
+    3. Return a ProviderCheckResult with full context for logging /
+       result_json / summary emails.
+
+    Args:
+        required: List of provider names to check, e.g. ["gemini", "openai"].
+                  Use "anthropic" (not "claude") as the canonical name for
+                  the Anthropic / Claude provider.
+    """
+    disabled: list[str] = []
+    for name in required:
+        if not is_provider_enabled(name):
+            disabled.append(name)
+
+    if disabled:
+        return ProviderCheckResult(
+            all_available=False,
+            disabled_providers=disabled,
+            skip_reason=f"disabled by env var: {', '.join(disabled)}",
+        )
+
+    exhausted: list[str] = []
+    for name in required:
+        result = _run_probe(name)
+        if result is None:
+            logger.warning(
+                "check_providers: no probe function for provider %r — skipping probe", name
+            )
+            continue
+        if not result:
+            exhausted.append(name)
+
+    if exhausted:
+        return ProviderCheckResult(
+            all_available=False,
+            exhausted_providers=exhausted,
+            skip_reason=f"quota exhausted: {', '.join(exhausted)}",
+        )
+
+    return ProviderCheckResult(all_available=True)

--- a/src/services/claude_client.py
+++ b/src/services/claude_client.py
@@ -53,9 +53,15 @@ def get_claude_client() -> ClaudeClient | None:
     """Return the cached ClaudeClient singleton, or None if not configured.
 
     Thread-safe via double-checked locking (matches gemini_vitals_researcher.py pattern).
-    Returns None (not raises) when ANTHROPIC_API_KEY is not set — feature
-    is silently disabled.
+    Returns None (not raises) when ANTHROPIC_ENABLED is disabled or
+    ANTHROPIC_API_KEY is not set — feature is silently disabled.
     """
+    from src.services.ai_provider_status import is_provider_enabled
+
+    if not is_provider_enabled("anthropic"):
+        logger.info("get_claude_client: ANTHROPIC_ENABLED is disabled — returning None")
+        return None
+
     global _client
     if _client is not None:
         return _client

--- a/src/services/consensus_voter.py
+++ b/src/services/consensus_voter.py
@@ -96,10 +96,14 @@ _SYSTEM_PROMPT = (
 def _vote_openai(prompt: str, context: dict) -> AIVote:
     """Call OpenAI gpt-4o-mini and return a vote."""
     try:
+        from src.services.ai_provider_status import is_provider_enabled
         from src.services.orchestrator import get_ai_builder
         import json
         import openai
         import time
+
+        if not is_provider_enabled("openai"):
+            return AIVote(provider="openai", is_valid=None, error="provider disabled")
 
         builder = get_ai_builder()
         if builder is None:
@@ -144,7 +148,11 @@ def _vote_openai(prompt: str, context: dict) -> AIVote:
 def _vote_gemini(prompt: str, context: dict) -> AIVote:
     """Call Gemini and return a vote."""
     try:
+        from src.services.ai_provider_status import is_provider_enabled
         from src.services.gemini_vitals_researcher import get_gemini_researcher
+
+        if not is_provider_enabled("gemini"):
+            return AIVote(provider="gemini", is_valid=None, error="provider disabled")
 
         researcher = get_gemini_researcher()
         if researcher is None:
@@ -168,7 +176,11 @@ def _vote_gemini(prompt: str, context: dict) -> AIVote:
 def _vote_claude(prompt: str, context: dict) -> AIVote:
     """Call Claude and return a vote."""
     try:
+        from src.services.ai_provider_status import is_provider_enabled
         from src.services.claude_client import get_claude_client
+
+        if not is_provider_enabled("anthropic"):
+            return AIVote(provider="claude", is_valid=None, error="provider disabled")
 
         client = get_claude_client()
         if client is None:

--- a/src/services/gemini_vitals_researcher.py
+++ b/src/services/gemini_vitals_researcher.py
@@ -67,9 +67,15 @@ def get_gemini_researcher() -> GeminiVitalsResearcher | None:
     """Return the cached GeminiVitalsResearcher singleton, or None if not configured.
 
     Thread-safe via double-checked locking (matches orchestrator.py pattern).
-    Returns None (not raises) when GEMINI_OFFICE_HOLDER is not set — feature
-    is silently disabled.
+    Returns None (not raises) when GEMINI_ENABLED is disabled or
+    GEMINI_OFFICE_HOLDER is not set — feature is silently disabled.
     """
+    from src.services.ai_provider_status import is_provider_enabled
+
+    if not is_provider_enabled("gemini"):
+        logger.info("get_gemini_researcher: GEMINI_ENABLED is disabled — returning None")
+        return None
+
     global _researcher
     if _researcher is not None:
         return _researcher

--- a/src/services/orchestrator.py
+++ b/src/services/orchestrator.py
@@ -7,8 +7,9 @@ Provides:
       Single SSRF enforcement point for all outbound Wikipedia requests triggered
       by user-supplied URLs. Raises ValueError for non-wikipedia.org domains.
 
-  get_ai_builder() -> AIOfficeBuilder
+  get_ai_builder() -> AIOfficeBuilder | None
       Lazy singleton — creates one AIOfficeBuilder per process and reuses it.
+      Returns None if OPENAI_ENABLED is disabled.
       Raises RuntimeError if OPENAI_API_KEY is not set.
 
   reset_ai_builder() -> None
@@ -35,8 +36,11 @@ Wikipedia API (src/scraper/wiki_fetch.py):
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
+
+logger = logging.getLogger(__name__)
 
 from src.scraper.wiki_fetch import normalize_wiki_url
 from src.services.ai_office_builder import AIOfficeBuilder
@@ -59,12 +63,19 @@ def validate_and_normalize_wiki_url(url: str) -> str:
     return normalized
 
 
-def get_ai_builder() -> AIOfficeBuilder:
+def get_ai_builder() -> AIOfficeBuilder | None:
     """Return the cached AIOfficeBuilder singleton, creating it on first call.
 
     Thread-safe via double-checked locking (matches wiki_session() pattern).
+    Returns None if OPENAI_ENABLED is set to a false-like value.
     Raises RuntimeError if OPENAI_API_KEY is not set in the environment.
     """
+    from src.services.ai_provider_status import is_provider_enabled
+
+    if not is_provider_enabled("openai"):
+        logger.info("get_ai_builder: OPENAI_ENABLED is disabled — returning None")
+        return None
+
     global _builder
     if _builder is not None:
         return _builder

--- a/src/services/page_quality_inspector.py
+++ b/src/services/page_quality_inspector.py
@@ -368,10 +368,22 @@ def inspect_one_page(conn=None) -> dict | None:
 
             db_pqc.mark_page_checked(source_page_id, conn=conn)
 
-        else:
-            # DISAGREEMENT or INSUFFICIENT_QUORUM — manual review
+        elif verdict == Verdict.DISAGREEMENT:
+            # Providers disagree — flag for manual review
             result_str = "manual_review"
             gh_url = _create_gh_issue(page_url, source_page_id, verdict.value, ai_summary)
+            db_pqc.mark_page_checked(source_page_id, conn=conn)
+
+        else:
+            # INSUFFICIENT_QUORUM — expected when providers are disabled or quota-exhausted.
+            # Not an error: log at INFO, no GH issue, mark checked so it re-enters LRU normally.
+            result_str = "skipped_quorum"
+            logger.info(
+                "page_quality_inspector: INSUFFICIENT_QUORUM for source_page_id=%d url=%s"
+                " — skipping without GH issue (providers unavailable)",
+                source_page_id,
+                page_url,
+            )
             db_pqc.mark_page_checked(source_page_id, conn=conn)
 
         check_id = db_pqc.insert_check(

--- a/tests/test_ai_provider_status.py
+++ b/tests/test_ai_provider_status.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for src/services/ai_provider_status.py.
+
+All SDK calls are mocked — no live API requests are made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.ai_provider_status import (
+    ProviderCheckResult,
+    _clear_probe_cache,
+    check_providers,
+    is_provider_enabled,
+    poll_anthropic_balance,
+    poll_gemini_balance,
+    poll_openai_balance,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the probe cache before and after every test."""
+    _clear_probe_cache()
+    yield
+    _clear_probe_cache()
+
+
+# ---------------------------------------------------------------------------
+# is_provider_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsProviderEnabled:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_ENABLED", raising=False)
+        assert is_provider_enabled("gemini") is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "False", "FALSE", "no", "off"])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("GEMINI_ENABLED", value)
+        assert is_provider_enabled("gemini") is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", ""])
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("GEMINI_ENABLED", value)
+        assert is_provider_enabled("gemini") is True
+
+    def test_anthropic_reads_correct_var(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_ENABLED", "0")
+        monkeypatch.delenv("GEMINI_ENABLED", raising=False)
+        assert is_provider_enabled("anthropic") is False
+        assert is_provider_enabled("gemini") is True
+
+    def test_openai_reads_correct_var(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_ENABLED", "false")
+        assert is_provider_enabled("openai") is False
+
+
+# ---------------------------------------------------------------------------
+# check_providers — kill switch behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCheckProvidersKillSwitch:
+    def test_gemini_disabled_returns_not_available(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_ENABLED", "0")
+        result = check_providers(["gemini"])
+        assert result.all_available is False
+        assert "gemini" in result.disabled_providers
+        assert result.skip_reason is not None
+
+    def test_anthropic_disabled_returns_not_available(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_ENABLED", "0")
+        result = check_providers(["anthropic"])
+        assert result.all_available is False
+        assert "anthropic" in result.disabled_providers
+
+    def test_openai_disabled_returns_not_available(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_ENABLED", "false")
+        result = check_providers(["openai"])
+        assert result.all_available is False
+        assert "openai" in result.disabled_providers
+
+    def test_disabled_provider_skips_remaining_probes(self, monkeypatch):
+        """If first required provider is disabled, no balance probes are called."""
+        monkeypatch.setenv("ANTHROPIC_ENABLED", "0")
+        with patch("src.services.ai_provider_status.poll_openai_balance") as mock_probe:
+            result = check_providers(["anthropic", "openai"])
+        assert result.all_available is False
+        mock_probe.assert_not_called()
+
+    def test_second_provider_disabled_skips_first_probe(self, monkeypatch):
+        """Kill-switch check happens before any probes — even for the first provider."""
+        monkeypatch.setenv("OPENAI_ENABLED", "0")
+        with patch("src.services.ai_provider_status.poll_gemini_balance") as mock_probe:
+            result = check_providers(["gemini", "openai"])
+        assert result.all_available is False
+        mock_probe.assert_not_called()
+
+    def test_all_enabled_with_mocked_probes_returns_available(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_ENABLED", raising=False)
+        monkeypatch.delenv("OPENAI_ENABLED", raising=False)
+        with (
+            patch("src.services.ai_provider_status.poll_gemini_balance", return_value=True),
+            patch("src.services.ai_provider_status.poll_openai_balance", return_value=True),
+        ):
+            result = check_providers(["gemini", "openai"])
+        assert result.all_available is True
+        assert result.disabled_providers == []
+        assert result.exhausted_providers == []
+
+
+# ---------------------------------------------------------------------------
+# check_providers — exhaustion behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCheckProvidersExhaustion:
+    def test_anthropic_rate_limit_error_marks_exhausted(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_ENABLED", raising=False)
+        with patch(
+            "src.services.ai_provider_status.poll_anthropic_balance", return_value=False
+        ):
+            result = check_providers(["anthropic"])
+        assert result.all_available is False
+        assert "anthropic" in result.exhausted_providers
+        assert result.disabled_providers == []
+
+    def test_openai_rate_limit_error_marks_exhausted(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_ENABLED", raising=False)
+        with patch(
+            "src.services.ai_provider_status.poll_openai_balance", return_value=False
+        ):
+            result = check_providers(["openai"])
+        assert result.all_available is False
+        assert "openai" in result.exhausted_providers
+
+    def test_gemini_resource_exhausted_marks_exhausted(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_ENABLED", raising=False)
+        with patch(
+            "src.services.ai_provider_status.poll_gemini_balance", return_value=False
+        ):
+            result = check_providers(["gemini"])
+        assert result.all_available is False
+        assert "gemini" in result.exhausted_providers
+
+
+# ---------------------------------------------------------------------------
+# poll_anthropic_balance
+# ---------------------------------------------------------------------------
+
+
+class TestPollAnthropicBalance:
+    def test_rate_limit_error_returns_false(self, monkeypatch):
+        import anthropic
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = anthropic.RateLimitError(
+            message="rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = poll_anthropic_balance()
+        assert result is False
+
+    def test_non_quota_error_returns_true(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = ConnectionError("network error")
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = poll_anthropic_balance()
+        assert result is True
+
+    def test_success_returns_true(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        mock_client = MagicMock()
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = poll_anthropic_balance()
+        assert result is True
+
+    def test_no_key_returns_true_without_probing(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with patch("anthropic.Anthropic") as mock_cls:
+            result = poll_anthropic_balance()
+        assert result is True
+        mock_cls.assert_not_called()
+
+    def test_result_is_cached(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        mock_client = MagicMock()
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            first = poll_anthropic_balance()
+            second = poll_anthropic_balance()
+        assert first == second
+        assert mock_client.messages.create.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# poll_openai_balance
+# ---------------------------------------------------------------------------
+
+
+class TestPollOpenAIBalance:
+    def test_rate_limit_error_returns_false(self, monkeypatch):
+        import openai
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = openai.RateLimitError(
+            message="rate limited",
+            response=MagicMock(status_code=429, headers={}),
+            body=None,
+        )
+        with patch("openai.OpenAI", return_value=mock_client):
+            result = poll_openai_balance()
+        assert result is False
+
+    def test_non_quota_error_returns_true(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = TimeoutError("timeout")
+        with patch("openai.OpenAI", return_value=mock_client):
+            result = poll_openai_balance()
+        assert result is True
+
+    def test_no_key_returns_true_without_probing(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("openai.OpenAI") as mock_cls:
+            result = poll_openai_balance()
+        assert result is True
+        mock_cls.assert_not_called()
+
+    def test_result_is_cached(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        mock_client = MagicMock()
+        with patch("openai.OpenAI", return_value=mock_client):
+            first = poll_openai_balance()
+            second = poll_openai_balance()
+        assert first == second
+        assert mock_client.chat.completions.create.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# poll_gemini_balance
+# ---------------------------------------------------------------------------
+
+
+class TestPollGeminiBalance:
+    def test_resource_exhausted_error_returns_false(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_OFFICE_HOLDER", "test-key")
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = Exception(
+            "RESOURCE_EXHAUSTED: quota exceeded"
+        )
+        with patch("google.genai.Client", return_value=mock_client):
+            result = poll_gemini_balance()
+        assert result is False
+
+    def test_non_quota_error_returns_true(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_OFFICE_HOLDER", "test-key")
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = ConnectionError("network")
+        with patch("google.genai.Client", return_value=mock_client):
+            result = poll_gemini_balance()
+        assert result is True
+
+    def test_no_key_returns_true_without_probing(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_OFFICE_HOLDER", raising=False)
+        with patch("google.genai.Client") as mock_cls:
+            result = poll_gemini_balance()
+        assert result is True
+        mock_cls.assert_not_called()
+
+    def test_result_is_cached(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_OFFICE_HOLDER", "test-key")
+        mock_client = MagicMock()
+        with patch("google.genai.Client", return_value=mock_client):
+            first = poll_gemini_balance()
+            second = poll_gemini_balance()
+        assert first == second
+        assert mock_client.models.generate_content.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# ProviderCheckResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestProviderCheckResult:
+    def test_defaults(self):
+        r = ProviderCheckResult(all_available=True)
+        assert r.disabled_providers == []
+        assert r.exhausted_providers == []
+        assert r.skip_reason is None
+
+    def test_skip_reason_populated_when_unavailable(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_ENABLED", "0")
+        result = check_providers(["gemini"])
+        assert result.skip_reason is not None
+        assert "gemini" in result.skip_reason

--- a/tests/test_ai_provider_status.py
+++ b/tests/test_ai_provider_status.py
@@ -122,9 +122,7 @@ class TestCheckProvidersKillSwitch:
 class TestCheckProvidersExhaustion:
     def test_anthropic_rate_limit_error_marks_exhausted(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_ENABLED", raising=False)
-        with patch(
-            "src.services.ai_provider_status.poll_anthropic_balance", return_value=False
-        ):
+        with patch("src.services.ai_provider_status.poll_anthropic_balance", return_value=False):
             result = check_providers(["anthropic"])
         assert result.all_available is False
         assert "anthropic" in result.exhausted_providers
@@ -132,18 +130,14 @@ class TestCheckProvidersExhaustion:
 
     def test_openai_rate_limit_error_marks_exhausted(self, monkeypatch):
         monkeypatch.delenv("OPENAI_ENABLED", raising=False)
-        with patch(
-            "src.services.ai_provider_status.poll_openai_balance", return_value=False
-        ):
+        with patch("src.services.ai_provider_status.poll_openai_balance", return_value=False):
             result = check_providers(["openai"])
         assert result.all_available is False
         assert "openai" in result.exhausted_providers
 
     def test_gemini_resource_exhausted_marks_exhausted(self, monkeypatch):
         monkeypatch.delenv("GEMINI_ENABLED", raising=False)
-        with patch(
-            "src.services.ai_provider_status.poll_gemini_balance", return_value=False
-        ):
+        with patch("src.services.ai_provider_status.poll_gemini_balance", return_value=False):
             result = check_providers(["gemini"])
         assert result.all_available is False
         assert "gemini" in result.exhausted_providers

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -205,16 +205,22 @@ class TestClaudePolicyCompliance:
         assert "ANTHROPIC_API_KEY" in content  # Should reference env var
 
     def test_anthropic_imports_only_in_service(self):
-        """Verify anthropic imports are only in the service file."""
+        """Verify anthropic imports are only in the permitted service files.
+
+        claude_client.py owns all client usage; ai_provider_status.py is also
+        permitted because it contains the lightweight balance probe that must
+        import the SDK directly.
+        """
         import glob
 
+        _ALLOWED = {"claude_client", "ai_provider_status"}
         for py_file in glob.glob("src/**/*.py", recursive=True):
-            if "claude_client" in py_file:
+            if any(name in py_file for name in _ALLOWED):
                 continue
             content = Path(py_file).read_text(encoding="utf-8")
             assert "import anthropic" not in content, (
                 f"Direct anthropic import found in {py_file} — "
-                "all Anthropic SDK usage should be in claude_client.py"
+                "all Anthropic SDK usage should be in claude_client.py or ai_provider_status.py"
             )
 
     def test_max_tokens_set(self):

--- a/tests/test_gemini_vitals_researcher.py
+++ b/tests/test_gemini_vitals_researcher.py
@@ -498,9 +498,9 @@ class TestPolicyCompliance:
                 f"Direct google.genai import found in {py_file} — "
                 "all Gemini SDK usage should be in gemini_vitals_researcher.py or ai_provider_status.py"
             )
-            assert "from google.genai" not in content, (
-                f"Direct google.genai import found in {py_file}"
-            )
+            assert (
+                "from google.genai" not in content
+            ), f"Direct google.genai import found in {py_file}"
 
     def test_gemini_max_output_tokens_set(self):
         """Verify max_output_tokens is set in the Gemini service."""

--- a/tests/test_gemini_vitals_researcher.py
+++ b/tests/test_gemini_vitals_researcher.py
@@ -482,20 +482,25 @@ class TestPolicyCompliance:
         assert "GEMINI_OFFICE_HOLDER" in content  # Should reference env var
 
     def test_gemini_imports_only_in_service(self):
-        """Verify google.genai imports are only in the service file."""
+        """Verify google.genai imports are only in the permitted service files.
+
+        gemini_vitals_researcher.py owns all client usage; ai_provider_status.py
+        is also permitted because it contains the lightweight balance probe.
+        """
         import glob
 
+        _ALLOWED = {"gemini_vitals_researcher", "ai_provider_status"}
         for py_file in glob.glob("src/**/*.py", recursive=True):
-            if "gemini_vitals_researcher" in py_file:
+            if any(name in py_file for name in _ALLOWED):
                 continue
             content = Path(py_file).read_text(encoding="utf-8")
             assert "from google import genai" not in content, (
                 f"Direct google.genai import found in {py_file} — "
-                "all Gemini SDK usage should be in gemini_vitals_researcher.py"
+                "all Gemini SDK usage should be in gemini_vitals_researcher.py or ai_provider_status.py"
             )
-            assert (
-                "from google.genai" not in content or "gemini_vitals_researcher" in py_file
-            ), f"Direct google.genai import found in {py_file}"
+            assert "from google.genai" not in content, (
+                f"Direct google.genai import found in {py_file}"
+            )
 
     def test_gemini_max_output_tokens_set(self):
         """Verify max_output_tokens is set in the Gemini service."""

--- a/tests/test_page_quality_inspector.py
+++ b/tests/test_page_quality_inspector.py
@@ -438,13 +438,15 @@ class TestInspectOnePage:
 
         assert result["result"] == "manual_review"
 
-    def test_insufficient_quorum_creates_manual_review(self, tmp_path):
+    def test_insufficient_quorum_skips_without_gh_issue(self, tmp_path):
+        """INSUFFICIENT_QUORUM is a non-error skip — no GH issue, result is skipped_quorum."""
         conn = _conn(tmp_path)
         page_id = _seed_page(conn)
 
         mock_voter = MagicMock()
         mock_voter.vote.return_value = _make_verdict(Verdict.INSUFFICIENT_QUORUM)
 
+        mock_create_gh_issue = MagicMock(return_value=None)
         with (
             patch(
                 "src.services.page_quality_inspector.db_pqc.pick_next_page",
@@ -460,7 +462,7 @@ class TestInspectOnePage:
             ),
             patch(
                 "src.services.page_quality_inspector._create_gh_issue",
-                return_value=None,
+                mock_create_gh_issue,
             ),
             patch("src.services.page_quality_inspector.ConsensusVoter", return_value=mock_voter),
         ):
@@ -468,7 +470,8 @@ class TestInspectOnePage:
 
             result = inspect_one_page(conn=conn)
 
-        assert result["result"] == "manual_review"
+        assert result["result"] == "skipped_quorum"
+        mock_create_gh_issue.assert_not_called()
 
     def test_no_data_skips_ai_vote_and_creates_gh_issue(self, tmp_path):
         """When our DB has zero records for a page, skip AI vote and create a GH issue."""


### PR DESCRIPTION
…skip guards (#496)

Closes #496, #497, #498, #499, #500, #501, #502, #503

- New `src/services/ai_provider_status.py`: single source of truth for provider availability. `is_provider_enabled()` reads GEMINI_ENABLED, ANTHROPIC_ENABLED, OPENAI_ENABLED (default: on). `check_providers()` checks kill switches first (no probes wasted), then runs per-provider 1-token balance probes cached 1 hour.
- `get_ai_builder()`, `get_gemini_researcher()`, `get_claude_client()`: return None immediately when their provider's kill switch is off — covers ad-hoc router calls that bypass scheduled job guards.
- `run_daily_gemini_research()` / `run_daily_page_quality()`: guard fires after pause/overlap checks, before `create_run()`. Skipped runs get a `scheduled_job_runs` row (status=skipped) and a summary email showing skip_reason, disabled_providers, exhausted_providers.
- `consensus_voter.py`: explicit `is_provider_enabled()` check in each vote function — defense-in-depth on top of the getter returning None.
- `page_quality_inspector.py`: INSUFFICIENT_QUORUM is now a non-error `skipped_quorum` result (no GH issue, log at INFO) instead of `manual_review` — expected when providers are disabled/exhausted.
- `sentry_setup.py`: `before_send` filter drops RateLimitError and RESOURCE_EXHAUSTED events — prevents spurious Sentry noise from intentional budget-exhaustion skips.
- 38 new tests in `test_ai_provider_status.py`; existing `test_insufficient_quorum_creates_manual_review` updated to assert new `skipped_quorum` behavior and no GH issue created.

## Summary

## <!-- What does this PR do? Focus on the why, not the how. -->

## Type of change

- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done

<!-- What did you run? Any coverage delta? -->

- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist

- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist _(web / frontend PRs only)_

- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom

## Mobile checklist _(iOS / Android PRs only)_

- [ ] Tested on iOS Simulator or physical device
- [ ] `ios-build-check` / `android-build-check` CI job passes
- [ ] No hardcoded local paths in `.pbxproj` (`local-path-check` passes)
- [ ] `pod install` run locally and `Podfile.lock` changes committed (if applicable)
