### PR TITLE
fix(ci): correct stale repo reference in deploy.yml (#630)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev, main]
   push:
     branches: [dev, main]
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ci:
-    uses: wcmchenry3-stack/office_holder_cursor/.github/workflows/ci.yml@main
+    uses: wcmchenry3-stack/RulersAI/.github/workflows/ci.yml@main
     secrets: inherit
 
   deploy:


### PR DESCRIPTION
## Summary

- Fixed stale `office_holder_cursor` repo reference in `deploy.yml` → now points to `wcmchenry3-stack/RulersAI/.github/workflows/ci.yml@main`
- Added `workflow_call` trigger to `ci.yml` so it can be invoked as a reusable workflow

## Root cause

`deploy.yml` was calling `ci.yml` via `uses:` with the old repo name (`office_holder_cursor`), causing every push to `main` to fail. Additionally, `ci.yml` lacked a `workflow_call` trigger, which is required for a workflow to be called by another workflow.

## Test plan

- [ ] Merge this PR to `dev`, then verify CI passes on `dev`
- [ ] Verify next push/merge to `main` triggers a successful deploy run (closes #630)

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)