### PR TITLE
fix: bound _infobox_cache to 500 entries (LRU) to stop memory baseline creep

### DIFF
--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -10,6 +10,7 @@ See: https://www.mediawiki.org/wiki/API:Etiquette#The_User-Agent_header
 import copy
 import logging
 import re
+from collections import OrderedDict
 from datetime import datetime, date
 from urllib.parse import urlparse, quote
 
@@ -590,8 +591,10 @@ class Offices:
 
         # Run-level infobox cache: persists across tables for the same parser instance so the
         # same individual appearing in multiple tables only pays one HTTP infobox call per run.
+        # Bounded to 500 entries (LRU) to prevent unbounded heap growth across nightly batch runs.
         if not hasattr(self, "_infobox_cache"):
-            self._infobox_cache = {}
+            self._infobox_cache: OrderedDict[str, dict] = OrderedDict()
+            self._infobox_cache_max: int = 500
         # tracks the previous entry --> this helps the rowspan function track
         previous_row_wiki_link = None
         previous_row_district = None
@@ -1330,6 +1333,7 @@ class Offices:
                         return [existing]
                 cache = getattr(self, "_infobox_cache", None)
                 if cache is not None and wiki_link in cache:
+                    cache.move_to_end(wiki_link)
                     cached = cache[wiki_link]
                     terms_list = cached["terms"]
                     infobox_items = cached["infobox_items"]
@@ -1351,6 +1355,8 @@ class Offices:
                             "infobox_items": infobox_items,
                             "bio_details": getattr(self.Biography, "_last_bio_details", None),
                         }
+                        if len(cache) > self._infobox_cache_max:
+                            cache.popitem(last=False)
                 logger.debug(f" find_term_dates returned {len(terms_list)} term(s) from infobox")
                 # When infobox had no dates (placeholder), use table years only for this record (same as "table has years only")
                 if (


### PR DESCRIPTION
## Summary
- Replaces the unbounded `_infobox_cache = {}` dict in `Offices.process_table` (`table_parser.py:594`) with an `OrderedDict`-backed LRU capped at 500 entries
- On cache write, evicts the oldest entry when capacity is exceeded (`popitem(last=False)`)
- On cache read, promotes the accessed entry to MRU (`move_to_end`) so least-recently-used entries are evicted first
- Adds `from collections import OrderedDict` import

Closes #615

## Why this fixes the memory baseline creep
The old plain dict accumulated infobox HTML/data (50–500 KB per entry) for every unique individual scraped across all nightly batch runs without any eviction. Over a week of daily runs this grew the idle heap by ~75 MB. The 500-entry cap bounds the cache to roughly 25–250 MB worst-case, but in practice nightly delta runs touch far fewer individuals so actual working size will be well under 50 MB.

The same LRU pattern already exists in `RunPageCache` (`src/scraper/run_cache.py`) — this change mirrors it exactly.

## Test plan
- [ ] `python -m pytest --ignore=tests/test_playwright.py` passes (verified locally, exit 0)
- [ ] CI green
- [ ] After merging + deploying, Render memory baseline should stabilize and no longer creep between deploys (verify over 3–5 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)