### PR TITLE
refactor: replace per-record GH issues with single summary issue

### DIFF
--- a/.claude/hooks/lint-gate.sh
+++ b/.claude/hooks/lint-gate.sh
@@ -18,14 +18,14 @@ REPORT=""
 
 # ── Python linting (black + ruff) ───────────────────────────────
 if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ]; then
-  if command -v black &>/dev/null; then
-    OUT=$(black --check --quiet . 2>&1) || {
+  if command -v black &>/dev/null || python -m black --version &>/dev/null 2>&1; then
+    OUT=$(python -m black --check --quiet . 2>&1) || {
       FAIL=1
       REPORT+="## black\n${OUT}\n\n"
     }
   fi
-  if command -v ruff &>/dev/null; then
-    OUT=$(ruff check --no-fix . 2>&1) || {
+  if command -v ruff &>/dev/null || python -m ruff --version &>/dev/null 2>&1; then
+    OUT=$(python -m ruff check --no-fix . 2>&1) || {
       FAIL=1
       REPORT+="## ruff\n${OUT}\n\n"
     }

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -688,6 +688,19 @@ def _run_pg_migrations(conn) -> None:
         "pg_office_table_config_cache_batch_backfill",
         "UPDATE office_table_config SET cache_batch = id % 7 WHERE cache_batch = 0",
     )
+    _apply(
+        "pg_create_structural_change_events",
+        "CREATE TABLE IF NOT EXISTS structural_change_events ("
+        " id SERIAL PRIMARY KEY,"
+        " tc_id INTEGER,"
+        " office_name TEXT,"
+        " page_url TEXT,"
+        " prev_rate REAL,"
+        " new_rate REAL,"
+        " drop_pp REAL,"
+        " resolved BOOLEAN NOT NULL DEFAULT FALSE,"
+        " created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
+    )
 
 
 def _sqlite_add_columns_if_missing(conn) -> None:

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -363,6 +363,19 @@ CREATE TABLE IF NOT EXISTS suspect_record_flags (
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- structural_change_events: fill-rate drops that indicate a Wikipedia table layout change.
+CREATE TABLE IF NOT EXISTS structural_change_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tc_id INTEGER,
+    office_name TEXT,
+    page_url TEXT,
+    prev_rate REAL,
+    new_rate REAL,
+    drop_pp REAL,
+    resolved INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- nolink_supersede_log: audit trail for no-link placeholder lifecycle events.
 -- Each row records when a "No link:…" placeholder was retired in favour of a real-URL individual.
 CREATE TABLE IF NOT EXISTS nolink_supersede_log (
@@ -769,6 +782,19 @@ CREATE TABLE IF NOT EXISTS suspect_record_flags (
     ai_votes TEXT,
     result TEXT NOT NULL DEFAULT 'skipped',
     gh_issue_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- structural_change_events: fill-rate drops that indicate a Wikipedia table layout change.
+CREATE TABLE IF NOT EXISTS structural_change_events (
+    id SERIAL PRIMARY KEY,
+    tc_id INTEGER,
+    office_name TEXT,
+    page_url TEXT,
+    prev_rate REAL,
+    new_rate REAL,
+    drop_pp REAL,
+    resolved BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/src/db/structural_change_events.py
+++ b/src/db/structural_change_events.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""CRUD helpers for the structural_change_events table."""
+
+from __future__ import annotations
+
+from src.db.connection import get_connection
+
+
+def insert_event(
+    tc_id: int | None,
+    office_name: str | None,
+    page_url: str | None,
+    prev_rate: float,
+    new_rate: float,
+    drop_pp: float,
+    conn=None,
+) -> int:
+    """Log one structural change detection. Returns the new row id."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cur = conn.execute(
+            "INSERT INTO structural_change_events"
+            " (tc_id, office_name, page_url, prev_rate, new_rate, drop_pp)"
+            " VALUES (%s, %s, %s, %s, %s, %s)"
+            " RETURNING id",
+            (tc_id, office_name, page_url, prev_rate, new_rate, drop_pp),
+        )
+        row = cur.fetchone()
+        if own_conn:
+            conn.commit()
+        return row[0] if row else 0
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def list_unresolved(conn=None) -> list[dict]:
+    """Return all unresolved structural change events, newest first."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        cur = conn.execute(
+            "SELECT id, tc_id, office_name, page_url, prev_rate, new_rate, drop_pp, created_at"
+            " FROM structural_change_events"
+            " WHERE resolved = FALSE OR resolved = 0"
+            " ORDER BY id DESC"
+        )
+        keys = ["id", "tc_id", "office_name", "page_url", "prev_rate", "new_rate", "drop_pp", "created_at"]
+        return [dict(zip(keys, row)) for row in cur.fetchall()]
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def mark_resolved(event_id: int, conn=None) -> None:
+    """Mark a structural change event as resolved."""
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE structural_change_events SET resolved = TRUE WHERE id = %s",
+            (event_id,),
+        )
+        if own_conn:
+            conn.commit()
+    finally:
+        if own_conn:
+            conn.close()

--- a/src/db/structural_change_events.py
+++ b/src/db/structural_change_events.py
@@ -48,7 +48,16 @@ def list_unresolved(conn=None) -> list[dict]:
             " WHERE resolved = FALSE OR resolved = 0"
             " ORDER BY id DESC"
         )
-        keys = ["id", "tc_id", "office_name", "page_url", "prev_rate", "new_rate", "drop_pp", "created_at"]
+        keys = [
+            "id",
+            "tc_id",
+            "office_name",
+            "page_url",
+            "prev_rate",
+            "new_rate",
+            "drop_pp",
+            "created_at",
+        ]
         return [dict(zip(keys, row)) for row in cur.fetchall()]
     finally:
         if own_conn:

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -525,6 +525,11 @@ def _check_fill_rate_drop(office_row: dict, new_rate: float) -> None:
         if gh is None:
             return
         title = f"[Structural change] Link fill rate dropped {drop * 100:.0f}pp: {office_name}"
+
+        if gh.find_open_issue_by_title(title, "structural-change"):
+            _log.debug("Dedup: open structural-change issue already exists for '%s'", title)
+            return
+
         body = (
             f"## Wikipedia table structure may have changed\n\n"
             f"**Office:** {office_name}\n"

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -3100,6 +3100,7 @@ def run_with_db(
         if not dry_run and not test_run:
             try:
                 from src.services.summary_issue_reporter import refresh as _refresh_summary
+
                 _refresh_summary(conn=conn)
             except Exception as _summary_err:
                 _log.warning("Summary issue refresh failed (run not affected): %s", _summary_err)

--- a/src/scraper/runner.py
+++ b/src/scraper/runner.py
@@ -519,33 +519,21 @@ def _check_fill_rate_drop(office_row: dict, new_rate: float) -> None:
         drop * 100,
     )
     try:
-        from src.services.github_client import get_github_client
+        from src.db import structural_change_events as db_sce
 
-        gh = get_github_client()
-        if gh is None:
-            return
-        title = f"[Structural change] Link fill rate dropped {drop * 100:.0f}pp: {office_name}"
-
-        if gh.find_open_issue_by_title(title, "structural-change"):
-            _log.debug("Dedup: open structural-change issue already exists for '%s'", title)
-            return
-
-        body = (
-            f"## Wikipedia table structure may have changed\n\n"
-            f"**Office:** {office_name}\n"
-            f"**Source page URL:** {page_url}\n"
-            f"**office_table_config id:** {tc_id}\n\n"
-            f"| Metric | Value |\n"
-            f"|---|---|\n"
-            f"| Previous fill rate | {prev_rate * 100:.1f}% |\n"
-            f"| Current fill rate  | {new_rate * 100:.1f}% |\n"
-            f"| Drop               | {drop * 100:.1f}pp |\n\n"
-            f"A drop of more than 30 percentage points suggests the Wikipedia table "
-            f"column layout has changed. Please review the page and update `office_table_config`."
+        db_sce.insert_event(
+            tc_id=tc_id,
+            office_name=str(office_name),
+            page_url=page_url,
+            prev_rate=prev_rate,
+            new_rate=new_rate,
+            drop_pp=drop,
         )
-        gh.create_issue(title=title, body=body, labels=["structural-change"])
+        _log.info(
+            "Logged structural change event for office '%s' (drop=%.0f%%)", office_name, drop * 100
+        )
     except Exception:
-        _log.exception("_check_fill_rate_drop: failed to create GH issue")
+        _log.exception("_check_fill_rate_drop: failed to log structural change event")
 
 
 def _suspect_gate(
@@ -3107,6 +3095,14 @@ def run_with_db(
             "Done",
             {"terms_parsed": total_terms, "unique_wiki_urls": len(unique_wiki_urls)},
         )
+
+        # Refresh the single summary GH issue with all outstanding data quality items
+        if not dry_run and not test_run:
+            try:
+                from src.services.summary_issue_reporter import refresh as _refresh_summary
+                _refresh_summary(conn=conn)
+            except Exception as _summary_err:
+                _log.warning("Summary issue refresh failed (run not affected): %s", _summary_err)
 
         # Preview rows: same filter/normalize as import so UI shows exactly what would be in the table (include dead-link / name-only rows)
         preview_rows = _build_preview_rows(all_office_data) if (dry_run or test_run) else None

--- a/src/services/github_client.py
+++ b/src/services/github_client.py
@@ -190,6 +190,18 @@ class GitHubClient:
             logger.exception("Failed to create PR: %s", title)
             return None
 
+    def find_open_issue_by_title(self, title: str, label: str) -> dict | None:
+        """Return the first open issue with the given label whose title matches exactly.
+
+        Uses list_open_issues_by_label so no extra API surface is needed.
+        Returns None if no match or on error.
+        """
+        issues = self.list_open_issues_by_label(label)
+        for issue in issues:
+            if issue.get("title") == title:
+                return issue
+        return None
+
     def create_issue(self, title: str, body: str, labels: list[str]) -> dict:
         """Create a new GitHub issue. Returns the response dict.
 

--- a/src/services/github_client.py
+++ b/src/services/github_client.py
@@ -202,6 +202,15 @@ class GitHubClient:
                 return issue
         return None
 
+    def update_issue(self, number: int, body: str) -> dict | None:
+        """Update the body of an existing issue. Returns the response dict or None on failure."""
+        url = f"{_GITHUB_API_BASE}/repos/{self._repo}/issues/{number}"
+        try:
+            return self._patch(url, json={"body": body})
+        except RuntimeError:
+            logger.exception("Failed to update issue #%d", number)
+            return None
+
     def create_issue(self, title: str, body: str, labels: list[str]) -> dict:
         """Create a new GitHub issue. Returns the response dict.
 
@@ -266,6 +275,31 @@ class GitHubClient:
                     f"GitHub PUT failed with HTTP {exc.response.status_code}"
                 ) from exc
         raise RuntimeError("GitHub PUT: unreachable after retry loop")
+
+    def _patch(self, url: str, json: dict) -> dict:
+        backoff = 1.0
+        for attempt in range(3):
+            try:
+                resp = httpx.patch(url, headers=self._headers, json=json, timeout=15.0)
+                if resp.status_code == 429:
+                    if attempt == 2:
+                        raise RuntimeError(f"GitHub PATCH rate-limited after 3 attempts: {url}")
+                    logger.warning(
+                        "GitHub PATCH rate-limited; retrying in %.0f s (attempt %d/3)",
+                        backoff,
+                        attempt + 1,
+                    )
+                    import time
+                    time.sleep(backoff)
+                    backoff *= 2
+                    continue
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.HTTPStatusError as exc:
+                raise RuntimeError(
+                    f"GitHub PATCH failed with HTTP {exc.response.status_code}"
+                ) from exc
+        raise RuntimeError("GitHub PATCH: unreachable after retry loop")
 
     def _post(self, url: str, json: dict) -> dict:
         backoff = 1.0

--- a/src/services/github_client.py
+++ b/src/services/github_client.py
@@ -290,6 +290,7 @@ class GitHubClient:
                         attempt + 1,
                     )
                     import time
+
                     time.sleep(backoff)
                     backoff *= 2
                     continue

--- a/src/services/summary_issue_reporter.py
+++ b/src/services/summary_issue_reporter.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Maintain a single GitHub issue that lists all outstanding data quality items.
+
+Instead of one GH issue per event, this reporter aggregates:
+  - structural_change_events (unresolved fill-rate drops)
+  - suspect_record_flags (result='needs_review')
+
+into one issue that is created on first run and updated body-in-place on
+subsequent runs.  The issue is identified by the label ``summary-report``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+_SUMMARY_LABEL = "summary-report"
+_SUMMARY_TITLE = "[Action Required] Open data quality issues"
+
+
+def _fmt_date(value) -> str:
+    if value is None:
+        return "—"
+    s = str(value)
+    return s[:10]  # YYYY-MM-DD from ISO string or datetime
+
+
+def _build_body(structural: list[dict], suspects: list[dict]) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    total = len(structural) + len(suspects)
+
+    lines = [
+        "## Open Data Quality Issues",
+        "",
+        f"_Last updated: {now} — **{total}** item(s) require attention._",
+        "_Resolve structural changes by updating `office_table_config`."
+        " Resolve suspect records by re-scraping the office after confirming the data._",
+        "",
+    ]
+
+    lines += [
+        f"### Structural Changes ({len(structural)})",
+        "",
+    ]
+    if structural:
+        lines += [
+            "| # | Office | Drop | Page | Detected |",
+            "|---|---|---|---|---|",
+        ]
+        for row in structural:
+            drop = f"{row['drop_pp'] * 100:.0f}pp" if row["drop_pp"] else "—"
+            page = f"[link]({row['page_url']})" if row.get("page_url") else "—"
+            lines.append(
+                f"| {row['id']} | {row['office_name'] or '—'} | {drop} | {page} | {_fmt_date(row['created_at'])} |"
+            )
+    else:
+        lines.append("_No unresolved structural changes._")
+
+    lines += [
+        "",
+        f"### Suspect Records ({len(suspects)})",
+        "",
+    ]
+    if suspects:
+        lines += [
+            "| # | Office ID | Name | Verdict | Flagged |",
+            "|---|---|---|---|---|",
+        ]
+        for row in suspects:
+            lines.append(
+                f"| {row['id']} | {row['office_id'] or '—'} | {row['full_name'] or '—'}"
+                f" | {row['result']} | {_fmt_date(row['created_at'])} |"
+            )
+    else:
+        lines.append("_No suspect records awaiting review._")
+
+    return "\n".join(lines)
+
+
+def refresh(conn=None) -> str | None:
+    """Create or update the single summary GH issue. Returns the issue URL or None.
+
+    Gracefully degrades when GITHUB_TOKEN is not set.
+    """
+    from src.services.github_client import get_github_client
+
+    gh = get_github_client()
+    if gh is None:
+        logger.debug("SummaryIssueReporter: GITHUB_TOKEN not set; skipping")
+        return None
+
+    from src.db import structural_change_events as db_sce
+    from src.db import suspect_record_flags as db_flags
+    from src.db.connection import get_connection
+
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+
+    try:
+        structural = db_sce.list_unresolved(conn=conn)
+        suspects = [r for r in db_flags.list_recent(limit=500, conn=conn) if r.get("result") == "needs_review"]
+
+        body = _build_body(structural, suspects)
+
+        existing = gh.find_open_issue_by_title(_SUMMARY_TITLE, _SUMMARY_LABEL)
+        if existing:
+            number = existing["number"]
+            gh.update_issue(number, body)
+            url = existing["html_url"]
+            logger.info("Updated summary issue #%d (%d items)", number, len(structural) + len(suspects))
+        else:
+            resp = gh.create_issue(title=_SUMMARY_TITLE, body=body, labels=[_SUMMARY_LABEL])
+            url = resp["html_url"]
+            logger.info("Created summary issue %s (%d items)", url, len(structural) + len(suspects))
+
+        return url
+    except Exception:
+        logger.exception("SummaryIssueReporter.refresh failed")
+        return None
+    finally:
+        if own_conn:
+            conn.close()

--- a/src/services/summary_issue_reporter.py
+++ b/src/services/summary_issue_reporter.py
@@ -101,7 +101,11 @@ def refresh(conn=None) -> str | None:
 
     try:
         structural = db_sce.list_unresolved(conn=conn)
-        suspects = [r for r in db_flags.list_recent(limit=500, conn=conn) if r.get("result") == "needs_review"]
+        suspects = [
+            r
+            for r in db_flags.list_recent(limit=500, conn=conn)
+            if r.get("result") == "needs_review"
+        ]
 
         body = _build_body(structural, suspects)
 
@@ -110,7 +114,9 @@ def refresh(conn=None) -> str | None:
             number = existing["number"]
             gh.update_issue(number, body)
             url = existing["html_url"]
-            logger.info("Updated summary issue #%d (%d items)", number, len(structural) + len(suspects))
+            logger.info(
+                "Updated summary issue #%d (%d items)", number, len(structural) + len(suspects)
+            )
         else:
             resp = gh.create_issue(title=_SUMMARY_TITLE, body=body, labels=[_SUMMARY_LABEL])
             url = resp["html_url"]

--- a/src/services/suspect_record_flagger.py
+++ b/src/services/suspect_record_flagger.py
@@ -13,8 +13,8 @@ Pattern triggers (no API cost — fast, deterministic):
 Consensus outcomes (via ConsensusVoter — all 3 AIs in parallel):
   - VALID              → insert normally; log to suspect_record_flags (result='allowed')
   - INVALID            → skip; log (result='skipped')
-  - DISAGREEMENT       → skip; create GH issue; log (result='gh_issue')
-  - INSUFFICIENT_QUORUM→ skip; create GH issue; log (result='gh_issue')
+  - DISAGREEMENT       → skip; log (result='needs_review') for summary issue reporter
+  - INSUFFICIENT_QUORUM→ skip; log (result='needs_review') for summary issue reporter
 
 Graceful degradation: if all 3 AI clients unavailable (INSUFFICIENT_QUORUM),
 the record is skipped and logged conservatively.
@@ -92,70 +92,6 @@ def detect_suspicious_patterns(full_name: str | None, wiki_url: str | None) -> l
 
 
 # ---------------------------------------------------------------------------
-# GH issue helper
-# ---------------------------------------------------------------------------
-
-_GH_LABEL = "suspect-record"
-
-
-def _create_gh_issue(
-    full_name: str | None,
-    wiki_url: str | None,
-    office_id: int,
-    flag_reasons: list[str],
-    verdict_name: str,
-    ai_votes_summary: str,
-    source_page_url: str | None = None,
-    row_data: dict | None = None,
-) -> str | None:
-    """Create a GitHub issue for manual review. Returns the issue URL or None."""
-    try:
-        from src.services.github_client import get_github_client
-
-        gh = get_github_client()
-        if gh is None:
-            return None
-
-        title = f"[Suspect record] {full_name or wiki_url or 'unknown'} (office {office_id})"
-
-        existing = gh.find_open_issue_by_title(title, _GH_LABEL)
-        if existing:
-            logger.debug("Dedup: open issue already exists for '%s'", title)
-            return existing.get("html_url")
-
-        source_section = ""
-        if source_page_url or row_data:
-            source_section = "\n\n### Source\n"
-            if source_page_url:
-                source_section += f"**Page URL:** {source_page_url}\n"
-            if row_data:
-                import json as _json
-
-                source_section += (
-                    "**Parsed row data:**\n```json\n"
-                    + _json.dumps(row_data, default=str, indent=2)
-                    + "\n```"
-                )
-
-        body = (
-            f"## Suspect record flagged at parse time\n\n"
-            f"**Verdict:** {verdict_name}\n"
-            f"**Office ID:** {office_id}\n"
-            f"**full_name:** `{full_name}`\n"
-            f"**wiki_url:** `{wiki_url}`\n\n"
-            f"### Pattern triggers\n"
-            + "\n".join(f"- {r}" for r in flag_reasons)
-            + f"\n\n### AI votes\n{ai_votes_summary}"
-            + source_section
-            + "\n\nThis record was **not inserted** into the database. "
-            "Please investigate and re-scrape the office if the record is legitimate."
-        )
-        result = gh.create_issue(title=title, body=body, labels=[_GH_LABEL])
-        return result.get("html_url")
-    except Exception:
-        logger.exception("Failed to create GH issue for suspect record")
-        return None
-
 
 # ---------------------------------------------------------------------------
 # Main gate function
@@ -231,20 +167,9 @@ def check_and_gate(
             return True, flag_id
 
         # INVALID, DISAGREEMENT, or INSUFFICIENT_QUORUM → skip
-        gh_url: str | None = None
         result_str = "skipped"
         if verdict in (Verdict.DISAGREEMENT, Verdict.INSUFFICIENT_QUORUM):
-            result_str = "gh_issue"
-            gh_url = _create_gh_issue(
-                full_name=full_name,
-                wiki_url=wiki_url,
-                office_id=office_id,
-                flag_reasons=reasons,
-                verdict_name=verdict.value,
-                ai_votes_summary=ai_votes_summary,
-                source_page_url=source_page_url,
-                row_data=row_data,
-            )
+            result_str = "needs_review"
 
         flag_id = db_flags.insert_flag(
             office_id=office_id,
@@ -253,15 +178,13 @@ def check_and_gate(
             flag_reasons=reasons,
             ai_votes=ai_votes_dicts,
             result=result_str,
-            gh_issue_url=gh_url,
             conn=conn,
         )
         logger.warning(
-            "Suspect record SKIPPED (verdict=%s, office=%d, name=%r, gh=%s)",
+            "Suspect record SKIPPED (verdict=%s, office=%d, name=%r)",
             verdict.value,
             office_id,
             full_name,
-            gh_url or "none",
         )
         return False, flag_id
 

--- a/src/services/suspect_record_flagger.py
+++ b/src/services/suspect_record_flagger.py
@@ -118,6 +118,11 @@ def _create_gh_issue(
 
         title = f"[Suspect record] {full_name or wiki_url or 'unknown'} (office {office_id})"
 
+        existing = gh.find_open_issue_by_title(title, _GH_LABEL)
+        if existing:
+            logger.debug("Dedup: open issue already exists for '%s'", title)
+            return existing.get("html_url")
+
         source_section = ""
         if source_page_url or row_data:
             source_section = "\n\n### Source\n"

--- a/tests/test_structural_change_detection.py
+++ b/tests/test_structural_change_detection.py
@@ -142,47 +142,47 @@ class TestCheckFillRateDrop:
             _check_fill_rate_drop(_office_row(prev_rate=0.80), new_rate=0.51)
         mock_gh.assert_not_called()
 
-    def test_drop_above_threshold_creates_gh_issue(self):
+    def test_drop_above_threshold_logs_to_db(self, tmp_path):
         from src.scraper.runner import _check_fill_rate_drop
 
-        mock_gh_client = MagicMock()
-        mock_gh_client.create_issue.return_value = {
-            "html_url": "https://github.com/org/repo/issues/1"
-        }
+        inserted = {}
 
-        with patch("src.services.github_client.get_github_client", return_value=mock_gh_client):
+        def fake_insert(tc_id, office_name, page_url, prev_rate, new_rate, drop_pp, conn=None):
+            inserted.update(
+                {
+                    "tc_id": tc_id,
+                    "office_name": office_name,
+                    "prev_rate": prev_rate,
+                    "new_rate": new_rate,
+                    "drop_pp": drop_pp,
+                }
+            )
+            return 1
+
+        with patch("src.db.structural_change_events.insert_event", side_effect=fake_insert):
             _check_fill_rate_drop(_office_row(prev_rate=0.90), new_rate=0.50)
 
-        mock_gh_client.create_issue.assert_called_once()
-        call_kwargs = mock_gh_client.create_issue.call_args.kwargs
-        assert "structural-change" in call_kwargs["labels"]
-        assert "40" in call_kwargs["title"]  # 40pp drop
+        assert inserted["office_name"] == "Test Office"
+        assert abs(inserted["drop_pp"] - 0.40) < 0.01
+        assert inserted["prev_rate"] == pytest.approx(0.90)
+        assert inserted["new_rate"] == pytest.approx(0.50)
 
-    def test_issue_body_contains_rates(self):
+    def test_drop_above_threshold_does_not_create_gh_issue(self):
         from src.scraper.runner import _check_fill_rate_drop
 
-        mock_gh_client = MagicMock()
-        mock_gh_client.create_issue.return_value = {}
-
-        with patch("src.services.github_client.get_github_client", return_value=mock_gh_client):
-            _check_fill_rate_drop(_office_row(prev_rate=0.80), new_rate=0.40)
-
-        body = mock_gh_client.create_issue.call_args.kwargs["body"]
-        assert "80.0%" in body
-        assert "40.0%" in body
-
-    def test_gh_client_unavailable_does_not_raise(self):
-        from src.scraper.runner import _check_fill_rate_drop
-
-        with patch("src.services.github_client.get_github_client", return_value=None):
-            # Should not raise
+        with patch("src.db.structural_change_events.insert_event", return_value=1), patch(
+            "src.services.github_client.get_github_client"
+        ) as mock_gh:
             _check_fill_rate_drop(_office_row(prev_rate=0.90), new_rate=0.50)
 
-    def test_gh_exception_swallowed(self):
+        mock_gh.assert_not_called()
+
+    def test_exception_swallowed(self):
         from src.scraper.runner import _check_fill_rate_drop
 
         with patch(
-            "src.services.github_client.get_github_client", side_effect=RuntimeError("api down")
+            "src.db.structural_change_events.insert_event",
+            side_effect=RuntimeError("db down"),
         ):
             # Should not raise
             _check_fill_rate_drop(_office_row(prev_rate=0.90), new_rate=0.50)

--- a/tests/test_suspect_record_flagger.py
+++ b/tests/test_suspect_record_flagger.py
@@ -250,39 +250,26 @@ class TestCheckAndGateSkipped:
         assert rows[0]["result"] == "skipped"
 
 
-class TestCheckAndGateGhIssue:
-    def test_disagreement_creates_gh_issue(self, tmp_path):
+class TestCheckAndGateNeedsReview:
+    def test_disagreement_logs_needs_review(self, tmp_path):
         conn = _conn(tmp_path)
         mock_voter = MagicMock()
         mock_voter.vote.return_value = _make_verdict(Verdict.DISAGREEMENT)
-        with (
-            patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter),
-            patch(
-                "src.services.suspect_record_flagger._create_gh_issue",
-                return_value="https://github.com/org/repo/issues/99",
-            ),
-        ):
+        with patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter):
             should_insert, flag_id = check_and_gate("1978", "No link:94:1978", 94, conn)
         assert should_insert is False
         rows = db_flags.list_recent(conn=conn)
-        assert rows[0]["result"] == "gh_issue"
-        assert rows[0]["gh_issue_url"] == "https://github.com/org/repo/issues/99"
+        assert rows[0]["result"] == "needs_review"
 
-    def test_insufficient_quorum_creates_gh_issue(self, tmp_path):
+    def test_insufficient_quorum_logs_needs_review(self, tmp_path):
         conn = _conn(tmp_path)
         mock_voter = MagicMock()
         mock_voter.vote.return_value = _make_verdict(Verdict.INSUFFICIENT_QUORUM)
-        with (
-            patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter),
-            patch(
-                "src.services.suspect_record_flagger._create_gh_issue",
-                return_value=None,
-            ),
-        ):
+        with patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter):
             should_insert, flag_id = check_and_gate("1978", "No link:94:1978", 94, conn)
         assert should_insert is False
         rows = db_flags.list_recent(conn=conn)
-        assert rows[0]["result"] == "gh_issue"
+        assert rows[0]["result"] == "needs_review"
 
 
 class TestCheckAndGateErrorHandling:
@@ -297,82 +284,3 @@ class TestCheckAndGateErrorHandling:
         assert flag_id is None
 
 
-# ---------------------------------------------------------------------------
-# GH issue enrichment: source_page_url + row_data (#400)
-# ---------------------------------------------------------------------------
-
-
-class TestCreateGhIssueEnrichment:
-    """_create_gh_issue includes source_page_url and row_data in the issue body."""
-
-    def _call(self, source_page_url=None, row_data=None):
-        from src.services.suspect_record_flagger import _create_gh_issue
-
-        captured = {}
-
-        def fake_create_issue(title, body, labels):
-            captured["body"] = body
-            return {"html_url": "https://github.com/org/repo/issues/1"}
-
-        mock_gh = MagicMock()
-        mock_gh.create_issue.side_effect = fake_create_issue
-        mock_gh.find_open_issue_by_title.return_value = None
-
-        with patch("src.services.github_client.get_github_client", return_value=mock_gh):
-            _create_gh_issue(
-                full_name="1999",
-                wiki_url="No link:42:1999",
-                office_id=42,
-                flag_reasons=["full_name is a 4-digit year: '1999'"],
-                verdict_name="disagreement",
-                ai_votes_summary="- **claude**: invalid",
-                source_page_url=source_page_url,
-                row_data=row_data,
-            )
-        return captured.get("body", "")
-
-    def test_source_page_url_appears_in_body(self):
-        body = self._call(source_page_url="https://en.wikipedia.org/wiki/Some_Office")
-        assert "### Source" in body
-        assert "https://en.wikipedia.org/wiki/Some_Office" in body
-
-    def test_row_data_appears_as_json_block(self):
-        row_data = {"Name": "1999", "Term start": "1999", "Term end": "2000"}
-        body = self._call(row_data=row_data)
-        assert "### Source" in body
-        assert "```json" in body
-        assert '"Name": "1999"' in body
-
-    def test_no_source_section_when_both_none(self):
-        body = self._call()
-        assert "### Source" not in body
-
-    def test_check_and_gate_passes_source_url_to_gh_issue(self, tmp_path):
-        """check_and_gate forwards source_page_url to _create_gh_issue."""
-        conn = _conn(tmp_path)
-        mock_voter = MagicMock()
-        mock_voter.vote.return_value = _make_verdict(Verdict.DISAGREEMENT)
-        captured = {}
-
-        def fake_gh_issue(**kwargs):
-            captured.update(kwargs)
-            return "https://github.com/org/repo/issues/2"
-
-        with (
-            patch("src.services.suspect_record_flagger.ConsensusVoter", return_value=mock_voter),
-            patch(
-                "src.services.suspect_record_flagger._create_gh_issue",
-                side_effect=fake_gh_issue,
-            ),
-        ):
-            check_and_gate(
-                full_name="1978",
-                wiki_url="No link:94:1978",
-                office_id=94,
-                conn=conn,
-                source_page_url="https://en.wikipedia.org/wiki/Test_Office",
-                row_data={"Name": "1978"},
-            )
-
-        assert captured.get("source_page_url") == "https://en.wikipedia.org/wiki/Test_Office"
-        assert captured.get("row_data") == {"Name": "1978"}

--- a/tests/test_suspect_record_flagger.py
+++ b/tests/test_suspect_record_flagger.py
@@ -316,6 +316,7 @@ class TestCreateGhIssueEnrichment:
 
         mock_gh = MagicMock()
         mock_gh.create_issue.side_effect = fake_create_issue
+        mock_gh.find_open_issue_by_title.return_value = None
 
         with patch("src.services.github_client.get_github_client", return_value=mock_gh):
             _create_gh_issue(

--- a/tests/test_suspect_record_flagger.py
+++ b/tests/test_suspect_record_flagger.py
@@ -282,5 +282,3 @@ class TestCheckAndGateErrorHandling:
             should_insert, flag_id = check_and_gate("1978", "", 94, conn)
         assert should_insert is True
         assert flag_id is None
-
-


### PR DESCRIPTION
## Summary
- Adds `structural_change_events` table to log fill-rate drops (both SQLite schema + PG migration)
- `_check_fill_rate_drop` in `runner.py` now logs to the table instead of creating a per-event GH issue
- `suspect_record_flagger`: removes `_create_gh_issue`; DISAGREEMENT / INSUFFICIENT_QUORUM now store `result='needs_review'` in `suspect_record_flags`
- New `GitHubClient.update_issue()` / `_patch()` for editing issue bodies in-place
- New `SummaryIssueReporter` (`summary_issue_reporter.py`) queries both tables and upserts a single `[Action Required] Open data quality issues` GH issue (label: `summary-report`) at the end of each non-dry runner run
- All 88 individual `suspect-record` / `structural-change` GH issues closed; the summary issue will be created on the next runner run
- Also includes the `lint-gate.sh` fix (use `python -m black/ruff` on Python 3.14)

Closes #601.

## Test plan
- [x] 35 tests pass (`test_suspect_record_flagger.py`, `test_quality_issue_reporter.py`)
- [x] Full test suite passes
- [ ] Verify next runner run creates/updates the single summary issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)