### PR TITLE
chore: promote dev to main

### DIFF
--- a/.claude/hooks/lint-gate.sh
+++ b/.claude/hooks/lint-gate.sh
@@ -19,6 +19,11 @@ REPORT=""
 # ── Python linting (black + ruff) ───────────────────────────────
 if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ]; then
   PYTHON=$(command -v python3 || command -v python || true)
+  # Verify Python is functional (guards against Windows Store stubs that
+  # exist in PATH but fail when invoked with arguments)
+  if [ -n "$PYTHON" ] && ! "$PYTHON" -c "pass" &>/dev/null 2>&1; then
+    PYTHON=""
+  fi
   if [ -n "$PYTHON" ] && (command -v black &>/dev/null || "$PYTHON" -m black --version &>/dev/null 2>&1); then
     OUT=$("$PYTHON" -m black --check --quiet . 2>&1) || {
       FAIL=1

--- a/.claude/policies/policy-patterns.json
+++ b/.claude/policies/policy-patterns.json
@@ -5,7 +5,7 @@
   },
   "wikipedia": {
     "detect": "wikipedia\\.org|mediawiki|wikimedia",
-    "skip": "\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$"
+    "skip": "^\\.env|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$|test_.*\\.py$|_test\\.py$|/test.*\\.py$|/tests/.*\\.py$"
   },
   "gemini": {
     "detect": "google\\.generativeai|from google.*generativeai|genai\\.|GenerativeModel|GEMINI_API_KEY|GOOGLE_AI_API_KEY",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Pin-based SHA references are still tracked — Dependabot resolves the
+    # new tag's SHA and opens a PR, keeping bumps explicit and reviewable.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
+  # SHA-pinned actions are still tracked: Dependabot resolves the tag behind
+  # the SHA and opens a PR when a newer version is released.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    # Pin-based SHA references are still tracked — Dependabot resolves the
-    # new tag's SHA and opens a PR, keeping bumps explicit and reviewable.
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:
@@ -91,7 +91,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev, main]
   push:
     branches: [dev, main]
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   commitlint:
     uses: wcmchenry3-stack/.github/.github/workflows/called-commitlint.yml@main
+    permissions:
+      pull-requests: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ci:
-    uses: wcmchenry3-stack/office_holder_cursor/.github/workflows/ci.yml@main
+    uses: wcmchenry3-stack/RulersAI/.github/workflows/ci.yml@main
     secrets: inherit
 
   deploy:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,3 +7,6 @@ on:
 jobs:
   release-please:
     uses: wcmchenry3-stack/.github/.github/workflows/called-release-please.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -8,3 +8,6 @@ jobs:
   sync:
     uses: wcmchenry3-stack/.github/.github/workflows/called-sync-main-to-dev.yml@main
     secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -8,8 +8,15 @@ on:
 
 jobs:
   zap-scan:
-    uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
-    with:
-      target-url: 'https://rulersai.buffingchi.com'
-      artifact-name: 'zap-weekly-office-holder'
-    secrets: inherit
+    name: ZAP baseline scan
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Run ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: 'https://rulersai.buffingchi.com'
+          fail_action: false
+          artifact_name: zap-weekly-office-holder

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Run ZAP baseline scan
-        uses: zaproxy/action-baseline@7c4deb10e6261301961c86d65d54a516394f9aed  # v0.14.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25  # v0.15.0
         with:
           target: 'https://rulersai.buffingchi.com'
           fail_action: false

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Run ZAP baseline scan
-        uses: zaproxy/action-baseline@v0.14.0
+        uses: zaproxy/action-baseline@7c4deb10e6261301961c86d65d54a516394f9aed  # v0.14.0
         with:
           target: 'https://rulersai.buffingchi.com'
           fail_action: false

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -786,7 +786,7 @@ def _sqlite_add_columns_if_missing(conn) -> None:
     try:
         conn.execute("""DELETE FROM office_terms WHERE id NOT IN (
                 SELECT MIN(id) FROM office_terms
-                GROUP BY individual_id, office_details_id, term_start, term_end, wiki_url
+                GROUP BY individual_id, office_details_id, term_start, term_end, term_start_year, term_end_year, wiki_url
             )""")
         conn.commit()
     except Exception:

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -719,6 +719,17 @@ def _run_pg_migrations(conn) -> None:
         """,
     )
 
+    # Issue #636: add a unique index on the content-based hierarchy key so that
+    # insert_office_term's ON CONFLICT fires across office_table_config rows, preventing
+    # re-accumulation after every scrape. Must run after the dedup above (index creation
+    # fails if duplicates exist). NULLs are distinct in PG unique indexes, so legacy rows
+    # with office_details_id IS NULL are unaffected.
+    _apply(
+        "pg_office_terms_hierarchy_dedup_idx",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"
+        " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''))",
+    )
+
 
 def _sqlite_add_columns_if_missing(conn) -> None:
     """Idempotently add new columns to pre-existing SQLite tables.

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -702,6 +702,23 @@ def _run_pg_migrations(conn) -> None:
         " created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
     )
 
