### PR TITLE
fix: address ZAP scan CSP directives and HSTS proxy detection (#658)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -267,10 +267,17 @@ async def add_security_headers(request: Request, call_next):
         "script-src 'self' 'unsafe-inline'; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "font-src 'self' https://fonts.gstatic.com; "
-        "img-src 'self' data: https://*.googleusercontent.com;",
+        "img-src 'self' data: https://*.googleusercontent.com; "
+        "form-action 'self'; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "object-src 'none';",
     )
     response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
-    if request.url.scheme == "https":
+    # X-Forwarded-Proto is set by Render's TLS-terminating proxy; fall back to
+    # request.url.scheme for local dev (where there is no proxy).
+    proto = request.headers.get("x-forwarded-proto", request.url.scheme)
+    if proto == "https":
         response.headers.setdefault(
             "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
         )

--- a/src/test_security.py
+++ b/src/test_security.py
@@ -330,6 +330,24 @@ def test_csp_header_present(client):
     assert "default-src" in csp, f"CSP must contain a default-src directive, got: {csp!r}"
 
 
+@pytest.mark.security
+def test_csp_no_fallback_directives(client):
+    """CSP must explicitly set directives that have no default-src fallback."""
+    resp = client.get("/run")
+    csp = resp.headers.get("content-security-policy", "")
+    for directive in ("form-action", "frame-ancestors", "base-uri", "object-src"):
+        assert directive in csp, f"CSP missing '{directive}' (no default-src fallback): {csp!r}"
+
+
+@pytest.mark.security
+def test_hsts_set_when_forwarded_proto_https(client):
+    """HSTS must be set when the request arrives via HTTPS proxy (X-Forwarded-Proto)."""
+    resp = client.get("/run", headers={"x-forwarded-proto": "https"})
+    hsts = resp.headers.get("strict-transport-security", "")
+    assert hsts, "HSTS header not set when X-Forwarded-Proto: https"
+    assert "max-age=" in hsts, f"HSTS header malformed: {hsts!r}"
+
+
 # ---------------------------------------------------------------------------
 # H12 — Rate limit exception handler wired up
 # ---------------------------------------------------------------------------

--- a/tests/test_e2e_security.py
+++ b/tests/test_e2e_security.py
@@ -77,6 +77,20 @@ def test_security_headers_csp_present(app_client):
     assert "default-src" in csp, f"CSP header missing or malformed: {csp!r}"
 
 
+def test_security_headers_csp_no_fallback_directives(app_client):
+    resp = app_client.get("/run")
+    csp = resp.headers.get("content-security-policy", "")
+    for directive in ("form-action", "frame-ancestors", "base-uri", "object-src"):
+        assert directive in csp, f"CSP missing '{directive}' (no default-src fallback): {csp!r}"
+
+
+def test_security_headers_hsts_with_forwarded_proto(app_client):
+    resp = app_client.get("/run", headers={"x-forwarded-proto": "https"})
+    hsts = resp.headers.get("strict-transport-security", "")
+    assert hsts, "HSTS header not set when X-Forwarded-Proto: https"
+    assert "max-age=" in hsts, f"HSTS header malformed: {hsts!r}"
+
+
 def test_security_headers_permissions_policy(app_client):
     resp = app_client.get("/run")
     pp = resp.headers.get("permissions-policy", "")


### PR DESCRIPTION
## Summary
- Add `form-action 'self'`, `frame-ancestors 'none'`, `base-uri 'self'`, `object-src 'none'` to CSP — these directives have no `default-src` fallback and must be set explicitly (ZAP rule 10055: CSP Failure to Define Directive with No Fallback)
- Fix HSTS: use `X-Forwarded-Proto` header to detect HTTPS when behind Render's TLS-terminating proxy — `request.url.scheme` is always `http` at the app level, so the previous `if request.url.scheme == "https"` guard never fired (ZAP rule 10035: Strict-Transport-Security Header Not Set)
- Add regression tests for both fixes in `src/test_security.py` and `tests/test_e2e_security.py`

Closes #658

## Test plan
- [x] `pytest src/test_security.py -m security` — 21 passed
- [x] `pytest tests/test_e2e_security.py` — 15 passed
- [x] Full suite (excluding Playwright) — 1776 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)