### PR TITLE
security: remove hardcoded email addresses from render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -31,9 +31,9 @@ services:
       - key: EMAIL_APP_PASSWORD
         sync: false
       - key: EMAIL_FROM
-        value: wcmchenry3@gmail.com
+        sync: false
       - key: EMAIL_TO
-        value: wcmchenry3@gmail.com
+        sync: false
       - key: DAILY_DELTA_ENABLED
         value: "1"
       - key: APP_ENVIRONMENT


### PR DESCRIPTION
## Summary
- `EMAIL_FROM` and `EMAIL_TO` were hardcoded as plaintext values in `render.yaml`, exposing PII in a public repository
- Switched both to `sync: false` — values are already set in the Render dashboard

Resolves GHSA-whg5-5mxh-f997

## Test plan
- [ ] Verify `EMAIL_FROM` and `EMAIL_TO` are set in Render env vars (already confirmed)
- [ ] Deploy and confirm scheduled emails still send correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)