### PR TITLE
fix: add missing privacy.html, terms.html, and /security.txt to fix 404s on login footer links

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -20,7 +20,7 @@ python -m pytest                            # included in full suite
 ### A01 — Broken Access Control
 - **Policy**: Every non-public route must redirect unauthenticated users to `/login` when
   `GOOGLE_CLIENT_ID` is set. Public paths are limited to `/login`, `/auth/google`,
-  `/auth/google/callback`, and `/static/`.
+  `/auth/google/callback`, `/static/`, and `/security.txt`.
 - **Test**: `test_auth_middleware_redirects_unauthenticated_requests`,
   `test_auth_middleware_allows_public_paths`
 - **Dev note**: Auth is intentionally disabled locally when `GOOGLE_CLIENT_ID` is unset. Never

--- a/src/main.py
+++ b/src/main.py
@@ -233,7 +233,7 @@ _APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
 _AUTH_ENABLED = bool(os.environ.get("GOOGLE_CLIENT_ID"))
 
 # Auth middleware — skips public paths and dev mode (no GOOGLE_CLIENT_ID set)
-_PUBLIC_PATHS = {"/login", "/auth/google", "/auth/google/callback", "/security.txt"}
+_PUBLIC_PATHS = {"/login", "/auth/google", "/auth/google/callback", "/security.txt", "/.well-known/security.txt"}
 
 
 @app.middleware("http")
@@ -406,6 +406,11 @@ async def security_txt():
         "Policy: https://rulersai.buffingchi.com/static/privacy.html\n"
     )
     return Response(content=content, media_type="text/plain")
+
+
+@app.get("/.well-known/security.txt", include_in_schema=False)
+async def security_txt_well_known():
+    return RedirectResponse("/security.txt", status_code=301)
 
 
 # ---------- Preview (single office) — see src/routers/preview.py ----------

--- a/src/main.py
+++ b/src/main.py
@@ -233,7 +233,7 @@ _APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
 _AUTH_ENABLED = bool(os.environ.get("GOOGLE_CLIENT_ID"))
 
 # Auth middleware — skips public paths and dev mode (no GOOGLE_CLIENT_ID set)
-_PUBLIC_PATHS = {"/login", "/auth/google", "/auth/google/callback"}
+_PUBLIC_PATHS = {"/login", "/auth/google", "/auth/google/callback", "/security.txt"}
 
 
 @app.middleware("http")
@@ -396,6 +396,16 @@ PROCESS_TYPES = ["run", "preview_all"]
 async def favicon():
     """Return 204 so the browser's automatic favicon request doesn't 404."""
     return Response(status_code=204)
+
+
+@app.get("/security.txt", include_in_schema=False)
+async def security_txt():
+    content = (
+        "Contact: mailto:wcmchenry3@gmail.com\n"
+        "Expires: 2027-05-04T00:00:00z\n"
+        "Policy: https://rulersai.buffingchi.com/static/privacy.html\n"
+    )
+    return Response(content=content, media_type="text/plain")
 
 
 # ---------- Preview (single office) — see src/routers/preview.py ----------

--- a/src/main.py
+++ b/src/main.py
@@ -233,7 +233,13 @@ _APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
 _AUTH_ENABLED = bool(os.environ.get("GOOGLE_CLIENT_ID"))
 
 # Auth middleware — skips public paths and dev mode (no GOOGLE_CLIENT_ID set)
-_PUBLIC_PATHS = {"/login", "/auth/google", "/auth/google/callback", "/security.txt", "/.well-known/security.txt"}
+_PUBLIC_PATHS = {
+    "/login",
+    "/auth/google",
+    "/auth/google/callback",
+    "/security.txt",
+    "/.well-known/security.txt",
+}
 
 
 @app.middleware("http")

