### PR TITLE
chore: merge dev into main

### DIFF
--- a/.claude/hooks/lint-gate.sh
+++ b/.claude/hooks/lint-gate.sh
@@ -18,14 +18,15 @@ REPORT=""
 
 # ── Python linting (black + ruff) ───────────────────────────────
 if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ]; then
-  if command -v black &>/dev/null || python -m black --version &>/dev/null 2>&1; then
-    OUT=$(python -m black --check --quiet . 2>&1) || {
+  PYTHON=$(command -v python3 || command -v python || true)
+  if [ -n "$PYTHON" ] && (command -v black &>/dev/null || "$PYTHON" -m black --version &>/dev/null 2>&1); then
+    OUT=$("$PYTHON" -m black --check --quiet . 2>&1) || {
       FAIL=1
       REPORT+="## black\n${OUT}\n\n"
     }
   fi
-  if command -v ruff &>/dev/null || python -m ruff --version &>/dev/null 2>&1; then
-    OUT=$(python -m ruff check --no-fix . 2>&1) || {
+  if [ -n "$PYTHON" ] && (command -v ruff &>/dev/null || "$PYTHON" -m ruff --version &>/dev/null 2>&1); then
+    OUT=$("$PYTHON" -m ruff check --no-fix . 2>&1) || {
       FAIL=1
       REPORT+="## ruff\n${OUT}\n\n"
     }

--- a/src/services/github_client.py
+++ b/src/services/github_client.py
@@ -229,7 +229,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.get(url, headers=self._headers, params=params, timeout=15.0)
+                resp = httpx.get(
+                    url, headers=self._headers, params=params, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         logger.error("GitHub GET rate-limited after 3 attempts: %s", url)
@@ -256,7 +258,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.put(url, headers=self._headers, json=json, timeout=15.0)
+                resp = httpx.put(
+                    url, headers=self._headers, json=json, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         raise RuntimeError(f"GitHub PUT rate-limited after 3 attempts: {url}")
@@ -280,7 +284,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.patch(url, headers=self._headers, json=json, timeout=15.0)
+                resp = httpx.patch(
+                    url, headers=self._headers, json=json, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         raise RuntimeError(f"GitHub PATCH rate-limited after 3 attempts: {url}")
@@ -306,7 +312,9 @@ class GitHubClient:
         backoff = 1.0
         for attempt in range(3):
             try:
-                resp = httpx.post(url, headers=self._headers, json=json, timeout=15.0)
+                resp = httpx.post(
+                    url, headers=self._headers, json=json, timeout=15.0, follow_redirects=True
+                )
                 if resp.status_code == 429:
                     if attempt == 2:
                         raise RuntimeError(f"GitHub POST rate-limited after 3 attempts: {url}")


### PR DESCRIPTION
Promotes dev → main (production deploy).

## Included since last release

- **fix:** `follow_redirects=True` on all httpx calls in `github_client.py` — resolves 16-day `daily_delta` failure where GitHub API 307 redirects were crashing `SummaryIssueReporter.refresh` (#625, #626)
- **fix:** `lint-gate.sh` hook updated to detect `python3` before `python`, fixing erroneously blocked `gh pr create` calls on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)