### PR TITLE
chore: merge dev into main

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -737,6 +737,23 @@ def _run_pg_migrations(conn) -> None:
         "pg_office_terms_hierarchy_dedup_idx_drop_v1",
         "DROP INDEX IF EXISTS idx_office_terms_hierarchy_dedup",
     )
+    # Dedup on the v2 index key before creating it. The earlier dedup grouped by
+    # individual_id, so rows with different individual_ids but the same
+    # (office_details_id, wiki_url, term dates, term years) both survived — they
+    # would collide on the new index. Keep MIN(id) per index-key tuple.
+    _apply(
+        "pg_office_terms_dedup_v2_index_key",
+        """
+        DELETE FROM office_terms
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM office_terms
+            GROUP BY office_details_id, wiki_url,
+                     COALESCE(term_start, ''), COALESCE(term_end, ''),
+                     COALESCE(term_start_year, -1), COALESCE(term_end_year, -1)
+        )
+        """,
+    )
     _apply(
         "pg_office_terms_hierarchy_dedup_idx_v2",
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"


### PR DESCRIPTION
## Summary
Promotes all recent dev fixes to main:

- **#649** fix: dedup on v2 index key before creating it to handle cross-individual duplicates (prod startup hotfix — Waightstill Avery collision on `idx_office_terms_hierarchy_dedup`)
- **#645** fix: stale repo deploy issue
- **#637** fix: office_terms dedup conflict key (add year columns to index, prevent multi-term collapse)
- **#644** fix(ci): startup failures (#631, #632)
- **#643/642/641** chore: bump dependabot GitHub Actions (zaproxy, setup-python, checkout)
- **#640** chore(zap): pin ZAP action to SHA, add dependabot.yml for Actions tracking
- **#638** fix(zap): inline scan to fix secrets-in-if validation failure
- **#635** fix: deduplicate milestone report rows caused by multiple office_table_configs

## Test plan
- [ ] CI passes on merge
- [ ] Render prod deploy succeeds (startup no longer throws unique index error)