### PR TITLE
chore: merge dev into main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,16 @@ Before every push: `python -m pytest` — all non-Playwright tests must pass.
 
 Finish: push commits → open PR `feature/<name>` → `dev` on GitHub.
 
+## Available Agents
+
+These project subagents live in `.claude/agents/` and are invoked via the `Agent` tool (not Skill). Always prefer them over a general-purpose agent for their domain.
+
+| Agent | `subagent_type` | When to use |
+|---|---|---|
+| lint-review | `lint-review` | Auto-fix lint issues after a lint-gate hook failure |
+| plan-issues | `plan-issues` | Break a feature/bug/initiative into scoped GitHub issues — investigates code first, drafts for confirmation, then calls `gh issue create` |
+| policy-compliance | `policy-compliance` | Check and fix policy violations after a policy-gate hook failure |
+
 ## Documentation
 
 | File | Contents |

--- a/src/scraper/table_parser.py
+++ b/src/scraper/table_parser.py
@@ -10,6 +10,7 @@ See: https://www.mediawiki.org/wiki/API:Etiquette#The_User-Agent_header
 import copy
 import logging
 import re
+from collections import OrderedDict
 from datetime import datetime, date
 from urllib.parse import urlparse, quote
 
@@ -590,8 +591,10 @@ class Offices:
 
         # Run-level infobox cache: persists across tables for the same parser instance so the
         # same individual appearing in multiple tables only pays one HTTP infobox call per run.
+        # Bounded to 500 entries (LRU) to prevent unbounded heap growth across nightly batch runs.
         if not hasattr(self, "_infobox_cache"):
-            self._infobox_cache = {}
+            self._infobox_cache: OrderedDict[str, dict] = OrderedDict()
+            self._infobox_cache_max: int = 500
         # tracks the previous entry --> this helps the rowspan function track
         previous_row_wiki_link = None
         previous_row_district = None
@@ -1330,6 +1333,7 @@ class Offices:
                         return [existing]
                 cache = getattr(self, "_infobox_cache", None)
                 if cache is not None and wiki_link in cache:
+                    cache.move_to_end(wiki_link)
                     cached = cache[wiki_link]
                     terms_list = cached["terms"]
                     infobox_items = cached["infobox_items"]
@@ -1351,6 +1355,8 @@ class Offices:
                             "infobox_items": infobox_items,
                             "bio_details": getattr(self.Biography, "_last_bio_details", None),
                         }
+                        if len(cache) > self._infobox_cache_max:
+                            cache.popitem(last=False)
                 logger.debug(f" find_term_dates returned {len(terms_list)} term(s) from infobox")
                 # When infobox had no dates (placeholder), use table years only for this record (same as "table has years only")
                 if (


### PR DESCRIPTION
## Summary
- Merges all changes accumulated on `dev` into `main` for production deployment
- Key changes since last merge:
  - **fix**: bound `_infobox_cache` to 500-entry LRU to stop memory baseline creep (#615)
  - **feat**: dedup suspect-record and structural-change GitHub issues; replace per-record issues with single summary issue (#602)
  - **security**: gitignore `render.yaml`, remove hardcoded email addresses (#597, #598)
  - **chore**: document available agents in `CLAUDE.md` (#612)
  - **ci**: tier CI workflow with fail-fast hygiene gates (#518)

## Test plan
- [ ] All CI checks green on `dev` before merge
- [ ] After deploy to `rulersai.buffingchi.com`, verify Render memory baseline stabilizes over next 3–5 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)