### PR TITLE
fix: resolve office_terms dedup/index conflicts preventing startup

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -737,6 +737,23 @@ def _run_pg_migrations(conn) -> None:
         "pg_office_terms_hierarchy_dedup_idx_drop_v1",
         "DROP INDEX IF EXISTS idx_office_terms_hierarchy_dedup",
     )
+    # Dedup on the v2 index key before creating it. The earlier dedup grouped by
+    # individual_id, so rows with different individual_ids but the same
+    # (office_details_id, wiki_url, term dates, term years) both survived — they
+    # would collide on the new index. Keep MIN(id) per index-key tuple.
+    _apply(
+        "pg_office_terms_dedup_v2_index_key",
+        """
+        DELETE FROM office_terms
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM office_terms
+            GROUP BY office_details_id, wiki_url,
+                     COALESCE(term_start, ''), COALESCE(term_end, ''),
+                     COALESCE(term_start_year, -1), COALESCE(term_end_year, -1)
+        )
+        """,
+    )
     _apply(
         "pg_office_terms_hierarchy_dedup_idx_v2",
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"


### PR DESCRIPTION
## Summary
- Adds a content-based unique index (`idx_office_terms_hierarchy_dedup`) on `office_terms(office_details_id, wiki_url, term_start, term_end, term_start_year, term_end_year)` to prevent re-accumulation of duplicate rows across scrape runs (issue #636)
- Extends the index to include year columns so persons who served multiple non-contiguous terms (both with NULL text dates) are not collapsed to a single row
- Adds a pre-index dedup step (`pg_office_terms_dedup_v2_index_key`) keyed on the exact index columns — the earlier dedup grouped by `individual_id`, so rows with different `individual_id` values but the same wiki/office/term combination both survived and caused index creation to fail on the prod deploy (Waightstill Avery, `office_details_id=1256`)

## Test plan
- [ ] Deploy succeeds on Render (startup no longer throws `could not create unique index`)
- [ ] Existing migration steps are idempotent — new step name `pg_office_terms_dedup_v2_index_key` only fires once
- [ ] Scraping the same page twice does not accumulate duplicate `office_terms` rows