### PR TITLE
fix(ci): grant callers write access, fix commitlint YAML

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   commitlint:
     uses: wcmchenry3-stack/.github/.github/workflows/called-commitlint.yml@main
+    permissions:
+      pull-requests: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,3 +7,6 @@ on:
 jobs:
   release-please:
     uses: wcmchenry3-stack/.github/.github/workflows/called-release-please.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -8,3 +8,6 @@ jobs:
   sync:
     uses: wcmchenry3-stack/.github/.github/workflows/called-sync-main-to-dev.yml@main
     secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary

- **Root cause #1 (Release Please & Sync)**: Repo default \`GITHUB_TOKEN\` permission is read-only. The called workflows (\`called-release-please.yml\`, \`called-sync-main-to-dev.yml\`) request \`contents: write\` / \`pull-requests: write\`, but the calling jobs never granted those permissions. GitHub refuses to start a reusable workflow when the caller cannot satisfy the callee's \`permissions:\` block → \`startup_failure\`.
- **Root cause #2 (Commitlint)**: \`called-commitlint.yml\` used a YAML folded scalar (\`>\`) with embedded double-quotes in \`subjectPatternError\` — the same parser issue that broke the ZAP workflow in #629. Fixed directly in the org \`.github\` repo (commit \`6bd8fda\`): replaced the folded scalar with a single-quoted inline string and replaced Unicode \`→\` arrows with ASCII \`->\`.

## Changes

### RulersAI repo (this PR)
- \`.github/workflows/release-please.yml\` — add \`permissions: contents: write, pull-requests: write\` to the calling job
- \`.github/workflows/sync-main-to-dev.yml\` — add \`permissions: contents: read, pull-requests: write\` to the calling job
- \`.github/workflows/commitlint.yml\` — add explicit \`permissions: pull-requests: read\` to the calling job

### Org \`.github\` repo (direct commits)
- \`6bd8fda\` — \`called-commitlint.yml\`: replace folded scalar \`>\` with embedded double-quotes; replace Unicode \`→\` with ASCII \`->\`
- \`called-release-please.yml\`: replace \`description: >\` folded scalar with inline single-quoted string (preventative — same YAML parser risk pattern)

## Notes

\`sync-main-to-dev.yml\` also depends on a May 30 org-repo fix (commit \`b7d7678\`) that removed a non-existent \`actions/checkout@v6\` step. That fix has not yet been exercised against a real \`main\` push — the Sync workflow can only be fully verified after this PR merges to \`main\`.

## Test plan

- [x] Opening this PR triggers the Commitlint workflow — passes (not \`startup_failure\`)
- [ ] CI passes on this branch
- [ ] After merging to \`dev\` and eventually to \`main\`, verify Release Please and Sync main→dev both run successfully on the next push to \`main\`

Closes #631 #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)