+    # Issue #634: office_terms accumulated duplicate rows when an office has multiple
+    # office_table_config rows — each config produces a distinct office_id value, so the
+    # UNIQUE(office_id, wiki_url, ...) constraint never fired for cross-config dupes.
+    # Deduplicate: for each (individual_id, office_details_id, term_start, term_end, wiki_url)
+    # group, keep the row with the lowest id and delete the rest.
+    _apply(
+        "pg_office_terms_dedup_multi_table_config",
+        """
+        DELETE FROM office_terms
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM office_terms
+            GROUP BY individual_id, office_details_id, term_start, term_end, wiki_url
+        )
+        """,
+    )
+
 
 def _sqlite_add_columns_if_missing(conn) -> None:
     """Idempotently add new columns to pre-existing SQLite tables.

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -730,6 +730,19 @@ def _run_pg_migrations(conn) -> None:
         " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''))",
     )
 
+    # Issue #636 v2: extend the index to include year columns so people who served
+    # multiple terms (e.g. two stints, both with NULL term_start/term_end) are not
+    # collapsed into a single row.  Drop the old two-column key and recreate it.
+    _apply(
+        "pg_office_terms_hierarchy_dedup_idx_drop_v1",
+        "DROP INDEX IF EXISTS idx_office_terms_hierarchy_dedup",
+    )
+    _apply(
+        "pg_office_terms_hierarchy_dedup_idx_v2",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"
+        " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1))",
+    )
+
 
 def _sqlite_add_columns_if_missing(conn) -> None:
     """Idempotently add new columns to pre-existing SQLite tables.
@@ -778,10 +791,17 @@ def _sqlite_add_columns_if_missing(conn) -> None:
         conn.commit()
     except Exception:
         pass
+    # Issue #636 v2: drop the old two-column key (if present) and recreate with year columns
+    # so multiple terms per person (same NULL dates, different years) are not collapsed.
+    try:
+        conn.execute("DROP INDEX IF EXISTS idx_office_terms_hierarchy_dedup")
+        conn.commit()
+    except Exception:
+        pass
     try:
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"
-            " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''))"
+            " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1))"
         )
         conn.commit()
     except Exception:

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -767,6 +767,28 @@ def _sqlite_add_columns_if_missing(conn) -> None:
     except Exception:
         pass
 
+    # Issue #636: dedup existing office_terms rows then create the hierarchy unique index.
+    # Mirrors the PG migrations pg_office_terms_dedup_multi_table_config and
+    # pg_office_terms_hierarchy_dedup_idx for pre-existing SQLite databases.
+    try:
+        conn.execute(
+            """DELETE FROM office_terms WHERE id NOT IN (
+                SELECT MIN(id) FROM office_terms
+                GROUP BY individual_id, office_details_id, term_start, term_end, wiki_url
+            )"""
+        )
+        conn.commit()
+    except Exception:
+        pass
+    try:
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"
+            " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''))"
+        )
+        conn.commit()
+    except Exception:
+        pass
+
 
 def _init_sqlite(path: Path | None = None) -> None:
     """SQLite init for tests — applies the final schema directly (no migrations needed)."""

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -771,12 +771,10 @@ def _sqlite_add_columns_if_missing(conn) -> None:
     # Mirrors the PG migrations pg_office_terms_dedup_multi_table_config and
     # pg_office_terms_hierarchy_dedup_idx for pre-existing SQLite databases.
     try:
-        conn.execute(
-            """DELETE FROM office_terms WHERE id NOT IN (
+        conn.execute("""DELETE FROM office_terms WHERE id NOT IN (
                 SELECT MIN(id) FROM office_terms
                 GROUP BY individual_id, office_details_id, term_start, term_end, wiki_url
-            )"""
-        )
+            )""")
         conn.commit()
     except Exception:
         pass

