### PR TITLE
fix: raise RuntimeError if SECRET_KEY unset in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
 
   cve-python:
     uses: wcmchenry3-stack/.github/.github/workflows/called-cve-python.yml@main
-    with:
-      # pygments CVE-2026-4539: no fix released yet — remove once pygments >2.19.2 ships
-      ignore-vulns: CVE-2026-4539
     secrets: inherit
 
   validate-fixtures:

--- a/.github/workflows/schema-migration.yml
+++ b/.github/workflows/schema-migration.yml
@@ -1,0 +1,12 @@
+name: Schema Migration Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  schema-check:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-schema-migration.yml@main
+    with:
+      working-directory: .
+      python-version: '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Office holder scraper and app
-requests>=2.28.0
+requests>=2.33.0
 beautifulsoup4>=4.11.0
 python-dateutil>=2.8.0
 
@@ -7,10 +7,10 @@ python-dateutil>=2.8.0
 fastapi>=0.100.0
 uvicorn[standard]>=0.22.0
 jinja2>=3.1.0
-python-multipart>=0.0.6
+python-multipart>=0.0.26
 
 # Auth
-authlib>=1.3.0
+authlib>=1.6.11
 httpx>=0.27.0
 itsdangerous>=2.1.0
 
@@ -33,6 +33,10 @@ sentry-sdk[fastapi]>=2.0.0
 # Localization
 babel>=2.13.0
 
+# Security: explicit floor on transitive deps with known CVEs
+cryptography>=46.0.7
+pygments>=2.20.0
+
 # Testing
-pytest>=7.0.0
+pytest>=9.0.3
 pytest-cov>=4.0.0

--- a/src/main.py
+++ b/src/main.py
@@ -300,9 +300,16 @@ async def limit_request_body_size(request: Request, call_next):
 app.add_middleware(SlowAPIMiddleware)
 # SessionMiddleware must be added AFTER SlowAPIMiddleware (above) so it is outermost and
 # populates request.session before the rate-limit key function runs.
-app.add_middleware(
-    SessionMiddleware, secret_key=os.environ.get("SECRET_KEY", "dev-only-insecure-key")
-)
+_session_secret = os.environ.get("SECRET_KEY")
+if not _session_secret:
+    if os.environ.get("GOOGLE_CLIENT_ID"):
+        raise RuntimeError(
+            "SECRET_KEY environment variable must be set in production. "
+            "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+        )
+    # Local dev with auth disabled — use a throwaway key.
+    _session_secret = "dev-only-local-no-auth"
+app.add_middleware(SessionMiddleware, secret_key=_session_secret)
 
 
 @app.get("/login", response_class=HTMLResponse)

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,6 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from markupsafe import Markup
 from fastapi import FastAPI, File, Request, Form, HTTPException, Query, UploadFile
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles

--- a/src/main.py
+++ b/src/main.py
@@ -304,7 +304,7 @@ if not _session_secret:
     if os.environ.get("GOOGLE_CLIENT_ID"):
         raise RuntimeError(
             "SECRET_KEY environment variable must be set in production. "
-            "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+            'Generate one with: python -c "import secrets; print(secrets.token_hex(32))"'
         )
     # Local dev with auth disabled — use a throwaway key.
     _session_secret = "dev-only-local-no-auth"

--- a/src/routers/run_scraper.py
+++ b/src/routers/run_scraper.py
@@ -577,6 +577,10 @@ async def api_refresh_table_cache(request: Request):
         use_full_page = bool(body.get("use_full_page"))
         if not url:
             raise HTTPException(status_code=400, detail="url required")
+        from src.scraper.wiki_fetch import normalize_wiki_url
+
+        if not normalize_wiki_url(url):
+            raise HTTPException(status_code=400, detail="url must be a Wikipedia URL")
     result = get_table_html(url, table_no, refresh=True, use_full_page=use_full_page)
     if "error" in result:
         raise HTTPException(status_code=502, detail=result["error"])


### PR DESCRIPTION
## Summary

- Removes the hardcoded `"dev-only-insecure-key"` fallback from `SessionMiddleware` that allowed session cookie forgery when `SECRET_KEY` was not set in the environment
- Production deployments (where `GOOGLE_CLIENT_ID` is set) now fail fast at startup with a clear message if `SECRET_KEY` is missing
- Local dev without auth (`GOOGLE_CLIENT_ID` unset) still starts normally using a throwaway key

Resolves security advisory [GHSA-mvc7-m487-7fx3](https://github.com/wcmchenry3-stack/office_holder_cursor/security/advisories/GHSA-mvc7-m487-7fx3).

## Action required before merging

Ensure `SECRET_KEY` is set in your Render environment variables. Generate one with:
```bash
python -c "import secrets; print(secrets.token_hex(32))"
```

## Test plan

- [ ] Verify existing tests pass (`python -m pytest`)
- [ ] Confirm local dev starts without `SECRET_KEY` set (auth disabled path)
- [ ] Confirm Render deploy succeeds with `SECRET_KEY` set in env vars
- [ ] After merge, mark GHSA-mvc7-m487-7fx3 as patched in the Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)