### PR TITLE
fix: use IS NOT TRUE in list_unresolved to fix Postgres boolean/integer type error

### DIFF
--- a/src/db/structural_change_events.py
+++ b/src/db/structural_change_events.py
@@ -45,7 +45,7 @@ def list_unresolved(conn=None) -> list[dict]:
         cur = conn.execute(
             "SELECT id, tc_id, office_name, page_url, prev_rate, new_rate, drop_pp, created_at"
             " FROM structural_change_events"
-            " WHERE resolved = FALSE OR resolved = 0"
+            " WHERE resolved IS NOT TRUE"
             " ORDER BY id DESC"
         )
         keys = [


### PR DESCRIPTION
## Summary

- Fixes `psycopg2.errors.UndefinedFunction: operator does not exist: boolean = integer` that was firing on every `daily_delta` run in Postgres environments (Sentry issue, 5 events, release `68bcb78dcdd4`).
- Root cause: `WHERE resolved = FALSE OR resolved = 0` in `list_unresolved` caused Postgres to reject the query at plan time — it has no `boolean = integer` operator. SQLite was permissive, so this wasn't caught locally.
- Fix: replaced with `WHERE resolved IS NOT TRUE`, which is valid in both Postgres (standard 3VL) and SQLite ≥ 3.23 (integer 0 is treated as falsy).
- Audited all other `resolved` comparisons in `src/db/` — no other occurrences of the same pattern.

Closes #614

## Test plan

- [x] All 909 existing tests pass (`python -m pytest tests/ -x -q`)
- [ ] Verify Sentry stops reporting `SummaryIssueReporter.refresh failed` after deploy to dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)