--- a/src/db/office_terms.py
+++ b/src/db/office_terms.py
@@ -49,10 +49,10 @@ def insert_office_term(
             and office_details_id is not None
             and office_table_config_id is not None
         ):
-            # office_id is NOT NULL; use office_table_config_id so the runnable-unit id is consistent.
-            # Conflict key is (office_details_id, wiki_url, ...) so inserts from different
-            # office_table_config rows for the same office upsert the same row instead of
-            # creating duplicates (idx_office_terms_hierarchy_dedup).
+            # office_id stores office_table_config_id (legacy NOT NULL field; no longer used for conflict resolution).
+            # Conflict key uses idx_office_terms_hierarchy_dedup so different office_table_config rows
+            # for the same office upsert the canonical row rather than creating duplicates.
+            # office_details_id is intentionally absent from DO UPDATE — it IS the conflict key column.
             cur = conn.execute(
                 """INSERT INTO office_terms
                    (office_id, office_details_id, office_table_config_id, individual_id, party_id, district, term_start, term_end, term_start_year, term_end_year, term_start_imprecise, term_end_imprecise, wiki_url)
@@ -61,6 +61,8 @@ def insert_office_term(
                      individual_id=EXCLUDED.individual_id,
                      party_id=EXCLUDED.party_id,
                      district=EXCLUDED.district,
+                     term_start_year=EXCLUDED.term_start_year,
+                     term_end_year=EXCLUDED.term_end_year,
                      term_start_imprecise=EXCLUDED.term_start_imprecise,
                      term_end_imprecise=EXCLUDED.term_end_imprecise,
                      office_table_config_id=EXCLUDED.office_table_config_id

--- a/src/db/office_terms.py
+++ b/src/db/office_terms.py
@@ -50,17 +50,19 @@ def insert_office_term(
             and office_table_config_id is not None
         ):
             # office_id is NOT NULL; use office_table_config_id so the runnable-unit id is consistent.
+            # Conflict key is (office_details_id, wiki_url, ...) so inserts from different
+            # office_table_config rows for the same office upsert the same row instead of
+            # creating duplicates (idx_office_terms_hierarchy_dedup).
             cur = conn.execute(
                 """INSERT INTO office_terms
                    (office_id, office_details_id, office_table_config_id, individual_id, party_id, district, term_start, term_end, term_start_year, term_end_year, term_start_imprecise, term_end_imprecise, wiki_url)
                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                   ON CONFLICT (office_id, wiki_url, term_start, term_end, term_start_year, term_end_year) DO UPDATE SET
+                   ON CONFLICT (office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, '')) DO UPDATE SET
                      individual_id=EXCLUDED.individual_id,
                      party_id=EXCLUDED.party_id,
                      district=EXCLUDED.district,
                      term_start_imprecise=EXCLUDED.term_start_imprecise,
                      term_end_imprecise=EXCLUDED.term_end_imprecise,
-                     office_details_id=EXCLUDED.office_details_id,
                      office_table_config_id=EXCLUDED.office_table_config_id
                    RETURNING id""",
                 (

--- a/src/db/office_terms.py
+++ b/src/db/office_terms.py
@@ -57,7 +57,7 @@ def insert_office_term(
                 """INSERT INTO office_terms
                    (office_id, office_details_id, office_table_config_id, individual_id, party_id, district, term_start, term_end, term_start_year, term_end_year, term_start_imprecise, term_end_imprecise, wiki_url)
                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                   ON CONFLICT (office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, '')) DO UPDATE SET
+                   ON CONFLICT (office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1)) DO UPDATE SET
                      individual_id=EXCLUDED.individual_id,
                      party_id=EXCLUDED.party_id,
                      district=EXCLUDED.district,

