### PR TITLE
fix: add follow_redirects=True to all httpx calls in github_client

### DIFF
--- a/.claude/hooks/lint-gate.sh
+++ b/.claude/hooks/lint-gate.sh
@@ -18,14 +18,15 @@ REPORT=""
 
 # ── Python linting (black + ruff) ───────────────────────────────
 if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ]; then
-  if command -v black &>/dev/null || python -m black --version &>/dev/null 2>&1; then
-    OUT=$(python -m black --check --quiet . 2>&1) || {
+  PYTHON=$(command -v python3 || command -v python || true)
+  if [ -n "$PYTHON" ] && (command -v black &>/dev/null || "$PYTHON" -m black --version &>/dev/null 2>&1); then
+    OUT=$("$PYTHON" -m black --check --quiet . 2>&1) || {
       FAIL=1
       REPORT+="## black\n${OUT}\n\n"
     }
   fi
-  if command -v ruff &>/dev/null || python -m ruff --version &>/dev/null 2>&1; then
-    OUT=$(python -m ruff check --no-fix . 2>&1) || {
+  if [ -n "$PYTHON" ] && (command -v ruff &>/dev/null || "$PYTHON" -m ruff --version &>/dev/null 2>&1); then
+    OUT=$("$PYTHON" -m ruff check --no-fix . 2>&1) || {
       FAIL=1
       REPORT+="## ruff\n${OUT}\n\n"
     }

--- a/src/services/github_client.py
+++ b/src/services/github_client.py
@@ -229,7 +229,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.get(url, headers=self._headers, params=params, timeout=15.0)
+                resp = httpx.get(
+                    url, headers=self._headers, params=params, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         logger.error("GitHub GET rate-limited after 3 attempts: %s", url)
@@ -256,7 +258,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.put(url, headers=self._headers, json=json, timeout=15.0)
+                resp = httpx.put(
+                    url, headers=self._headers, json=json, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         raise RuntimeError(f"GitHub PUT rate-limited after 3 attempts: {url}")
@@ -280,7 +284,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.patch(url, headers=self._headers, json=json, timeout=15.0)
+                resp = httpx.patch(
+                    url, headers=self._headers, json=json, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         raise RuntimeError(f"GitHub PATCH rate-limited after 3 attempts: {url}")
@@ -306,7 +312,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.post(url, headers=self._headers, json=json, timeout=15.0)
+                resp = httpx.post(
+                    url, headers=self._headers, json=json, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         raise RuntimeError(f"GitHub POST rate-limited after 3 attempts: {url}")


### PR DESCRIPTION
## Summary

- GitHub's API was returning 301/307 redirects for the named repo URL (`wcmchenry3-stack/office_holder_cursor` → numeric ID form), causing `daily_delta`'s `SummaryIssueReporter` to fail with `RuntimeError: GitHub POST failed with HTTP 307` (16 Sentry events over 16 days)
- `httpx` defaults to `follow_redirects=False`, so redirects raised `HTTPStatusError` before the request completed; same problem silently affected `_get` (logged 301 warning, returned `None`), `_put`, and `_patch`
- Added `follow_redirects=True` to all four httpx calls in `src/services/github_client.py`
- Also fixed `lint-gate.sh` hook which hardcoded `python` instead of `python3`, causing all `gh pr create` calls to be erroneously blocked on macOS

Closes #625

## Test plan

- [ ] CI passes
- [ ] Next `daily_delta` run completes without `GitHub POST failed with HTTP 307` in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)