### PR TITLE
chore(zap): pin action to SHA and add Dependabot Actions tracking (#639)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Pin-based SHA references are still tracked — Dependabot resolves the
+    # new tag's SHA and opens a PR, keeping bumps explicit and reviewable.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
+  # SHA-pinned actions are still tracked: Dependabot resolves the tag behind
+  # the SHA and opens a PR when a newer version is released.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    # Pin-based SHA references are still tracked — Dependabot resolves the
-    # new tag's SHA and opens a PR, keeping bumps explicit and reviewable.
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Run ZAP baseline scan
-        uses: zaproxy/action-baseline@v0.14.0
+        uses: zaproxy/action-baseline@7c4deb10e6261301961c86d65d54a516394f9aed  # v0.14.0
         with:
           target: 'https://rulersai.buffingchi.com'
           fail_action: false


### PR DESCRIPTION
## Summary

- Pin `zaproxy/action-baseline` to its commit SHA (`7c4deb10e6261301961c86d65d54a516394f9aed`, tagged `v0.14.0`) so the reference is immutable — a tag can be force-pushed silently, a SHA cannot
- Add `.github/dependabot.yml` to enable Dependabot tracking for GitHub Actions across all workflows; Dependabot resolves SHA pins to their underlying tags and opens PRs when new versions are available, keeping upgrades explicit and requiring review

## Why both

SHA pinning alone stops silent tag mutations but doesn't surface new versions. Dependabot alone (with a mutable tag) is what caused the original issue chain (#629) — auto-merged bumps to invalid-or-breaking versions went unreviewed. Together: the SHA is immutable day-to-day, and Dependabot creates reviewable PRs when an upgrade is worth considering.

## Test plan

- [ ] Verify `zap-scan.yml` references the SHA (not the tag) after merge
- [ ] Confirm Dependabot picks up the new `dependabot.yml` and begins tracking Actions (visible in the repo's Dependabot tab within ~24h)
- [ ] Trigger a manual `workflow_dispatch` on the ZAP scan to confirm the SHA reference resolves and runs correctly

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)