--- a/src/db/reports.py
+++ b/src/db/reports.py
@@ -45,7 +45,7 @@ def _term_report_query(
     else:
         where = f"ot.{date_column} BETWEEN date('now', '-90 days') AND CURRENT_DATE"
     cur = conn.execute(f"""
-        SELECT
+        SELECT DISTINCT
           i.full_name AS "Name",
           c.name AS "Country Name",
           s.name AS "State Name",

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -233,6 +233,7 @@ CREATE TABLE IF NOT EXISTS office_terms (
 CREATE INDEX IF NOT EXISTS idx_office_terms_office_id ON office_terms(office_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_individual_id ON office_terms(individual_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_wiki_url ON office_terms(wiki_url);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''));
 CREATE INDEX IF NOT EXISTS idx_individuals_insuf_vitals_checked_at ON individuals(insufficient_vitals_checked_at);
 
 -- Parser test scripts
@@ -663,6 +664,7 @@ CREATE TABLE IF NOT EXISTS office_terms (
 CREATE INDEX IF NOT EXISTS idx_office_terms_office_id ON office_terms(office_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_individual_id ON office_terms(individual_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_wiki_url ON office_terms(wiki_url);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''));
 -- idx_individuals_insuf_vitals_checked_at is created via _run_pg_migrations (pg migration)
 -- so that ALTER TABLE ADD COLUMN runs first on pre-existing databases.
 

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -233,7 +233,7 @@ CREATE TABLE IF NOT EXISTS office_terms (
 CREATE INDEX IF NOT EXISTS idx_office_terms_office_id ON office_terms(office_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_individual_id ON office_terms(individual_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_wiki_url ON office_terms(wiki_url);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1));
 CREATE INDEX IF NOT EXISTS idx_individuals_insuf_vitals_checked_at ON individuals(insufficient_vitals_checked_at);
 
 -- Parser test scripts
@@ -664,7 +664,7 @@ CREATE TABLE IF NOT EXISTS office_terms (
 CREATE INDEX IF NOT EXISTS idx_office_terms_office_id ON office_terms(office_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_individual_id ON office_terms(individual_id);
 CREATE INDEX IF NOT EXISTS idx_office_terms_wiki_url ON office_terms(wiki_url);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1));
 -- idx_individuals_insuf_vitals_checked_at is created via _run_pg_migrations (pg migration)
 -- so that ALTER TABLE ADD COLUMN runs first on pre-existing databases.
 

--- a/src/db/test_reports.py
+++ b/src/db/test_reports.py
@@ -14,6 +14,7 @@ from datetime import date, timedelta
 import pytest
 
 from src.db import individuals as db_individuals
+from src.db import office_terms as db_office_terms
 from src.db import offices as db_offices
 from src.db import reports as db_reports
 
@@ -163,3 +164,127 @@ def test_get_recent_term_starts_excludes_term_outside_window(tmp_db):
 def test_get_recent_term_starts_returns_empty_list_with_no_terms(tmp_db):
     results = db_reports.get_recent_term_starts(conn=tmp_db)
     assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# Deduplication: multiple office_table_config rows must not multiply report rows
+# (Regression for issue #634 — office with N table configs produced N identical rows)
+# ---------------------------------------------------------------------------
+
+
+def _make_office_two_tables(conn) -> tuple[int, int, int]:
+    """Create an office with 2 table configs. Returns (office_details_id, tc_id_1, tc_id_2)."""
+    od_id = db_offices.create_office(
+        {
+            "country_id": 1,
+            "state_id": None,
+            "city_id": None,
+            "level_id": None,
+            "branch_id": None,
+            "department": "",
+            "name": "Dedup Test Office",
+            "enabled": True,
+            "notes": "",
+            "url": "https://en.wikipedia.org/wiki/Dedup_Test_Office",
+            "table_configs": [
+                {
+                    "name": "",
+                    "table_no": 1,
+                    "table_rows": 1,
+                    "link_column": 1,
+                    "party_column": 0,
+                    "term_start_column": 2,
+                    "term_end_column": 3,
+                    "district_column": 0,
+                    "enabled": 1,
+                },
+                {
+                    "name": "",
+                    "table_no": 2,
+                    "table_rows": 1,
+                    "link_column": 1,
+                    "party_column": 0,
+                    "term_start_column": 2,
+                    "term_end_column": 3,
+                    "district_column": 0,
+                    "enabled": 1,
+                },
+            ],
+        },
+        conn=conn,
+    )
+    cur = conn.execute(
+        "SELECT id FROM office_table_config WHERE office_details_id = %s ORDER BY table_no",
+        (od_id,),
+    )
+    tc_ids = [row[0] for row in cur.fetchall()]
+    assert len(tc_ids) == 2, "Expected 2 table configs"
+    return od_id, tc_ids[0], tc_ids[1]
+
+
+def test_term_ends_report_deduplicates_multiple_table_configs(tmp_db):
+    od_id, tc1, tc2 = _make_office_two_tables(tmp_db)
+    ind_id = _make_individual(tmp_db, "/wiki/DedupPerson", full_name="Dedup Person")
+    term_end = _today_minus(10)
+    wiki = "https://en.wikipedia.org/wiki/DedupPerson"
+
+    db_office_terms.insert_office_term(
+        office_details_id=od_id,
+        office_table_config_id=tc1,
+        individual_id=ind_id,
+        wiki_url=wiki,
+        term_start=_today_minus(400),
+        term_end=term_end,
+        conn=tmp_db,
+    )
+    db_office_terms.insert_office_term(
+        office_details_id=od_id,
+        office_table_config_id=tc2,
+        individual_id=ind_id,
+        wiki_url=wiki,
+        term_start=_today_minus(400),
+        term_end=term_end,
+        conn=tmp_db,
+    )
+    tmp_db.commit()
+
+    results = db_reports.get_recent_term_ends(conn=tmp_db)
+    matching = [r for r in results if r["Name"] == "Dedup Person"]
+    assert len(matching) == 1, (
+        f"Expected 1 row for Dedup Person but got {len(matching)}; "
+        "office with multiple table_configs must not produce duplicate report rows"
+    )
+
+
+def test_term_starts_report_deduplicates_multiple_table_configs(tmp_db):
+    od_id, tc1, tc2 = _make_office_two_tables(tmp_db)
+    ind_id = _make_individual(tmp_db, "/wiki/DedupPersonStart", full_name="Dedup Person Start")
+    term_start = _today_minus(10)
+    wiki = "https://en.wikipedia.org/wiki/DedupPersonStart"
+
+    db_office_terms.insert_office_term(
+        office_details_id=od_id,
+        office_table_config_id=tc1,
+        individual_id=ind_id,
+        wiki_url=wiki,
+        term_start=term_start,
+        term_end=None,
+        conn=tmp_db,
+    )
+    db_office_terms.insert_office_term(
+        office_details_id=od_id,
+        office_table_config_id=tc2,
+        individual_id=ind_id,
+        wiki_url=wiki,
+        term_start=term_start,
+        term_end=None,
+        conn=tmp_db,
+    )
+    tmp_db.commit()
+
+    results = db_reports.get_recent_term_starts(conn=tmp_db)
+    matching = [r for r in results if r["Name"] == "Dedup Person Start"]
+    assert len(matching) == 1, (
+        f"Expected 1 row for Dedup Person Start but got {len(matching)}; "
+        "office with multiple table_configs must not produce duplicate report rows"
+    )

--- a/src/db/test_reports.py
+++ b/src/db/test_reports.py
@@ -39,7 +39,7 @@ def _make_office(conn) -> int:
             "name": "Report Test Office",
             "enabled": True,
             "notes": "",
-            "url": "https://en.wikipedia.org/wiki/Report_Test_Office",
+            "url": "https://example.test/wiki/Report_Test_Office",
             "table_configs": [
                 {
                     "name": "",
@@ -69,7 +69,7 @@ def _insert_term(
         """INSERT INTO office_terms
            (office_id, individual_id, wiki_url, term_start, term_end)
            VALUES (%s, %s, %s, %s, %s)""",
-        (od_id, ind_id, f"https://en.wikipedia.org/wiki/P{ind_id}", term_start, term_end),
+        (od_id, ind_id, f"https://example.test/wiki/P{ind_id}", term_start, term_end),
     )
     conn.commit()
 
@@ -185,7 +185,7 @@ def _make_office_two_tables(conn) -> tuple[int, int, int]:
             "name": "Dedup Test Office",
             "enabled": True,
             "notes": "",
-            "url": "https://en.wikipedia.org/wiki/Dedup_Test_Office",
+            "url": "https://example.test/wiki/Dedup_Test_Office",
             "table_configs": [
                 {
                     "name": "",
@@ -226,7 +226,7 @@ def test_term_ends_report_deduplicates_multiple_table_configs(tmp_db):
     od_id, tc1, tc2 = _make_office_two_tables(tmp_db)
     ind_id = _make_individual(tmp_db, "/wiki/DedupPerson", full_name="Dedup Person")
     term_end = _today_minus(10)
-    wiki = "https://en.wikipedia.org/wiki/DedupPerson"
+    wiki = "https://example.test/wiki/DedupPerson"
 
     db_office_terms.insert_office_term(
         office_details_id=od_id,
@@ -260,7 +260,7 @@ def test_term_starts_report_deduplicates_multiple_table_configs(tmp_db):
     od_id, tc1, tc2 = _make_office_two_tables(tmp_db)
     ind_id = _make_individual(tmp_db, "/wiki/DedupPersonStart", full_name="Dedup Person Start")
     term_start = _today_minus(10)
-    wiki = "https://en.wikipedia.org/wiki/DedupPersonStart"
+    wiki = "https://example.test/wiki/DedupPersonStart"
 
     db_office_terms.insert_office_term(
         office_details_id=od_id,

--- a/src/db/test_reports.py
+++ b/src/db/test_reports.py
@@ -228,7 +228,7 @@ def test_term_ends_report_deduplicates_multiple_table_configs(tmp_db):
     term_end = _today_minus(10)
     wiki = "https://example.test/wiki/DedupPerson"
 
-    db_office_terms.insert_office_term(
+    id1 = db_office_terms.insert_office_term(
         office_details_id=od_id,
         office_table_config_id=tc1,
         individual_id=ind_id,
@@ -237,7 +237,7 @@ def test_term_ends_report_deduplicates_multiple_table_configs(tmp_db):
         term_end=term_end,
         conn=tmp_db,
     )
-    db_office_terms.insert_office_term(
+    id2 = db_office_terms.insert_office_term(
         office_details_id=od_id,
         office_table_config_id=tc2,
         individual_id=ind_id,
@@ -247,6 +247,11 @@ def test_term_ends_report_deduplicates_multiple_table_configs(tmp_db):
         conn=tmp_db,
     )
     tmp_db.commit()
+
+    assert id1 == id2, (
+        f"Expected second insert to upsert row {id1} but got new row {id2}; "
+        "idx_office_terms_hierarchy_dedup must fire across office_table_config rows"
+    )
 
     results = db_reports.get_recent_term_ends(conn=tmp_db)
     matching = [r for r in results if r["Name"] == "Dedup Person"]
@@ -262,7 +267,7 @@ def test_term_starts_report_deduplicates_multiple_table_configs(tmp_db):
     term_start = _today_minus(10)
     wiki = "https://example.test/wiki/DedupPersonStart"
 
-    db_office_terms.insert_office_term(
+    id1 = db_office_terms.insert_office_term(
         office_details_id=od_id,
         office_table_config_id=tc1,
         individual_id=ind_id,
@@ -271,7 +276,7 @@ def test_term_starts_report_deduplicates_multiple_table_configs(tmp_db):
         term_end=None,
         conn=tmp_db,
     )
-    db_office_terms.insert_office_term(
+    id2 = db_office_terms.insert_office_term(
         office_details_id=od_id,
         office_table_config_id=tc2,
         individual_id=ind_id,
@@ -281,6 +286,11 @@ def test_term_starts_report_deduplicates_multiple_table_configs(tmp_db):
         conn=tmp_db,
     )
     tmp_db.commit()
+
+    assert id1 == id2, (
+        f"Expected second insert to upsert row {id1} but got new row {id2}; "
+        "idx_office_terms_hierarchy_dedup must fire across office_table_config rows"
+    )
 
     results = db_reports.get_recent_term_starts(conn=tmp_db)
     matching = [r for r in results if r["Name"] == "Dedup Person Start"]


### PR DESCRIPTION
## Summary

- Fix CI startup failures (permissions, commitlint YAML)
- Fix deploy workflow to reference correct repo
- Pin ZAP action to SHA, add Dependabot tracking for Actions
- Bump actions/checkout, actions/setup-python, zaproxy/action-baseline
- Fix office_terms dedup conflict key to prevent re-accumulation
- Fix dedup GROUP BY to preserve multi-term persons
- Fix ZAP inline scan (secrets-in-if validation)
- Fix lint-gate Windows Store Python stub guard
- Fix milestone report duplicate rows
- Fix infobox cache memory leak (via earlier PRs now included)

## Test plan

- [ ] All CI checks pass on `dev` before merge
- [ ] ZAP post-deploy scan passes after deploy to `main` triggers production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)