--- a/src/static/privacy.html
+++ b/src/static/privacy.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy — RulersAI</title>
+  <link rel="icon" type="image/png" href="/static/images/rulersai-icon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/theme.css">
+  <script>
+    (function () {
+      try {
+        if (localStorage.getItem('rulersai_theme') === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--color-background);
+      color: var(--color-on-surface);
+      margin: 0;
+      padding: 2rem 1rem;
+    }
+    main {
+      max-width: 680px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--color-on-surface);
+      margin-bottom: 0.25rem;
+    }
+    .updated {
+      font-size: 0.85rem;
+      color: var(--color-on-surface-variant);
+      margin-bottom: 2rem;
+    }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 1.75rem;
+      margin-bottom: 0.5rem;
+    }
+    p, li {
+      font-size: 0.9375rem;
+      line-height: 1.6;
+      color: var(--color-on-surface-variant);
+    }
+    ul {
+      padding-left: 1.25rem;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 2.5rem;
+      font-size: 0.875rem;
+      color: var(--color-on-tertiary-container);
+      text-decoration: none;
+    }
+    .back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: 2026-05-04</p>
+
+    <p>RulersAI is a private, single-user application. This policy describes what data is collected and how it is used.</p>
+
+    <h2>Authentication</h2>
+    <p>Access requires sign-in via Google OAuth. The app receives your Google account email address solely to verify that you are the authorized user. No other profile data (name, photo, contacts) is stored.</p>
+
+    <h2>Data stored</h2>
+    <ul>
+      <li>Your email address, held in a server-side session for the duration of your login.</li>
+      <li>Political office holder data scraped from Wikipedia — no personal data about you.</li>
+      <li>Application logs (scraper runs, errors) stored locally on the server.</li>
+    </ul>
+
+    <h2>Data sharing</h2>
+    <p>No data is sold, rented, or shared with third parties. The app makes outbound requests only to Wikipedia (data source), Google OAuth (authentication), and optionally Google Gemini / OpenAI APIs (AI features). Those services have their own privacy policies.</p>
+
+    <h2>Cookies &amp; analytics</h2>
+    <p>A single session cookie is set to maintain your login state. No advertising cookies, fingerprinting, or third-party tracking scripts are used.</p>
+
+    <h2>Contact</h2>
+    <p>Questions about this policy: <a href="mailto:wcmchenry3@gmail.com">wcmchenry3@gmail.com</a></p>
+
+    <a class="back" href="/login">&larr; Back to sign-in</a>
+  </main>
+</body>
+</html>

--- a/src/static/terms.html
+++ b/src/static/terms.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Terms of Use — RulersAI</title>
+  <link rel="icon" type="image/png" href="/static/images/rulersai-icon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/css/theme.css">
+  <script>
+    (function () {
+      try {
+        if (localStorage.getItem('rulersai_theme') === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    })();
+  </script>
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--color-background);
+      color: var(--color-on-surface);
+      margin: 0;
+      padding: 2rem 1rem;
+    }
+    main {
+      max-width: 680px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--color-on-surface);
+      margin-bottom: 0.25rem;
+    }
+    .updated {
+      font-size: 0.85rem;
+      color: var(--color-on-surface-variant);
+      margin-bottom: 2rem;
+    }
+    h2 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-top: 1.75rem;
+      margin-bottom: 0.5rem;
+    }
+    p, li {
+      font-size: 0.9375rem;
+      line-height: 1.6;
+      color: var(--color-on-surface-variant);
+    }
+    ul {
+      padding-left: 1.25rem;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 2.5rem;
+      font-size: 0.875rem;
+      color: var(--color-on-tertiary-container);
+      text-decoration: none;
+    }
+    .back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Terms of Use</h1>
+    <p class="updated">Last updated: 2026-05-04</p>
+
+    <p>RulersAI is a private, single-user application. By signing in you agree to the following terms.</p>
+
+    <h2>Authorized use</h2>
+    <p>Access is restricted to the single authorized account holder. Sharing credentials or attempting to bypass authentication is prohibited.</p>
+
+    <h2>Acceptable use</h2>
+    <ul>
+      <li>The app may be used to research political office holder data for lawful, non-commercial purposes.</li>
+      <li>You must not use the app in any way that violates Wikipedia's Terms of Use or the terms of any third-party service the app integrates with (Google OAuth, Google Gemini, OpenAI).</li>
+      <li>Automated scraping beyond the app's built-in rate-limited workflows is not permitted.</li>
+    </ul>
+
+    <h2>No warranty</h2>
+    <p>The app and its data are provided "as is" without warranty of any kind. Office holder data is sourced from Wikipedia and may be incomplete or incorrect. Do not rely on it for legal, financial, or safety-critical decisions.</p>
+
+    <h2>Limitation of liability</h2>
+    <p>The operator shall not be liable for any direct, indirect, or consequential damages arising from use of the app or reliance on data it presents.</p>
+
+    <h2>Changes</h2>
+    <p>These terms may be updated at any time. Continued use after an update constitutes acceptance of the revised terms.</p>
+
+    <h2>Contact</h2>
+    <p>Questions: <a href="mailto:wcmchenry3@gmail.com">wcmchenry3@gmail.com</a></p>
+
+    <a class="back" href="/login">&larr; Back to sign-in</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Audited all three login page footer links — all three were 404-ing.
- Created `src/static/privacy.html` and `src/static/terms.html` as minimal but complete pages styled with the app's design tokens (`theme.css`). Both include dark-mode support and a back-link to `/login`. Content satisfies Google OAuth consent screen requirements.
- Added a `/security.txt` route in `main.py` (RFC 9116 format) for the Security Disclosure link, and added `/security.txt` to `_PUBLIC_PATHS` so it remains accessible without authentication.

Closes #619

## Test plan

- [x] All 909 existing tests pass (`python -m pytest tests/ -x -q`)
- [ ] Visit `/static/privacy.html` on dev — page renders with correct styling and dark-mode toggle works
- [ ] Visit `/static/terms.html` on dev — same
- [ ] Visit `/security.txt` on dev — returns `text/plain` with `Contact:`, `Expires:`, `Policy:` fields
- [ ] Verify login page footer links no longer 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)