### PR TITLE
fix: accept HEAD on /login to stop 405s from link previewers and uptime monitors

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -317,7 +317,7 @@ if not _session_secret:
 app.add_middleware(SessionMiddleware, secret_key=_session_secret)
 
 
-@app.get("/login", response_class=HTMLResponse)
+@app.api_route("/login", methods=["GET", "HEAD"], response_class=HTMLResponse)
 async def login_page(request: Request):
     return templates.TemplateResponse(request, "login.html")
 

--- a/src/test_security.py
+++ b/src/test_security.py
@@ -132,6 +132,10 @@ def test_auth_middleware_allows_public_paths():
             assert (
                 resp.status_code == 200
             ), f"/login must be publicly accessible, got {resp.status_code}"
+            head_resp = c.head("/login", follow_redirects=False)
+            assert (
+                head_resp.status_code == 200
+            ), f"HEAD /login must return 200, got {head_resp.status_code}"
     finally:
         main_mod._AUTH_ENABLED = original
         if prior_db is not None:


### PR DESCRIPTION
## Summary

- Changed `@app.get("/login")` to `@app.api_route("/login", methods=["GET", "HEAD"])` so HEAD requests are accepted per RFC 9110 §9.3.2 (Starlette strips the body automatically).
- Added `head_resp = c.head("/login")` assertion to `test_auth_middleware_allows_public_paths` so this regression is caught by CI going forward.
- `/auth/google` left as GET-only — a HEAD there would trigger an OAuth redirect to Google, which isn't meaningful.

Closes #620

## Test plan

- [x] All 909 existing tests pass (`python -m pytest tests/ -x -q`)
- [x] `HEAD /login` now asserted 200 in `test_auth_middleware_allows_public_paths`
- [ ] Verify no more 405 entries for `HEAD /login` in production logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)