### PR TITLE
chore(deps): group Dependabot action bumps into one weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,14 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: chore
+    groups:
+      # CVE fixes get their own PR so they are never held up behind a routine batch.
+      security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
+      # Minor/patch action bumps batch into one PR. Majors still open
+      # individually — an action major can change inputs or runtime.
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

Adds grouping to the `github-actions` ecosystem so minor/patch action bumps arrive as **one PR per week** instead of one PR per action.

- `security-updates` — CVE fixes get their own PR so they are never held behind a routine batch.
- `actions` — minor/patch bumps batch together. **Majors still open individually**, since an action major can change inputs or runtime.

Part of reducing Dependabot PR volume across the stack (~83 merges/month). This repo is low-volume, but the same pattern is being applied everywhere for consistency.

## Test plan

- [ ] Merge, then confirm the next Dependabot run opens a single grouped PR rather than one per action
- [ ] Confirm a major-version action bump still arrives as its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn