### PR TITLE
fix: atomic office_terms v2 index migration to break deploy deadlock

### DIFF
--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -766,17 +766,18 @@ def _run_pg_migrations(conn) -> None:
                 ("pg_office_terms_hierarchy_dedup_idx_v2",),
             )
             conn.commit()
-        except Exception as _idx_err:
+        except Exception as idx_err:
             conn.rollback()
             _log.warning(
                 "office_terms v2 index migration failed — starting without index,"
-                " will retry next boot: %s",
-                _idx_err,
+                " will retry next boot. WARNING: hierarchy insert_office_term calls"
+                " will fail until the index exists: %s",
+                idx_err,
             )
             try:
                 import sentry_sdk
 
-                sentry_sdk.capture_exception(_idx_err)
+                sentry_sdk.capture_exception(idx_err)
             except Exception:
                 pass
 

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -737,28 +737,48 @@ def _run_pg_migrations(conn) -> None:
         "pg_office_terms_hierarchy_dedup_idx_drop_v1",
         "DROP INDEX IF EXISTS idx_office_terms_hierarchy_dedup",
     )
-    # Issue #651: the dedup MUST NOT be a one-time _apply step. Between deploy retries
-    # there is no dedup index (it was dropped above), so ON CONFLICT cannot fire and
-    # scrape jobs re-insert duplicates. Running the dedup inside _apply means it is
-    # skipped on subsequent attempts, hitting fresh duplicates every time. Instead,
-    # run it unconditionally on every startup until the index has been committed.
+    # Issues #654, #655: dedup + CREATE INDEX + migration-record must be a single atomic
+    # transaction under a table lock. SHARE ROW EXCLUSIVE blocks concurrent INSERT/UPDATE/DELETE
+    # (including the still-live old deploy's scrape jobs) for the duration, but allows reads.
+    # With no intermediate commit, no duplicate can be inserted between the DELETE and the index
+    # creation. On failure, rollback and continue startup without the index — the migration row
+    # is not recorded so the block retries on the next boot (graceful degradation, not crash-loop).
     if "pg_office_terms_hierarchy_dedup_idx_v2" not in applied:
-        conn.execute("""
-            DELETE FROM office_terms
-            WHERE id NOT IN (
-                SELECT MIN(id)
-                FROM office_terms
-                GROUP BY office_details_id, wiki_url,
-                         COALESCE(term_start, ''), COALESCE(term_end, ''),
-                         COALESCE(term_start_year, -1), COALESCE(term_end_year, -1)
-            )
+        try:
+            conn.execute("LOCK TABLE office_terms IN SHARE ROW EXCLUSIVE MODE")
+            conn.execute("""
+                DELETE FROM office_terms
+                WHERE id NOT IN (
+                    SELECT MIN(id)
+                    FROM office_terms
+                    GROUP BY office_details_id, wiki_url,
+                             COALESCE(term_start, ''), COALESCE(term_end, ''),
+                             COALESCE(term_start_year, -1), COALESCE(term_end_year, -1)
+                )
             """)
-        conn.commit()
-    _apply(
-        "pg_office_terms_hierarchy_dedup_idx_v2",
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"
-        " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''), COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1))",
-    )
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_office_terms_hierarchy_dedup"
+                " ON office_terms(office_details_id, wiki_url, COALESCE(term_start, ''),"
+                " COALESCE(term_end, ''), COALESCE(term_start_year, -1), COALESCE(term_end_year, -1))"
+            )
+            conn.execute(
+                "INSERT INTO schema_migrations (id) VALUES (%s)",
+                ("pg_office_terms_hierarchy_dedup_idx_v2",),
+            )
+            conn.commit()
+        except Exception as _idx_err:
+            conn.rollback()
+            _log.warning(
+                "office_terms v2 index migration failed — starting without index,"
+                " will retry next boot: %s",
+                _idx_err,
+            )
+            try:
+                import sentry_sdk
+
+                sentry_sdk.capture_exception(_idx_err)
+            except Exception:
+                pass
 
 
 def _sqlite_add_columns_if_missing(conn) -> None:

--- a/src/db/test_office_terms_dedup.py
+++ b/src/db/test_office_terms_dedup.py
@@ -322,9 +322,9 @@ def test_pg_v2_index_block_is_skipped_when_already_applied():
     _run_pg_migrations(mock_conn)
 
     executed_sqls = [str(c.args[0]) for c in mock_conn.execute.call_args_list if c.args]
-    assert not any("LOCK TABLE" in s for s in executed_sqls), (
-        "LOCK TABLE must not run when v2 migration is already applied"
-    )
+    assert not any(
+        "LOCK TABLE" in s for s in executed_sqls
+    ), "LOCK TABLE must not run when v2 migration is already applied"
     # Distinguish the v2-block DELETE (groups by term_start_year) from the earlier
     # one-time dedup migration (groups by individual_id, no year columns).
     assert not any(

--- a/src/db/test_office_terms_dedup.py
+++ b/src/db/test_office_terms_dedup.py
@@ -1,9 +1,9 @@
 """Regression tests for office_terms dedup behaviour during DB startup.
 
-Covers issue #651: the dedup must clean cross-individual duplicate rows (rows
-with different individual_id but the same index key) so that
-idx_office_terms_hierarchy_dedup can always be created, even when scrape jobs
-have accumulated duplicate rows between deploy retries.
+Covers issues #651, #654, #655: the dedup must clean cross-individual duplicate rows and
+the dedup + CREATE INDEX + migration-record must be atomic (single transaction under a
+table lock) so concurrent writers cannot reintroduce duplicates between the steps.
+Startup must also degrade gracefully rather than crash-loop when the index step fails.
 
 Run: pytest src/db/test_office_terms_dedup.py -v
 """
@@ -243,3 +243,90 @@ def test_dedup_cleans_duplicates_accumulated_between_deploy_retries(tmp_db):
 
     assert _count_terms(tmp_db, wiki) == 1, "Retry dedup must clean newly accumulated duplicates"
     assert _index_exists(tmp_db), "Index must exist after successful retry dedup"
+
+
+# ---------------------------------------------------------------------------
+# PG migration path: atomicity and graceful degradation (issues #654, #655)
+# ---------------------------------------------------------------------------
+
+
+def test_pg_v2_index_failure_degrades_gracefully():
+    """If CREATE UNIQUE INDEX fails, _run_pg_migrations must not raise, must call
+    rollback(), and must not record the migration row (so the block retries next boot).
+
+    Regression for #654/#655: previously the non-atomic two-step (dedup commit then
+    separate index creation) would crash the app, perpetuating a deadlock where the
+    old instance kept the new one from ever becoming healthy.
+    """
+    from unittest.mock import MagicMock
+    from src.db.connection import _run_pg_migrations
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []  # empty applied set — all migrations will run
+
+    mock_conn = MagicMock()
+    schema_migrations_inserts: list[str] = []
+
+    def _execute(sql, *args, **kwargs):
+        sql_str = sql.strip() if isinstance(sql, str) else ""
+        if "SELECT id FROM schema_migrations" in sql_str:
+            return mock_cursor
+        # Only fail on the v2 index (which includes term_start_year),
+        # not the earlier v1 index (4-column key, no year columns).
+        if (
+            "CREATE UNIQUE INDEX" in sql_str
+            and "idx_office_terms_hierarchy_dedup" in sql_str
+            and "term_start_year" in sql_str
+        ):
+            raise RuntimeError("could not create unique index: duplicate key")
+        if "INSERT INTO schema_migrations" in sql_str and args:
+            schema_migrations_inserts.append(str(args[0]))
+        return MagicMock()
+
+    mock_conn.execute.side_effect = _execute
+
+    # Must NOT raise — graceful degradation
+    _run_pg_migrations(mock_conn)
+
+    # rollback must be called exactly once (for the failed v2 block)
+    mock_conn.rollback.assert_called_once()
+
+    # Migration row must NOT be recorded — ensures retry on next boot
+    assert not any(
+        "pg_office_terms_hierarchy_dedup_idx_v2" in s for s in schema_migrations_inserts
+    ), "v2 migration row must not be recorded when index creation fails"
+
+
+def test_pg_v2_index_block_is_skipped_when_already_applied():
+    """If the v2 migration is already in schema_migrations, the dedup block is not re-run.
+
+    Verifies idempotency: once the index is committed, neither LOCK TABLE nor DELETE
+    executes on subsequent startups.
+    """
+    from unittest.mock import MagicMock, call
+    from src.db.connection import _run_pg_migrations
+
+    mock_cursor = MagicMock()
+    # Simulate a DB where the v2 migration has already been applied
+    mock_cursor.fetchall.return_value = [("pg_office_terms_hierarchy_dedup_idx_v2",)]
+
+    mock_conn = MagicMock()
+
+    def _execute(sql, *args, **kwargs):
+        if "SELECT id FROM schema_migrations" in sql.strip():
+            return mock_cursor
+        return MagicMock()
+
+    mock_conn.execute.side_effect = _execute
+
+    _run_pg_migrations(mock_conn)
+
+    executed_sqls = [str(c.args[0]) for c in mock_conn.execute.call_args_list if c.args]
+    assert not any("LOCK TABLE" in s for s in executed_sqls), (
+        "LOCK TABLE must not run when v2 migration is already applied"
+    )
+    # Distinguish the v2-block DELETE (groups by term_start_year) from the earlier
+    # one-time dedup migration (groups by individual_id, no year columns).
+    assert not any(
+        "DELETE FROM office_terms" in s and "term_start_year" in s for s in executed_sqls
+    ), "v2 dedup DELETE must not run when migration is already applied"

--- a/src/db/test_office_terms_dedup.py
+++ b/src/db/test_office_terms_dedup.py
@@ -303,7 +303,7 @@ def test_pg_v2_index_block_is_skipped_when_already_applied():
     Verifies idempotency: once the index is committed, neither LOCK TABLE nor DELETE
     executes on subsequent startups.
     """
-    from unittest.mock import MagicMock, call
+    from unittest.mock import MagicMock
     from src.db.connection import _run_pg_migrations
 
     mock_cursor = MagicMock()


### PR DESCRIPTION
## Summary

- Wraps the `office_terms` v2 index migration (dedup DELETE + `CREATE UNIQUE INDEX` + migration-record) in a single transaction behind `LOCK TABLE office_terms IN SHARE ROW EXCLUSIVE MODE`, eliminating the race window from the old non-atomic two-step (closes #654).
- On failure, rolls back and continues startup without the index — graceful degradation instead of crash-loop. The migration row is not recorded so it retries next boot (closes #655).
- Adds two PG-path regression tests: graceful degradation on index failure, and idempotency when already applied.

See #656 for the ops runbook to unblock production immediately.

## Root cause recap

Every deploy since `346c7a9` crashed because:
1. **Non-atomic** — `conn.commit()` between the dedup and `CREATE UNIQUE INDEX` opened a window for concurrent inserts.
2. **Active concurrent writer** — the last-good deploy is still live; its scrape jobs use the legacy `ON CONFLICT (office_id,…)` path that creates cross-config duplicates freely.
3. **Fatal startup** — the crash prevents Render from retiring the old instance, completing the deadlock.

## Test plan
- [x] `pytest src/db/test_office_terms_dedup.py -v` — all 6 pass (4 existing + 2 new)
- [x] Full test suite — 0 failures
- [ ] Run ops runbook (#656) against prod DB, then redeploy this branch; confirm app healthy and `idx_office_terms_hierarchy_dedup` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)